### PR TITLE
src/dmm.cpp: Fix build - add boost/make_shared include

### DIFF
--- a/src/dmm.cpp
+++ b/src/dmm.cpp
@@ -30,6 +30,8 @@
 #include <gnuradio/blocks/sub_ff.h>
 #include <gnuradio/filter/dc_blocker_ff.h>
 
+#include <boost/make_shared.hpp>
+
 #include <memory>
 #include <QJSEngine>
 


### PR DESCRIPTION
This fixes this build error:

scopy/src/dmm.cpp:41:26: error: ‘make_shared’ is not a member of ‘boost’
  ui(new Ui::DMM), signal(boost::make_shared<signal_sample>()),
scopy/src/dmm.cpp:41:26: error: ‘make_shared’ is not a member of ‘boost’

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>