### PR TITLE
Spinbox: Add unit measurement input to spinbox edit control

### DIFF
--- a/src/spinbox_a.hpp
+++ b/src/spinbox_a.hpp
@@ -130,6 +130,7 @@ protected:
 	virtual bool eventFilter(QObject *obj, QEvent *event);
 	double findUnitOfValue(double val,int *posInUnitsList = NULL);
 	void setUnits(const QStringList& map);
+	bool isUnitMatched(const QString& unit, double value);
 
 protected:
 	Ui::SpinBoxA *ui;


### PR DESCRIPTION
If the input is a measurement value then the text is not case sensitive.
Otherwise the text is case sensitive.

Signed-off-by: Sarca <Septimiu.Sarca@analog.com>