### PR TITLE
[for v1.0.1] build,travis-ci: add Xenial builds to the job run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       os: linux
       dist: trusty
       env: LDIST=-trusty
+    - compiler: gcc
+      os: linux
+      dist: xenial
+      env: LDIST=-xenial
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./CI/travis/before_install_darwin.sh ; fi

--- a/CI/travis/before_install_linux.sh
+++ b/CI/travis/before_install_linux.sh
@@ -4,7 +4,7 @@ set -e
 source ./CI/travis/lib.sh
 
 if ! is_new_ubuntu ; then
-	sudo add-apt-repository --yes ppa:beineri/opt-qt592-trusty
+	sudo add-apt-repository --yes ppa:beineri/opt-qt592${LDIST}
 fi
 
 sudo apt-get -qq update
@@ -34,7 +34,8 @@ source ./CI/travis/before_install_lib.sh
 
 if ! is_new_ubuntu ; then
 	sudo apt-get install -y qt59base qt59declarative qt59quickcontrols \
-		qt59svg qt59tools python-dev automake libtool mesa-common-dev
+		qt59svg qt59tools python-dev automake libtool mesa-common-dev \
+		libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libglu1-mesa-dev
 	# temporarily disable `set -e`
 	QMAKE=/opt/qt59/bin/qmake
 	$QMAKE -set QMAKE $QMAKE


### PR DESCRIPTION
Time to also build for Ubuntu 16.04.
Unfortunately, the QT5 libs are still too old for Scopy, so we need to pull
an external Qt5.9 repo from launchpad (similar as for Trusty).

Link is:
  https://launchpad.net/~beineri/+archive/ubuntu/opt-qt592-xenial

Same packager also has builds for Xenial.

And we also need to specifically pull the Mesa GL dev libs so that libqwt
builds fine.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>