### PR TITLE
Add support for delayed acquisition in OSC and Logic Analyzer

### DIFF
--- a/src/la_capture_params.cpp
+++ b/src/la_capture_params.cpp
@@ -140,8 +140,8 @@ void LogicAnalyzerSymmetricBufferMode::configParamsOnTimeBaseChanged()
 			triggOffset;
 
 		if (bufferSize > m_entireBufferMaxSize) {
-			trigBuffSize = triggPosInBuffer;
-			bufferSize = getVisibleBufferSize(sampleRate);
+			trigBuffSize = -(bufferSize - m_entireBufferMaxSize);
+			bufferSize = m_entireBufferMaxSize;
 		} else {
 			bufferSize = m_entireBufferMaxSize;
 			triggPosInBuffer = -m_entireBufferMaxSize +
@@ -183,8 +183,8 @@ void LogicAnalyzerSymmetricBufferMode::configParamsOnTriggPosChanged()
 		m_triggerBufferSize = 0;
 
 		if (bufferSize > m_entireBufferMaxSize) {
-			m_triggerBufferSize = triggPosInBuffer;
-			bufferSize = (m_timeBase * m_timeDivsCount) * m_sampleRate;
+			m_triggerBufferSize = -(bufferSize - m_entireBufferMaxSize);
+			bufferSize = m_entireBufferMaxSize;
 		}
 		m_visibleBufferSize = bufferSize;
 		return;

--- a/src/la_capture_params.hpp
+++ b/src/la_capture_params.hpp
@@ -64,7 +64,7 @@ private:
 	double m_sampleRate;
 	double m_triggPosSR;
 	unsigned long m_visibleBufferSize;
-	unsigned long m_triggerBufferSize;
+	long long m_triggerBufferSize;
 };
 
 #endif // LA_CAPTURE_PARAMS_H

--- a/src/logic_analyzer.cpp
+++ b/src/logic_analyzer.cpp
@@ -233,10 +233,12 @@ LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx,
 		{"ns", 1E-9},
 		{"μs", 1E-6},
 		{"ms", 1E-3},
-		{"s", 1E0}
+		{"s", 1E0},
+		{"min", 60E0},
+		{"h", 36E2}
 	}, "Position",
 	-timeBase->maxValue() * 5,
-	timeBase->maxValue() * 5,
+	36E2,
 	true,
 	false,
 	this);
@@ -1253,10 +1255,10 @@ void LogicAnalyzer::startStop(bool start)
 void LogicAnalyzer::setTriggerDelay(bool silent)
 {
 	if( !silent ) {
-		main_win->view_->set_offset(timePosition->value(), active_plot_timebase * 10, running);
 		if( running )
 			main_win->view_->viewport()->setTimeTriggerSample(
 				-active_triggerSampleCount);
+		main_win->view_->set_offset(timePosition->value(), active_plot_timebase * 10, running);
 	}
 }
 

--- a/src/logic_analyzer.cpp
+++ b/src/logic_analyzer.cpp
@@ -1254,11 +1254,16 @@ void LogicAnalyzer::startStop(bool start)
 
 void LogicAnalyzer::setTriggerDelay(bool silent)
 {
+	double val = timePosition->value();
 	if( !silent ) {
 		if( running )
 			main_win->view_->viewport()->setTimeTriggerSample(
 				-active_triggerSampleCount);
-		main_win->view_->set_offset(timePosition->value(), active_plot_timebase * 10, running);
+		if (active_triggerSampleCount > 0) {
+			val = active_triggerSampleCount / active_sampleRate +
+					active_plot_timebase * 5;
+		}
+		main_win->view_->set_offset(val, active_plot_timebase * 10, running);
 	}
 }
 

--- a/src/logic_analyzer.cpp
+++ b/src/logic_analyzer.cpp
@@ -140,7 +140,7 @@ LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx,
 
 	symmBufferMode = make_shared<LogicAnalyzerSymmetricBufferMode>();
 	symmBufferMode->setMaxSampleRate(maxSamplingFrequency);
-	symmBufferMode->setEntireBufferMaxSize(500000); // max 0.5 mega-samples
+	symmBufferMode->setEntireBufferMaxSize(64000);
 	symmBufferMode->setTriggerBufferMaxSize(8192); // 8192 is what hardware supports
 	symmBufferMode->setTimeDivisionCount(10);
 

