### PR TITLE
Oscilloscope adjustable memory depth

### DIFF
--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -159,6 +159,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(QWidget* parent, unsigned int xNumD
   d_sample_rate = 1;
   d_data_starting_point = 0.0;
   d_curves_hidden = false;
+  d_nbPtsXAxis = 0;
 
   // Reconfigure the bottom horizontal axis that was created by the base class
   configureAxis(QwtPlot::xBottom, 0);
@@ -447,6 +448,11 @@ void TimeDomainDisplayPlot::newData(const QEvent* updateEvent)
 	const std::vector< std::vector<gr::tag_t> > tags = tevent->getTags();
 	const std::string sender = tevent->senderName();
 
+	if ((d_nbPtsXAxis != 0) && (d_nbPtsXAxis <= numDataPoints)
+			&& sender == "Osc Time") {
+		Q_EMIT filledScreen(true);
+	}
+
 	this->plotNewData(sender,
 			dataPoints,
 			numDataPoints,
@@ -584,6 +590,11 @@ TimeDomainDisplayPlot::removeZoomer(unsigned int zoomerIdx)
 		if (d_zoomer[i]->isEnabled())
 			d_zoomer[i]->setAxes(QwtAxisId(QwtPlot::xBottom, 0), QwtAxisId(QwtPlot::yLeft, i));
 	}
+}
+
+void TimeDomainDisplayPlot::setXAxisNumPoints(unsigned int pts)
+{
+	d_nbPtsXAxis = pts;
 }
 
 void

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -450,7 +450,7 @@ void TimeDomainDisplayPlot::newData(const QEvent* updateEvent)
 
 	if ((d_nbPtsXAxis != 0) && (d_nbPtsXAxis <= numDataPoints)
 			&& sender == "Osc Time") {
-		Q_EMIT filledScreen(true);
+		Q_EMIT filledScreen(true, numDataPoints);
 	}
 
 	this->plotNewData(sender,

--- a/src/TimeDomainDisplayPlot.h
+++ b/src/TimeDomainDisplayPlot.h
@@ -120,7 +120,7 @@ public:
 Q_SIGNALS:
   void channelAdded(int);
   void newData();
-  void filledScreen(bool);
+  void filledScreen(bool, unsigned int);
 
 public Q_SLOTS:
   void setSampleRate(double sr, double units,

--- a/src/TimeDomainDisplayPlot.h
+++ b/src/TimeDomainDisplayPlot.h
@@ -89,7 +89,6 @@ public:
 		   const int64_t numDataPoints, const double timeInterval,
                    const std::vector< std::vector<gr::tag_t> > &tags \
 		   = std::vector< std::vector<gr::tag_t> >());
-
   void replot();
 
   void stemPlot(bool en);
@@ -116,10 +115,12 @@ public:
 
   void addZoomer(unsigned int zoomerIdx);
   void removeZoomer(unsigned int zoomerIdx);
+  void setXAxisNumPoints(unsigned int);
 
 Q_SIGNALS:
   void channelAdded(int);
   void newData();
+  void filledScreen(bool);
 
 public Q_SLOTS:
   void setSampleRate(double sr, double units,
@@ -198,6 +199,7 @@ private:
 
   SinkManager d_sinkManager;
 
+  unsigned int d_nbPtsXAxis;
   bool d_curves_hidden;
 
   QColor getChannelColor();

--- a/src/hardware_trigger.cpp
+++ b/src/hardware_trigger.cpp
@@ -344,7 +344,13 @@ void HardwareTrigger::setDelay(int delay)
 
 void HardwareTrigger::setStreamingFlag(bool val)
 {
+	m_streaming_flag = val;
 	iio_device_attr_write_bool(m_trigger_device, "streaming", val);
+}
+
+bool HardwareTrigger::getStreamingFlag()
+{
+	return m_streaming_flag;
 }
 
 HardwareTrigger::settings_uptr HardwareTrigger::getCurrentHwSettings()

--- a/src/hardware_trigger.cpp
+++ b/src/hardware_trigger.cpp
@@ -111,6 +111,7 @@ HardwareTrigger::HardwareTrigger(struct iio_device *trigg_dev) :
 	if (!m_delay_trigger) {
 		throw std::runtime_error("no delay trigger available");
 	}
+	setStreamingFlag(false);
 }
 
 uint HardwareTrigger::numChannels() const
@@ -339,6 +340,11 @@ int HardwareTrigger::delay() const
 void HardwareTrigger::setDelay(int delay)
 {
 	iio_channel_attr_write_longlong(m_delay_trigger, "delay", delay);
+}
+
+void HardwareTrigger::setStreamingFlag(bool val)
+{
+	iio_device_attr_write_bool(m_trigger_device, "streaming", val);
 }
 
 HardwareTrigger::settings_uptr HardwareTrigger::getCurrentHwSettings()

--- a/src/hardware_trigger.hpp
+++ b/src/hardware_trigger.hpp
@@ -82,7 +82,8 @@ public:
 	std::unique_ptr<struct Settings> getCurrentHwSettings();
 	void setHwTriggerSettings(struct Settings *settings);
 
-	void setStreaming(bool);
+	void setStreamingFlag(bool);
+	bool getStreamingFlag();
 
 private:
 	struct iio_device *m_trigger_device;
@@ -90,6 +91,7 @@ private:
 	QList<struct iio_channel *> m_digital_channels;
 	QList<struct iio_channel *> m_logic_channels;
 	struct iio_channel *m_delay_trigger;
+	bool m_streaming_flag;
 
 	uint m_num_channels;
 

--- a/src/hardware_trigger.hpp
+++ b/src/hardware_trigger.hpp
@@ -82,6 +82,8 @@ public:
 	std::unique_ptr<struct Settings> getCurrentHwSettings();
 	void setHwTriggerSettings(struct Settings *settings);
 
+	void setStreaming(bool);
+
 private:
 	struct iio_device *m_trigger_device;
 	QList<struct iio_channel *> m_analog_channels;

--- a/src/osc_capture_params.hpp
+++ b/src/osc_capture_params.hpp
@@ -30,6 +30,8 @@ public:
 		double timePos;
 		unsigned long entireBufferSize;
 		unsigned long triggerBufferSize;
+		unsigned long maxBufferSize;
+		std::vector<unsigned long long> availableBufferSizes;
 	};
 
 	virtual capture_parameters captureParameters() const = 0;
