### PR TITLE
power_controller: Add support for individual POS/NEG powerdown (HW Re…

### DIFF
--- a/src/power_controller.hpp
+++ b/src/power_controller.hpp
@@ -70,7 +70,7 @@ namespace adiscope {
 
 	private:
 		Ui::PowerController *ui;
-		struct iio_channel *ch1w, *ch2w, *ch1r, *ch2r, *pd;
+		struct iio_channel *ch1w, *ch2w, *ch1r, *ch2r, *pd_pos, *pd_neg;
 		QTimer timer;
 		bool in_sync;
 


### PR DESCRIPTION
…v.C)

HW Rev.C implements individual powerdown controls for the
positive and negative power rails.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>