### PR TITLE
build: fix Linux build (part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 deps
 scopy
 *.swp
+html/

--- a/CI/travis/before_install_darwin.sh
+++ b/CI/travis/before_install_darwin.sh
@@ -9,7 +9,8 @@ brew_install_or_upgrade() {
 		brew ls --versions $1 # check if installed last-ly
 }
 
-PACKAGES="qt cmake fftw bison gettext autoconf automake libtool libzip glib libusb python3 python brew-pip"
+PYTHON="python3 python@2 python brew-pip"
+PACKAGES="qt cmake fftw bison gettext autoconf automake libtool libzip glib libusb $PYTHON"
 PACKAGES="$PACKAGES glibmm doxygen wget boost gnu-sed libmatio dylibbundler libxml2 pkg-config"
 
 for pak in $PACKAGES ; do

--- a/CI/travis/before_install_darwin.sh
+++ b/CI/travis/before_install_darwin.sh
@@ -26,10 +26,9 @@ QT_PATH="$(brew --prefix qt)/bin"
 export PATH="${QT_PATH}:$PATH"
 
 patch_qwtpolar_mac() {
-	[ -f qwtpolar-qwt-6.1-compat.patch ] || {
-		patch_qwtpolar
+	patch_qwtpolar
 
-		patch -p1 <<-EOF
+	patch -p1 <<-EOF
 --- a/qwtpolarconfig.pri
 +++ b/qwtpolarconfig.pri
 @@ -16,7 +16,9 @@ QWT_POLAR_VER_PAT      = 1
@@ -44,7 +43,6 @@ patch_qwtpolar_mac() {
  
  win32 {
 EOF
-	}
 }
 
 # Get pip if not installed ; on Travis + OS X, Python is not well supported

--- a/CI/travis/before_install_linux.sh
+++ b/CI/travis/before_install_linux.sh
@@ -92,7 +92,7 @@ if [ "$TRAVIS" == "true" ] ; then
 else
 	cmake_build_git "libiio" "https://github.com/analogdevicesinc/libiio" "" "-DINSTALL_UDEV_RULE:BOOL=OFF"
 
-	cmake_build_git "libad9361-iio" "https://github.com/analogdevicesinc/libad9361-iio" "" "-DLIBIIO_INCLUDEDIR:STRING=$STAGINGDIR/include -DLIBIIO_LIBRARIES:STRING=$STAGINGDIR/lib"
+	cmake_build_git "libad9361-iio" "https://github.com/analogdevicesinc/libad9361-iio" "" "-DLIBIIO_INCLUDEDIR:PATH=$STAGINGDIR/include -DLIBIIO_LIBRARIES:FILEPATH=$STAGINGDIR/lib/libiio.so"
 fi
 
 cmake_build_git "gr-iio" "https://github.com/analogdevicesinc/gr-iio"

--- a/CI/travis/before_install_linux.sh
+++ b/CI/travis/before_install_linux.sh
@@ -48,10 +48,9 @@ else
 fi
 
 patch_qwtpolar_linux() {
-	[ -f qwtpolar-qwt-6.1-compat.patch ] || {
-		patch_qwtpolar
+	patch_qwtpolar
 
-		patch -p1 <<-EOF
+	patch -p1 <<-EOF
 --- a/qwtpolarconfig.pri
 +++ b/qwtpolarconfig.pri
 @@ -16,7 +16,9 @@ QWT_POLAR_VER_PAT      = 1
@@ -66,7 +65,6 @@ patch_qwtpolar_linux() {
  
  win32 {
 EOF
-	}
 }
 
 if ! is_new_ubuntu ; then


### PR DESCRIPTION
The build on master seems to fail currently, because of some fluke/goof with how caching works on Travis CI.

Link: 
https://travis-ci.org/analogdevicesinc/scopy/builds/411606380

Fixed this by patching dependencies only once when they're downloaded.
This also simplifies things on patching in general.

Also fixes the local build of `libad9361-iio` when building Scopy.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>