@@ -53,10 +55,14 @@ public:
 
 	void setTimeBase(double secsPerDiv);
 	void setTriggerPos(double pos);
+	void setCustomBufferSize(unsigned long customSize);
+	bool isEnhancedMemDepth();
+	bool setEnhancedMemDepth(bool);
 
 private:
 	void configParamsOnTimeBaseChanged();
 	void configParamsOnTriggPosChanged();
+	void configParamsOnCustomSizeChanged();
 
 	unsigned long getVisibleBufferSize(double sampleRate)
 	{
@@ -65,11 +71,14 @@ private:
 			0.5; // Round the positive value to nearest int
 	}
 
+	double getSamplerateFor(unsigned long);
+
 private:
 	std::vector<double> m_sampleRates;
 	unsigned int m_timeDivsCount;
 	unsigned long long m_entireBufferMaxSize;
 	unsigned long long m_triggerBufferMaxSize;
+	std::vector<unsigned long long> m_availableBufferSizes;
 
 	double m_timeBase;
 	double m_triggerPos;
@@ -78,6 +87,7 @@ private:
 	double m_triggPosSR;
 	unsigned long m_visibleBufferSize;
 	unsigned long m_triggerBufferSize;
+	bool m_enhancedMemoryDepth;
 };
 
 #endif // OSC_CAPTURE_PARAMS_H

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3281,26 +3281,6 @@ void Oscilloscope::cleanBuffersAllSinks()
 	qt_fft_block->clean_buffers();
 }
 
