### PR TITLE
Power Controller: Handle user supply powerdown strobe

### DIFF
--- a/src/power_controller.hpp
+++ b/src/power_controller.hpp
@@ -70,7 +70,7 @@ namespace adiscope {
 
 	private:
 		Ui::PowerController *ui;
-		struct iio_channel *ch1w, *ch2w, *ch1r, *ch2r;
+		struct iio_channel *ch1w, *ch2w, *ch1r, *ch2r, *pd;
 		QTimer timer;
 		bool in_sync;
 


### PR DESCRIPTION
There is a common powerdown for the output amplifier. In case positive
and negative supply are disabled, in order to save more power we disable
the output amplifier.


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>