### PR TITLE
Logic Analyzer and Pattern Generator small fix

### DIFF
--- a/src/la_channel_manager.cpp
+++ b/src/la_channel_manager.cpp
@@ -189,6 +189,11 @@ void LogicAnalyzerChannelUI::mouseMoveEvent(QMouseEvent *event)
 
 void LogicAnalyzerChannelUI::dragEnterEvent(QDragEnterEvent *event)
 {
+	if (!event->source()) {
+		event->ignore();
+		return;
+	}
+
 	auto w = ui->baseWidget->geometry().width();
 	auto h = ui->baseWidget->geometry().height();
 
@@ -936,6 +941,11 @@ void LogicAnalyzerChannelGroupUI::mouseMoveEvent(QMouseEvent *event)
 
 void LogicAnalyzerChannelGroupUI::dragEnterEvent(QDragEnterEvent *event)
 {
+	if (!event->source()) {
+		event->ignore();
+		return;
+	}
+
 	auto w = ui->baseWidget->geometry().width();
 	auto h = ui->baseWidget->geometry().height();
 	topDragbox.setRect(0, 0, w, h/3);

--- a/src/pg_channel_manager.cpp
+++ b/src/pg_channel_manager.cpp
@@ -230,6 +230,11 @@ void PatternGeneratorChannelUI::mouseMoveEvent(QMouseEvent *event)
 
 void PatternGeneratorChannelUI::dragEnterEvent(QDragEnterEvent *event)
 {
+	if (!event->source()) {
+		event->ignore();
+		return;
+	}
+
 	auto w = ui->widget_2->geometry().width();
 	auto h = ui->widget_2->geometry().height();
 	topDragbox.setRect(0, 0, w, h/2);
@@ -760,6 +765,11 @@ void PatternGeneratorChannelGroupUI::mouseMoveEvent(QMouseEvent *event)
 
 void PatternGeneratorChannelGroupUI::dragEnterEvent(QDragEnterEvent *event)
 {
+	if (!event->source()) {
+		event->ignore();
+		return;
+	}
+
 	auto w = ui->widget_2->geometry().width();
 	auto h = ui->widget_2->geometry().height(); // include lines
 	topDragbox.setRect(0, 0, w, h/3);


### PR DESCRIPTION
This fixes a issue where channels from the Logic Analyzer or Pattern Generator were able to be dragged and dropped between two instances of Scopy.