-void Oscilloscope::preparePlotSampleCount() {
-	if (!symmBufferMode->isEnhancedMemDepth()) {
-		if (timeBase->value() >= TIMEBASE_THRESHOLD) {
-			plot_samples_sequentially = true;
-			if (active_sample_count != -active_trig_sample_count) {
-				active_sample_count = -active_trig_sample_count;
-				setSinksDisplayOneBuffer(false);
-				plot.setXAxisNumPoints(active_plot_sample_count);
-//				resetStreamingFlag(true);
-			}
-		} else {
-			plot_samples_sequentially = false;
-			setSinksDisplayOneBuffer(true);
-			plot.setXAxisNumPoints(0);
-			/* Reset the triggered && streaming flag */
-//			resetStreamingFlag(false);
-		}
-	}
-}
-
 void Oscilloscope::onIioDataRefillTimeout()
 {
 	if (trigger_settings.triggerMode() == TriggerSettings::AUTO)

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -2209,7 +2209,7 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 
 	// Compute the appropriate value for fft_size
 	double power;
-	if (symmBufferMode->isEnhancedMemDepth()) {
+	if (symmBufferMode->isEnhancedMemDepth() || plot_samples_sequentially) {
 		power = floor(log2(active_plot_sample_count));
 	} else {
 		power = ceil(log2(active_plot_sample_count));
@@ -2334,7 +2334,7 @@ void adiscope::Oscilloscope::onTimePositionChanged(double value)
 
 	// Compute the appropriate value for fft_size
 	double power;
-	if (symmBufferMode->isEnhancedMemDepth()) {
+	if (symmBufferMode->isEnhancedMemDepth() || plot_samples_sequentially) {
 		power = floor(log2(active_plot_sample_count));
 	} else {
 		power = ceil(log2(active_plot_sample_count));

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3835,6 +3835,34 @@ void Oscilloscope_API::setTimeBase(double value)
 	osc->timeBase->setValue(value);
 }
 
+void Oscilloscope_API::setMemoryDepth(int val)
+{
+	bool ok = false;
+	unsigned long buffersize = 0;
+	int i = 0;
+	QString currentText;
+	for (i = 0; i < osc->ch_ui->cmbMemoryDepth->count(); i++) {
+		ok = false;
+		currentText = osc->ch_ui->cmbMemoryDepth->itemText(i);
+		buffersize = currentText.toInt(&ok);
+		if (ok && (val == buffersize)) {
+			break;
+		}
+	}
+	if (i >= osc->ch_ui->cmbMemoryDepth->count()) {
+		i = 0;
+	}
+	osc->ch_ui->cmbMemoryDepth->setCurrentIndex(i);
+}
+
+int Oscilloscope_API::getMemoryDepth()
+{
+	bool ok;
+	QString currentText = osc->ch_ui->cmbMemoryDepth->currentText();
+	unsigned long bufferSize = currentText.toInt(&ok);
+	return bufferSize;
+}
+
 bool Oscilloscope_API::running() const
 {
 	return osc->ui->pushButtonRunStop->isChecked();

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -199,7 +199,6 @@ namespace adiscope {
 		void onCmbMemoryDepthChanged(QString);
 		void setSinksDisplayOneBuffer(bool);
 		void cleanBuffersAllSinks();
-		void preparePlotSampleCount();
 		void resetStreamingFlag(bool);
 		void onFilledScreen(bool, unsigned int);
 

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -463,6 +463,9 @@ namespace adiscope {
 			   WRITE setExportAll)
 		Q_PROPERTY(bool autoset_en READ autosetEnabled WRITE enableAutoset)
 
+		Q_PROPERTY(int memory_depth READ getMemoryDepth
+			   WRITE setMemoryDepth)
+
 	public:
 		explicit Oscilloscope_API(Oscilloscope *osc) :
 			ApiObject(), osc(osc) {}
@@ -565,6 +568,9 @@ namespace adiscope {
 
 		int getCursorsTransparency() const;
 		void setCursorsTransparency(int val);
+
+		int getMemoryDepth();
+		void setMemoryDepth(int val);
 
 	private:
 		Oscilloscope *osc;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -196,11 +196,12 @@ namespace adiscope {
 
 		void readPreferences();
 
+		void onCmbMemoryDepthChanged(QString);
 		void setSinksDisplayOneBuffer(bool);
 		void cleanBuffersAllSinks();
 		void preparePlotSampleCount();
 		void resetStreamingFlag(bool);
-		void onFilledScreen(bool);
+		void onFilledScreen(bool, unsigned int);
 
 	public Q_SLOTS:
 		void requestAutoset();
@@ -216,6 +217,7 @@ namespace adiscope {
 		unsigned long active_plot_sample_count;
 		long long active_trig_sample_count;
 		double active_time_pos;
+		double memory_adjusted_time_pos;
 		double last_set_time_pos;
 		unsigned long last_set_sample_count;
 		int zoom_level;
@@ -303,6 +305,7 @@ namespace adiscope {
 
 		int fft_size;
 		int autoset_fft_size;
+		int fft_plot_size;
 
 		NumberSeries voltsPerDivList;
 		NumberSeries secPerDivList;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -63,6 +63,8 @@
 /*Generated UI */
 #include "ui_math_panel.h"
 
+#define TIMEBASE_THRESHOLD 0.1
+
 class QJSEngine;
 class SymmetricBufferMode;
 
@@ -194,6 +196,12 @@ namespace adiscope {
 
 		void readPreferences();
 
+		void setSinksDisplayOneBuffer(bool);
+		void cleanBuffersAllSinks();
+		void preparePlotSampleCount();
+		void resetStreamingFlag(bool);
+		void onFilledScreen(bool);
+
 	public Q_SLOTS:
 		void requestAutoset();
 		void enableLabels(bool);
@@ -205,11 +213,13 @@ namespace adiscope {
 		double active_sample_rate;
 		double noZoomXAxisWidth;
 		unsigned long active_sample_count;
+		unsigned long active_plot_sample_count;
 		long long active_trig_sample_count;
 		double active_time_pos;
 		double last_set_time_pos;
 		unsigned long last_set_sample_count;
 		int zoom_level;
+		bool plot_samples_sequentially, d_displayOneBuffer, d_shouldResetStreaming;
 
 		int autosetFFTIndex;
 		double autosetFrequency;

--- a/src/scope_sink_f.h
+++ b/src/scope_sink_f.h
@@ -56,6 +56,7 @@ namespace adiscope {
       virtual int nsamps() const = 0;
       virtual std::string name() const = 0;
       virtual void reset() = 0;
+      virtual void set_displayOneBuffer(bool) = 0;
       virtual void clean_buffers() = 0;
 
       QApplication *d_qApplication;

--- a/src/scope_sink_f_impl.h
+++ b/src/scope_sink_f_impl.h
@@ -56,6 +56,8 @@ namespace adiscope {
       int d_trigger_channel;
       pmt::pmt_t d_trigger_tag_key;
       bool d_triggered;
+
+      bool d_displayOneBuffer;
       bool d_cleanBuffers;
 
       void _reset();
@@ -79,6 +81,8 @@ namespace adiscope {
       void set_samp_rate(const double samp_rate);
       void set_trigger_mode(trigger_mode mode, int channel,
 			    const std::string &tag_key="");
+
+      void set_displayOneBuffer(bool);
 
       int nsamps() const;
       std::string name() const;

--- a/ui/channel_settings.ui
+++ b/ui/channel_settings.ui
@@ -105,8 +105,8 @@ font-weight: normal;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>252</width>
-        <height>497</height>
+        <width>228</width>
+        <height>472</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -846,6 +846,29 @@ Attenuation</string>
         </layout>
        </item>
        <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="styleSheet">
+           <string notr="true">color: rgba(255, 255, 255, 102);</string>
+          </property>
+          <property name="text">
+           <string>Memory depth</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="cmbMemoryDepth"/>
+        </item>
+       </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_9">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -885,8 +908,8 @@ QPushButton:hover
          <property name="text">
           <string>Autoset</string>
          </property>
-        </widget>
-       </item>
+        </widget> 
+        </item>
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">


### PR DESCRIPTION
This pull request implements two changes:
1) The adjustable memory depth allows the user to increase the number of acquired samples
for any time base, thus increasing the sampling frequency.

2) Oscilloscope needs to be able to plot samples as soon as they are available. So for large time bases, the user should not wait for the entire buffer. It should wait for the samples that are before the trigger and then display them sequentially.