--- a/src/osc_capture_params.cpp
+++ b/src/osc_capture_params.cpp
@@ -167,8 +167,8 @@ void SymmetricBufferMode::configParamsOnTimeBaseChanged()
 			triggOffset;
 
 		if (bufferSize > m_entireBufferMaxSize) {
-			trigBuffSize = triggPosInBuffer;
-			bufferSize = getVisibleBufferSize(sampleRate);
+			trigBuffSize = -(bufferSize - m_entireBufferMaxSize);
+			bufferSize = m_entireBufferMaxSize;
 		} else {
 			bufferSize = m_entireBufferMaxSize;
 			triggPosInBuffer = -m_entireBufferMaxSize +
@@ -238,8 +238,8 @@ void SymmetricBufferMode::configParamsOnTriggPosChanged()
 		// Limit buffer size and recalculate trigger position
 		if (bufferSize > m_entireBufferMaxSize) {
 			/* Delayed acquisition */
-			m_triggerBufferSize = triggPosInBuffer;
-			bufferSize = (m_timeBase * m_timeDivsCount) * m_sampleRate;
+			m_triggerBufferSize = -(bufferSize - m_entireBufferMaxSize);
+			bufferSize = m_entireBufferMaxSize;
 		}
 
 		m_visibleBufferSize = bufferSize;

--- a/src/osc_capture_params.hpp
+++ b/src/osc_capture_params.hpp
@@ -29,8 +29,9 @@ public:
 		double sampleRate;
 		double timePos;
 		unsigned long entireBufferSize;
-		unsigned long triggerBufferSize;
-		unsigned long maxBufferSize;
+		long long triggerBufferSize;
+		long long maxBufferSize;
+		long long dataStartingPoint;
 		std::vector<unsigned long long> availableBufferSizes;
 	};
 
@@ -86,7 +87,7 @@ private:
 	double m_sampleRate;
 	double m_triggPosSR;
 	unsigned long m_visibleBufferSize;
-	unsigned long m_triggerBufferSize;
+	long long m_triggerBufferSize;
 	bool m_enhancedMemoryDepth;
 };
 

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -371,10 +371,12 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 				{"ns", 1E-9},
 				{"μs", 1E-6},
 				{"ms", 1E-3},
-				{"s", 1E0}
+				{"s", 1E0},
+				{"min", 60E0},
+				{"h", 36E2}
 				}, "Position",
 				-timeBase->maxValue() * 5,
-				timeBase->maxValue() * 5,
+				36E2,
 				true, false, this);
 	voltsPerDiv = new ScaleSpinButton({
 //				{"μVolts", 1E-6},

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -122,7 +122,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		symmBufferMode = make_shared<SymmetricBufferMode>();
 		symmBufferMode->setSampleRates(
 			m2k_adc->availSamplRates().toVector().toStdVector());
-		symmBufferMode->setEntireBufferMaxSize(500000); // max 0.5 mega-samples
+		symmBufferMode->setEntireBufferMaxSize(64000);
 		symmBufferMode->setTriggerBufferMaxSize(8192); // 8192 is what hardware supports
 		symmBufferMode->setTimeDivisionCount(plot.xAxisNumDiv());
 	}

--- a/src/pulseview/pv/view/view.cpp
+++ b/src/pulseview/pv/view/view.cpp
@@ -1246,13 +1246,17 @@ void View::set_offset(double timePos, double timeSpan, bool running)
 	if( running )
 	{
 		ruler_->set_offset(value);
-		start_plot_offset_ = value;
-		Q_EMIT offset_changed();
-		if(value > 0 ){
-			start_plot_offset_ = 0;
-			set_scale_offset(scale_, Timestamp(0));
+		if (value > 0) {
+			if (viewport_->getTimeTriggerSample() < 0) {
+				start_plot_offset_ = value;
+			} else {
+				start_plot_offset_ = 0;
+			}
+			set_scale_offset(scale_, Timestamp(start_plot_offset_));
+		} else {
+			start_plot_offset_ = value;
+			Q_EMIT offset_changed();
 		}
-
 	}
 	else
 	{


### PR DESCRIPTION
Through this pull request, enhancement #50 is implemented. Both the Oscilloscope and the Logic Analyzer now provide support for delayed acquisitions. No UI element was added to control this. The only element that has control over this feature is the trigger position. 
Once the corresponding buffer size (for the trigger position) moves past the threshold (500000), the delayed acquisition is automatically enabled.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>