### PR TITLE
scopy: dmm: Fix build error

### DIFF
--- a/src/dmm.hpp
+++ b/src/dmm.hpp
@@ -22,6 +22,7 @@
 
 #include <QPushButton>
 #include <QWidget>
+#include <atomic>
 
 #include "apiObject.hpp"
 #include "filter.hpp"


### PR DESCRIPTION
This fixes:

In file included from scopy/src/dmm.cpp:20:0:
scopy/src/dmm.hpp:69:21: error: field ‘interrupt_data_logging’ has incomplete type ‘std::atomic<bool>’
   std::atomic<bool> interrupt_data_logging;

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>