### PR TITLE
Fix homepage for load reset scenario

### DIFF
--- a/src/stacked_homepage.cpp
+++ b/src/stacked_homepage.cpp
@@ -56,6 +56,13 @@ void StackedHomepage::addWidget(QWidget *widget)
 	s_hc->raise();
 }
 
+void StackedHomepage::removeWidget(QWidget *widget)
+{
+	QStackedWidget::removeWidget(widget);
+	s_hc->setVisible(count() > 1);
+	s_hc->lower();
+}
+
 void StackedHomepage::moveLeft()
 {
 	slideInPrev();

--- a/src/stacked_homepage.h
+++ b/src/stacked_homepage.h
@@ -45,6 +45,7 @@ public:
 	~StackedHomepage();
 
 	void addWidget(QWidget *widget);
+	void removeWidget(QWidget *widget);
 
 public Q_SLOTS:
 	void moveLeft();

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -272,6 +272,8 @@ void ToolLauncher::loadSession()
 			}
 		}
 	}
+	updateHomepage();
+	setupHomepage();
 }
 
 void ToolLauncher::resetSession()
@@ -671,6 +673,17 @@ void ToolLauncher::setupHomepage()
 		} else {
 			indexFile.close();
 		}
+	}
+}
+
+void ToolLauncher::updateHomepage()
+{
+	int count = ui->stackedWidget->count();
+
+	while (count) {
+		ui->stackedWidget->removeWidget(ui->stackedWidget->currentWidget());
+		ui->stackedWidget->moveLeft();
+		count--;
 	}
 }
 

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -286,10 +286,12 @@ void ToolLauncher::resetSession()
 				uri = (*it)->second.btn->property("uri").toString();
 			}
 		}
-
 		this->disconnect();
 		deviceConnected = true;
 	}
+	indexFile = "";
+	updateHomepage();
+	setupHomepage();
 
 	QSettings settings;
 	QFile fileScopy(settings.fileName());

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -66,7 +66,7 @@ ToolLauncher::ToolLauncher(QWidget *parent) :
 	skip_calibration(false),
 	calibrating(false),
 	debugger_enabled(false),
-	indexFile("")
+	indexFile(""), pathToFile("")
 {
 	if (!isatty(STDIN_FILENO))
 		notifier.setEnabled(false);
@@ -172,7 +172,7 @@ ToolLauncher::ToolLauncher(QWidget *parent) :
 		SLOT(setButtonBackground(bool)));
 
 	ui->saveBtn->parentWidget()->setEnabled(false);
-	ui->loadBtn->parentWidget()->setEnabled(false);
+	ui->loadBtn->parentWidget()->setEnabled(true);
 
 	ui->btnHome->toggle();
 
@@ -250,30 +250,29 @@ void ToolLauncher::saveSession()
 
 void ToolLauncher::loadSession()
 {
-	if (ctx) {
-		auto export_dialog( new QFileDialog( this ) );
-		export_dialog->setWindowModality( Qt::WindowModal );
-		export_dialog->setFileMode( QFileDialog::AnyFile );
-		export_dialog->setAcceptMode( QFileDialog::AcceptOpen );
-		export_dialog->setNameFilters({"Scopy-Files (*.ini)"});
-		if (export_dialog->exec()){
-			QFile f(export_dialog->selectedFiles().at(0));
-			QStack<QPushButton*> enabledTools;
-			for (auto tool : toolMenu)
-				if (tool->getToolStopBtn()->isEnabled()) {
-					enabledTools.push(tool->getToolStopBtn());
-					tool->getToolStopBtn()->setDisabled(true);
-				}
-			this->tl_api->load(f.fileName());
-			while (!enabledTools.isEmpty()) {
-				QPushButton *btn = enabledTools.back();
-				btn->setEnabled(true);
-				enabledTools.pop();
+	auto export_dialog( new QFileDialog( this ) );
+	export_dialog->setWindowModality( Qt::WindowModal );
+	export_dialog->setFileMode( QFileDialog::AnyFile );
+	export_dialog->setAcceptMode( QFileDialog::AcceptOpen );
+	export_dialog->setNameFilters({"Scopy-Files (*.ini)"});
+	if (export_dialog->exec()){
+		QFile f(export_dialog->selectedFiles().at(0));
+		QStack<QPushButton*> enabledTools;
+		for (auto tool : toolMenu)
+			if (tool->getToolStopBtn()->isEnabled()) {
+				enabledTools.push(tool->getToolStopBtn());
+				tool->getToolStopBtn()->setDisabled(true);
 			}
+		pathToFile = f.fileName();
+		this->tl_api->load(pathToFile);
+		while (!enabledTools.isEmpty()) {
+			QPushButton *btn = enabledTools.back();
+			btn->setEnabled(true);
+			enabledTools.pop();
 		}
+		updateHomepage();
+		setupHomepage();
 	}
-	updateHomepage();
-	setupHomepage();
 }
 
 void ToolLauncher::resetSession()
@@ -289,6 +288,7 @@ void ToolLauncher::resetSession()
 		this->disconnect();
 		deviceConnected = true;
 	}
+	pathToFile = "";
 	indexFile = "";
 	updateHomepage();
 	setupHomepage();
@@ -538,7 +538,7 @@ void ToolLauncher::loadToolTips(bool connected){
 		toolMenu["Voltmeter"]->getToolBtn()->setToolTip(
 					QString());
 		ui->saveBtn->setToolTip(QString());
-		ui->loadBtn->setToolTip(QString());
+		ui->loadBtn->setToolTip(QString("Click to load a session"));
 		ui->btnConnect->setToolTip(QString("Select a device first"));
 	}
 }
@@ -841,7 +841,6 @@ void adiscope::ToolLauncher::disconnect()
 		toolMenu["Debugger"]->getToolStopBtn()->setChecked(false);
 
 		ui->saveBtn->parentWidget()->setEnabled(false);
-		ui->loadBtn->parentWidget()->setEnabled(false);
 
 		for (auto x : detachedWindows){
 			x->close();
@@ -898,7 +897,6 @@ void adiscope::ToolLauncher::on_btnConnect_clicked(bool pressed)
 		search_timer->stop();
 
 		ui->saveBtn->parentWidget()->setEnabled(true);
-		ui->loadBtn->parentWidget()->setEnabled(true);
 
 		if (label) {
 			label->setText(filter->hw_name());
@@ -1096,6 +1094,10 @@ void adiscope::ToolLauncher::enableDacBasedTools()
 			toolMenu["Signal Generator"]->getToolStopBtn(), &js_engine, this);
 		toolList.push_back(signal_generator);
 	}
+	if (pathToFile != "") {
+		this->tl_api->load(pathToFile);
+	}
+
 	Q_EMIT dacToolsCreated();
 }
 
