### PR TITLE
Autoset

### DIFF
--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -2916,7 +2916,7 @@ void Oscilloscope::setupAutosetFreqSweep()
 	if (m2k_adc) {
 		high_gain_modes[autosetChannel] = M2kAdc::LOW_GAIN_MODE;
 		trigger_settings.autoTriggerDisable();
-		trigger_settings.on_intern_en_toggled(false);
+		trigger_settings.setTriggerEnable(false);
 	}
 	autosetSampleRateCnt--;
 	active_sample_rate = m2k_adc->availSamplRates()[autosetSampleRateCnt];

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -2979,8 +2979,9 @@ void Oscilloscope::autosetFinalStep() {
 
 	// autoset frequency found
 	if(autosetFFTIndex>1) {
-		timebaseval = (1/autosetFrequency)/5;
-		voltsperdiv = (autosetMaxAmpl-autosetMinAmpl)/4;
+		timebaseval = (1/autosetFrequency)/2;
+		voltsperdiv = (max(abs(autosetMaxAmpl),
+				   abs(autosetMinAmpl)))/5;
 		triggerlevel = (autosetMaxAmpl+autosetMinAmpl)/2;
 	}
 

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -218,7 +218,7 @@ namespace adiscope {
 		int autosetSampleRateCnt;
 		int autosetChannel;
 		bool autosetEnabled;
-		const int autosetSkippedTimeSamples = 3000;
+		const int autosetSkippedTimeSamples = 4096;
 		const int autosetFFTSize = 8192;
 		const int autosetNrOfSkippedTones=50;
 		const int autosetValidTone = 250;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -219,9 +219,9 @@ namespace adiscope {
 		int autosetChannel;
 		bool autosetEnabled;
 		const int autosetSkippedTimeSamples = 3000;
-		const int autosetFFTSize = 16384;
-		const int autosetNrOfSkippedTones=250;
-		const int autosetValidTone = 500;
+		const int autosetFFTSize = 8192;
+		const int autosetNrOfSkippedTones=50;
+		const int autosetValidTone = 250;
 
 		Ui::Oscilloscope *ui;
 		Ui::OscGeneralSettings *gsettings_ui;

--- a/src/trigger_settings.cpp
+++ b/src/trigger_settings.cpp
@@ -392,6 +392,16 @@ void TriggerSettings::setTriggerHystRange(int chn,
 	}
 }
 
+void TriggerSettings::setTriggerEnable(bool en) {
+	ui->intern_en->setChecked(en);
+	on_intern_en_toggled(en);
+}
+
+void TriggerSettings::setTriggerSource(int ch) {
+	ui->cmb_source->setCurrentIndex(ch);
+	on_cmb_source_currentIndexChanged(ch);
+}
+
 void TriggerSettings::setTriggerLevelStep(int chn, double step)
 {
 	trigg_configs[chn].level_step = step;

--- a/src/trigger_settings.hpp
+++ b/src/trigger_settings.hpp
@@ -88,6 +88,8 @@ namespace adiscope {
 			const QPair<double, double>& range);
 		void setTriggerHystRange(int chn,
 			const QPair<double, double>& range);
+		void setTriggerEnable(bool);
+		void setTriggerSource(int);
 		void setTriggerLevelStep(int chn, double step);
 		void setTriggerHystStep(int chn, double step);
 		void autoTriggerDisable();
@@ -96,12 +98,14 @@ namespace adiscope {
 		void setAdcRunningState(bool on);
 		void onSpinboxTriggerLevelChanged(double);
 
-	private Q_SLOTS:
+		void on_intern_en_toggled(bool);
 		void on_cmb_source_currentIndexChanged(int);
+
+	private Q_SLOTS:
 		void onSpinboxTriggerHystChanged(double);
 		void on_cmb_condition_currentIndexChanged(int);
 		void on_cmb_extern_condition_currentIndexChanged(int);
-		void on_intern_en_toggled(bool);
+
 		void on_extern_en_toggled(bool);
 		void on_cmb_analog_extern_currentIndexChanged(int);
 		void on_btnAuto_toggled(bool);

--- a/src/trigger_settings.hpp
+++ b/src/trigger_settings.hpp
@@ -98,14 +98,12 @@ namespace adiscope {
 		void setAdcRunningState(bool on);
 		void onSpinboxTriggerLevelChanged(double);
 
-		void on_intern_en_toggled(bool);
-		void on_cmb_source_currentIndexChanged(int);
-
 	private Q_SLOTS:
 		void onSpinboxTriggerHystChanged(double);
 		void on_cmb_condition_currentIndexChanged(int);
 		void on_cmb_extern_condition_currentIndexChanged(int);
-
+		void on_intern_en_toggled(bool);
+		void on_cmb_source_currentIndexChanged(int);
 		void on_extern_en_toggled(bool);
 		void on_cmb_analog_extern_currentIndexChanged(int);
 		void on_btnAuto_toggled(bool);

--- a/ui/channel_settings.ui
+++ b/ui/channel_settings.ui
@@ -864,19 +864,22 @@ Attenuation</string>
        <item>
         <widget class="QPushButton" name="btnAutoset">
          <property name="styleSheet">
-          <string notr="true">QPushButton {
-	background-color: rgba(0, 0, 0, 80);
-	color: gray;
-	font: bold  &quot;Times New Roman&quot;;	
-	font-size: 16px;
-	border-radius: 3px;
-  	border: 2px rgba(0, 0, 0, 80);
+          <string notr="true">QPushButton{
+  width: 175px;
+  height: 30px;
+  border-radius: 4px;
+  background-color: #4a64ff;
+  font-family: ArialMT;
+  font-size: 14px;
+  font-weight: normal;
+  font-style: normal;
+  text-align: center;
+  color: #ffffff;
 }
 
-QPushButton:hover {
-	color: white;
-	background-color: rgba(0, 0, 0, 60);
-	border-color: rgba(0, 0, 0, 60);
+QPushButton:hover
+{
+	 background-color: #4a34ff;
 }</string>
          </property>
          <property name="text">

--- a/ui/channel_settings.ui
+++ b/ui/channel_settings.ui
@@ -846,6 +846,45 @@ Attenuation</string>
         </layout>
        </item>
        <item>
+        <spacer name="verticalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnAutoset">
+         <property name="styleSheet">
+          <string notr="true">QPushButton {
+	background-color: rgba(0, 0, 0, 80);
+	color: gray;
+	font: bold  &quot;Times New Roman&quot;;	
+	font-size: 16px;
+	border-radius: 3px;
+  	border: 2px rgba(0, 0, 0, 80);
+}
+
+QPushButton:hover {
+	color: white;
+	background-color: rgba(0, 0, 0, 60);
+	border-color: rgba(0, 0, 0, 60);
+}</string>
+         </property>
+         <property name="text">
+          <string>Autoset</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
The autoset feature is implemented with this pull request. The autoset will perform FFT on the captured data and try to find the highest amplitude tone in the FFT. This FFT is performed multiple times on different sample rates to provide accuracy. Once the tone is found, the algorithm scans for the min/max of the waveform, and updates the vertical/horizontal controls. Also sets the trigger to (max-min)/2 - at 50%.