### PR TITLE
Compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,14 @@ configure_file(Info.plist.cmakein ${CMAKE_CURRENT_BINARY_DIR}/Info.plist @ONLY)
 # Compiler options
 target_compile_options(${PROJECT_NAME} PUBLIC -Wall)
 
+#List of warnings to be treated as errors
+target_compile_options(${PROJECT_NAME} PUBLIC
+	-Werror=return-type
+	-Werror=uninitialized
+	-Werror=init-self
+	-Werror=switch
+)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
 		CXX_STANDARD 11
 		CXX_STANDARD_REQUIRED ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,9 @@ endif()
 
 configure_file(Info.plist.cmakein ${CMAKE_CURRENT_BINARY_DIR}/Info.plist @ONLY)
 
+# Compiler options
+target_compile_options(${PROJECT_NAME} PUBLIC -Wall)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
 		CXX_STANDARD 11
 		CXX_STANDARD_REQUIRED ON

--- a/src/pg_patterns.cpp
+++ b/src/pg_patterns.cpp
@@ -1300,6 +1300,9 @@ uint16_t UARTPattern::encapsulateUartFrame(char chr, uint16_t *bits_per_frame)
 		parity_bit_available = true;
 		parity_bit_value = 0;
 		break;
+
+	case SP_PARITY_INVALID:
+		qDebug() << "Invalid parity setting detected";
 	}
 
 	if (!msb_first) {

--- a/src/pulseview/pv/view/viewport.cpp
+++ b/src/pulseview/pv/view/viewport.cpp
@@ -323,22 +323,22 @@ void Viewport::paint_last_sample_cursor(QPainter &p, const ViewItemPaintParams &
 {
 	int sample_index = view_.session().get_logic_active_sample();
 	double samplerate = view_.session().get_samplerate();
-	int px;
+
 	if( samplerate != 1 ) {
 		const double samples_per_pixel = samplerate * pp.scale();
 		const double pixels_offset = pp.pixels_offset();
-		px = (sample_index / samples_per_pixel - pixels_offset) + pp.left();
+		int px = (sample_index / samples_per_pixel - pixels_offset) + pp.left();
+
+		QPen pen = QPen(QColor("white"));
+		p.setPen(pen);
+		const int y = view_.owner_visual_v_offset();
+		const int h = pp.height();
+		int row_count = view_.height() / divisionHeight;
+
+		QPoint p1 = QPoint(px, y);
+		QPoint p2 = QPoint(px, y + h * row_count);
+		p.drawLine(p1, p2);
 	}
-
-	QPen pen = QPen(QColor("white"));
-	p.setPen(pen);
-	const int y = view_.owner_visual_v_offset();
-	const int h = pp.height();
-	int row_count = view_.height() / divisionHeight;
-
-	QPoint p1 = QPoint(px, y);
-	QPoint p2 = QPoint(px, y + h * row_count);
-	p.drawLine(p1, p2);
 }
 
 void Viewport::paint_grid(QPainter &p, const ViewItemPaintParams &pp)

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -487,7 +487,7 @@ void SpectrumAnalyzer::triggerRightMenuToggle(CustomPushButton *btn, bool checke
 
 void SpectrumAnalyzer::toggleRightMenu(CustomPushButton *btn, bool checked)
 {
-	int index;
+	int index = 0;
 	bool chSettings = false;
 	int id = -1;
 
@@ -514,8 +514,6 @@ void SpectrumAnalyzer::toggleRightMenu(CustomPushButton *btn, bool checked)
 		} else if (btn == ui->btnMarkers) {
 			index = 3;
 		}
-	} else {
-		index = 0;
 	}
 
 	if (id != -1) {

--- a/src/spinbox_a.cpp
+++ b/src/spinbox_a.cpp
@@ -771,13 +771,15 @@ void PhaseSpinButton::setValue(double value)
 		}
 	}
 
-	int index;
-	auto scale = inSeconds() ? findUnitOfValue(value, &index)
-	             : m_units.at(ui->SBA_Combobox->currentIndex()).second;
 	double period = 360;
+	double scale;
 
 	if (inSeconds()) {
+		int index;
+		scale = findUnitOfValue(value, &index);
 		value = computeSecondsTransformation(scale, index, value);
+	} else {
+		scale = m_units.at(ui->SBA_Combobox->currentIndex()).second;
 	}
 
 	// Update line edit

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1057,7 +1057,7 @@ void adiscope::ToolLauncher::resetStylesheets()
 
 void adiscope::ToolLauncher::deviceBtn_clicked(bool pressed)
 {
-	DeviceWidget *dev;
+	DeviceWidget *dev = nullptr;
 	for (auto d : devices) {
 		if (d == sender()) {
 			dev = d;


### PR DESCRIPTION
 - Enable the -Wall set of warnings. This increase the awareness of possible coding issues.
 - Tell the compiler to treat a couple of these warnings as errors to ensure the warnings don't get overlooked.

Ideally all warnings should be treated as errors or at least a large part of them.  I've added only a a few as there were many unused functions/variables warnings as well as reorder warnings which would require too many code changes for a single PR.