@@ -1573,6 +1575,7 @@ bool ToolLauncher_API::connect(const QString& uri)
 		QCoreApplication::processEvents();
 		QThread::msleep(10);
 	} while (!done);
+
 	return did_connect;
 }
 

--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -216,6 +216,7 @@ private:
 	bool debugger_enabled;
 
 	QString indexFile;
+	QString pathToFile;
 };
 
 class ToolLauncher_API: public ApiObject

--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -96,7 +96,6 @@ public Q_SLOTS:
 	void saveSession();
 
 private Q_SLOTS:
-
 	void search();
 	void update();
 	void ping();
@@ -132,6 +131,34 @@ private Q_SLOTS:
 	void swapMenuOptions(int source, int destination, bool dropAfter);
 	void highlight(bool on, int position);
 	void resetSession();
+
+private:
+	void loadToolTips(bool connected);
+	QVector<QString> searchDevices();
+	void swapMenu(QWidget *menu);
+	void destroyContext();
+	bool loadDecoders(QString path);
+	bool switchContext(const QString& uri);
+	void resetStylesheets();
+	void calibrate();
+	void checkIp(const QString& ip);
+	void disconnect();
+	void saveSettings();
+	Q_INVOKABLE QPushButton *addContext(const QString& hostname);
+
+	QList<QString> getOrder();
+	void setOrder(QList<QString> list);
+
+	void updateListOfDevices(const QVector<QString>& uris);
+	void generateMenu();
+	QStringList tools;
+	QStringList toolIcons;
+	void UpdatePosition(QWidget *widget, int position);
+	void insertMenuOptions();
+	void closeEvent(QCloseEvent *event);
+	void highlightDevice(QPushButton *btn);
+	void setupHomepage();
+	void updateHomepage();
 
 private:
 	Ui::ToolLauncher *ui;
@@ -180,41 +207,15 @@ private:
 	QSocketNotifier notifier;
 	QString previousIp;
 
+	QTextBrowser *welcome;
+	QTextBrowser *index;
+
 	bool calibrating;
 	bool skip_calibration;
 
 	bool debugger_enabled;
 
 	QString indexFile;
-
-	void loadToolTips(bool connected);
-	QVector<QString> searchDevices();
-	void swapMenu(QWidget *menu);
-	void destroyContext();
-	bool loadDecoders(QString path);
-	bool switchContext(const QString& uri);
-	void resetStylesheets();
-	void calibrate();
-	void checkIp(const QString& ip);
-	void disconnect();
-	void saveSettings();
-	Q_INVOKABLE QPushButton *addContext(const QString& hostname);
-
-	QList<QString> getOrder();
-	void setOrder(QList<QString> list);
-
-	QTextBrowser *welcome;
-	QTextBrowser *index;
-
-	void updateListOfDevices(const QVector<QString>& uris);
-	void generateMenu();
-	QStringList tools;
-	QStringList toolIcons;
-	void UpdatePosition(QWidget *widget, int position);
-	void insertMenuOptions();
-	void closeEvent(QCloseEvent *event);
-	void highlightDevice(QPushButton *btn);
-	void setupHomepage();
 };
 
 class ToolLauncher_API: public ApiObject


### PR DESCRIPTION
The homepage is now updated after using load/reset functionality.
A file can be loaded before the connection to the device is made.  In that case the changes will apply after the connection is done.
The application can be reset either it is connected to a device or not.