### PR TITLE
Oscilloscope math channel fixes

### DIFF
--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -1085,6 +1085,11 @@ bool TimeDomainDisplayPlot::registerSink(std::string sinkUniqueNme, unsigned int
 			QwtSymbol *symbol = new QwtSymbol(QwtSymbol::NoSymbol, QBrush(color),
 							QPen(color), QSize(7,7));
 
+			if (sinkIndex >= 1) {
+				d_plot_curve.back()->setPaintAttribute(QwtPlotCurve::ClipPolygons, false);
+				d_plot_curve.back()->setPaintAttribute(QwtPlotCurve::FilterPointsAggressive, true);
+			}
+
 			d_plot_curve.back()->setRawSamples(d_xdata[sinkIndex], d_ydata[n], channelsDataLength);
 			d_plot_curve.back()->setSymbol(symbol);
 

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -874,6 +874,12 @@ bool TimeDomainDisplayPlot::isReferenceWaveform(QwtPlotCurve *curve)
 	return d_ref_curves.values().contains(curve);
 }
 
+bool TimeDomainDisplayPlot::isMathWaveform(QwtPlotCurve *curve)
+{
+	return d_math_curves.values().contains(curve);
+}
+
+
 int TimeDomainDisplayPlot::getCurveNextTo(int pos)
 {
 	while (isReferenceWaveform(Curve(pos))) pos++;
@@ -1058,6 +1064,17 @@ void TimeDomainDisplayPlot::realignReferenceWaveforms(double timebase, double ti
 	}
 }
 
+bool TimeDomainDisplayPlot::registerMathWaveform(std::string sinkUniqueNme, unsigned int numChannels,
+	 unsigned long long channelsDataLength, bool curvesAttached)
+{
+	bool ret = registerSink(sinkUniqueNme, numChannels, channelsDataLength, curvesAttached);
+	if (ret) {
+		d_math_curves.insert(QString::fromStdString(sinkUniqueNme), d_plot_curve.back());
+	}
+	return ret;
+}
+
+
 bool TimeDomainDisplayPlot::registerSink(std::string sinkUniqueNme, unsigned int numChannels,
 	unsigned long long channelsDataLength, bool curvesAttached)
 {
@@ -1105,6 +1122,15 @@ bool TimeDomainDisplayPlot::registerSink(std::string sinkUniqueNme, unsigned int
 		d_sink_reset_x_axis_pts.push_back(false);
 	}
 
+	return ret;
+}
+
+bool TimeDomainDisplayPlot::unregisterMathWaveform(std::string sinkName)
+{
+	int ret = unregisterSink(sinkName);
+	if (ret) {
+		d_math_curves.remove(QString::fromStdString(sinkName));
+	}
 	return ret;
 }
 

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -874,7 +874,7 @@ bool TimeDomainDisplayPlot::isReferenceWaveform(QwtPlotCurve *curve)
 	return d_ref_curves.values().contains(curve);
 }
 
-bool TimeDomainDisplayPlot::isMathWaveform(QwtPlotCurve *curve)
+bool TimeDomainDisplayPlot::isMathWaveform(QwtPlotCurve *curve) const
 {
 	return d_math_curves.values().contains(curve);
 }
@@ -1064,7 +1064,7 @@ void TimeDomainDisplayPlot::realignReferenceWaveforms(double timebase, double ti
 	}
 }
 
-bool TimeDomainDisplayPlot::registerMathWaveform(std::string sinkUniqueNme, unsigned int numChannels,
+bool TimeDomainDisplayPlot::registerMathWaveform(const std::string &sinkUniqueNme, unsigned int numChannels,
 	 unsigned long long channelsDataLength, bool curvesAttached)
 {
 	bool ret = registerSink(sinkUniqueNme, numChannels, channelsDataLength, curvesAttached);
@@ -1125,7 +1125,7 @@ bool TimeDomainDisplayPlot::registerSink(std::string sinkUniqueNme, unsigned int
 	return ret;
 }
 
-bool TimeDomainDisplayPlot::unregisterMathWaveform(std::string sinkName)
+bool TimeDomainDisplayPlot::unregisterMathWaveform(const std::string &sinkName)
 {
 	int ret = unregisterSink(sinkName);
 	if (ret) {

--- a/src/TimeDomainDisplayPlot.h
+++ b/src/TimeDomainDisplayPlot.h
@@ -111,6 +111,10 @@ public:
 	unsigned long long channelsDataLength, bool curvesAttached = true);
   bool unregisterSink(std::string sinkName);
 
+  bool registerMathWaveform(std::string sinkUniqueNme, unsigned int numChannels,
+	unsigned long long channelsDataLength, bool curvesAttached = true);
+  bool unregisterMathWaveform(std::string sinkName);
+
   long dataStartingPoint() const;
 
   void addZoomer(unsigned int zoomerIdx);
@@ -185,6 +189,7 @@ protected:
   QVector<QVector<double>> d_preview_ydata;
   QVector<QwtPlotCurve *> d_preview_curves;
   bool isReferenceWaveform(QwtPlotCurve *curve);
+  bool isMathWaveform(QwtPlotCurve *curve);
   int countReferenceWaveform(int position);
 
 private:
@@ -220,6 +225,7 @@ private:
   QColor getChannelColor();
 
   QMap<QString, QwtPlotCurve *> d_ref_curves;
+  QMap<QString, QwtPlotCurve *> d_math_curves;
   int d_nb_ref_curves;
   int getCurveNextTo(int pos);
 };

--- a/src/TimeDomainDisplayPlot.h
+++ b/src/TimeDomainDisplayPlot.h
@@ -111,9 +111,9 @@ public:
 	unsigned long long channelsDataLength, bool curvesAttached = true);
   bool unregisterSink(std::string sinkName);
 
-  bool registerMathWaveform(std::string sinkUniqueNme, unsigned int numChannels,
+  bool registerMathWaveform(const std::string &sinkUniqueNme, unsigned int numChannels,
 	unsigned long long channelsDataLength, bool curvesAttached = true);
-  bool unregisterMathWaveform(std::string sinkName);
+  bool unregisterMathWaveform(const std::string &sinkName);
 
   long dataStartingPoint() const;
 
@@ -189,7 +189,7 @@ protected:
   QVector<QVector<double>> d_preview_ydata;
   QVector<QwtPlotCurve *> d_preview_curves;
   bool isReferenceWaveform(QwtPlotCurve *curve);
-  bool isMathWaveform(QwtPlotCurve *curve);
+  bool isMathWaveform(QwtPlotCurve *curve) const;
   int countReferenceWaveform(int position);
 
 private:

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "measure.h"
+#include <cmath>
 #include "adc_sample_conv.hpp"
 #include <qmath.h>
 #include <QDebug>
@@ -499,6 +500,10 @@ void Measure::measure()
 	int startIndex;
 	int endIndex;
 
+	if (isnanf(data[0])) {
+		return;
+	}
+
 	//if gating is enabled measure only on data between the gates
 	if(m_gatingEnabled){
 		//make sure that start/end indexes are valid
@@ -525,10 +530,6 @@ void Measure::measure()
 		endIndex = data_length;
 	}
 
-	if (isnanl(data[0])) {
-		return;
-	}
-
 	m_cross_detect = new CrossingDetection(m_cross_level, m_hysteresis_span,
 			"P");
 	if (using_histogram_method)
@@ -536,7 +537,7 @@ void Measure::measure()
 
 	for (size_t i = startIndex; i < endIndex; i++) {
 
-		if (isnanl(data[i])) {
+		if (isnanf(data[i])) {
 			count--;
 			continue;
 		}

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -535,12 +535,14 @@ void Measure::measure()
 		m_cross_detect->crossDetectStep(data, i);
 
 		// Min
-		if (data[i] < min)
+		if (data[i] < min) {
 			min = data[i];
+		}
 
 		// Max
-		if (data[i] > max)
+		if (data[i] > max) {
 			max = data[i];
+		}
 
 		// Sum of values
 		sum += data[i];

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -500,7 +500,7 @@ void Measure::measure()
 	int startIndex;
 	int endIndex;
 
-	if (isnanf(data[0])) {
+	if (qIsNaN(data[0])) {
 		return;
 	}
 
@@ -537,7 +537,7 @@ void Measure::measure()
 
 	for (size_t i = startIndex; i < endIndex; i++) {
 
-		if (isnanf(data[i])) {
+		if (qIsNaN(data[i])) {
 			count--;
 			continue;
 		}

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -73,8 +73,8 @@
 #include "ui_trigger_settings.h"
 
 #define MAX_MATH_CHANNELS 4
-#define MAX_MATH_RANGE 100
-#define MIN_MATH_RANGE -100
+#define MAX_MATH_RANGE SHRT_MAX
+#define MIN_MATH_RANGE SHRT_MIN
 #define MAX_AMPL 25
 
 using namespace adiscope;
@@ -666,8 +666,8 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 
 		auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
 		for (auto rail : math_rails.values()) {
-			rail->set_lo(MIN_MATH_RANGE * (*max_elem));
-			rail->set_hi(MAX_MATH_RANGE * (*max_elem));
+			rail->set_lo(MIN_MATH_RANGE);
+			rail->set_hi(MAX_MATH_RANGE);
 		}
 
 		if (started)
@@ -1707,8 +1707,7 @@ void Oscilloscope::add_math_channel(const std::string& function)
 	}
 
 	auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
-	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE * (*max_elem),
-					      MAX_MATH_RANGE * (*max_elem));
+	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE, MAX_MATH_RANGE);
 	auto math = iio::iio_math::make(function, nb_channels);
 	unsigned int curve_id = nb_channels + nb_math_channels + nb_ref_channels;
 	unsigned int curve_number = find_curve_number();
@@ -3253,8 +3252,7 @@ void Oscilloscope::editMathChannelFunction(int id, const std::string& new_functi
 	std::string name = qname.toStdString();
 
 	auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
-	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE * (*max_elem),
-					      MAX_MATH_RANGE * (*max_elem));
+	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE, MAX_MATH_RANGE);
 	auto math = iio::iio_math::make(new_function, nb_channels);
 
 	bool started = iio->started();

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3238,17 +3238,17 @@ void Oscilloscope::editMathChannelFunction(int id, const std::string& new_functi
 	int current_x = index_x;
 	int current_y = index_y;
 
+	triggerRightMenuToggle(
+				static_cast<CustomPushButton* >(ui->btnAddMath), false);
+	triggerRightMenuToggle(
+				static_cast<CustomPushButton* >(chn_widget->menuButton()), true);
+	math_pair->first.btnAddChannel->setText("Add Channel");
+	math_pair->second->setFunction("");
+	addChannel = true;
+	ch_ui->btnEditMath->setChecked(false);
 
-	if (new_function != chn_widget->function().toStdString()) {
-		triggerRightMenuToggle(
-					static_cast<CustomPushButton* >(ui->btnAddMath), false);
-		triggerRightMenuToggle(
-					static_cast<CustomPushButton* >(chn_widget->menuButton()), true);
-		math_pair->first.btnAddChannel->setText("Add Channel");
-		math_pair->second->setFunction("");
-		addChannel = true;
-		ch_ui->btnEditMath->setChecked(false);
-	}
+	if (chn_widget->function().toStdString() == new_function)
+		return;
 
 	QString qname = chn_widget->deleteButton()->property("curve_name").toString();
 	std::string name = qname.toStdString();

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3238,14 +3238,17 @@ void Oscilloscope::editMathChannelFunction(int id, const std::string& new_functi
 	int current_x = index_x;
 	int current_y = index_y;
 
-	triggerRightMenuToggle(
-		static_cast<CustomPushButton* >(ui->btnAddMath), false);
-	triggerRightMenuToggle(
-		static_cast<CustomPushButton* >(chn_widget->menuButton()), true);
-	math_pair->first.btnAddChannel->setText("Add Channel");
-	math_pair->second->setFunction("");
-	addChannel = true;
-	ch_ui->btnEditMath->setChecked(false);
+
+	if (new_function != chn_widget->function().toStdString()) {
+		triggerRightMenuToggle(
+					static_cast<CustomPushButton* >(ui->btnAddMath), false);
+		triggerRightMenuToggle(
+					static_cast<CustomPushButton* >(chn_widget->menuButton()), true);
+		math_pair->first.btnAddChannel->setText("Add Channel");
+		math_pair->second->setFunction("");
+		addChannel = true;
+		ch_ui->btnEditMath->setChecked(false);
+	}
 
 	QString qname = chn_widget->deleteButton()->property("curve_name").toString();
 	std::string name = qname.toStdString();

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1747,7 +1747,7 @@ void Oscilloscope::add_math_channel(const std::string& function)
 	if (started)
 		iio->unlock();
 
-	plot.registerSink(name, 1,
+	plot.registerMathWaveform(name, 1,
 			noZoomXAxisWidth *
 			adc->sampleRate());
 
@@ -1874,7 +1874,7 @@ void Oscilloscope::onChannelWidgetDeleteClicked()
 	measure_settings->onChannelRemoved(curve_id);
 
 	if (cw->isMathChannel()) {
-		plot.unregisterSink(qname.toStdString());
+		plot.unregisterMathWaveform(qname.toStdString());
 
 		exportSettings->removeChannel(curve_id - nb_ref_channels);
 		exportConfig.remove(curve_id - nb_ref_channels);

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -303,6 +303,7 @@ namespace adiscope {
 
 		QMap<QString, QPair<gr::basic_block_sptr,
 			gr::basic_block_sptr>> math_sinks;
+		QMap<QString, gr::basic_block_sptr> math_rails;
 
 		iio_manager::port_id *ids;
 		iio_manager::port_id *fft_ids;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -28,6 +28,7 @@
 #include <gnuradio/blocks/complex_to_mag_squared.h>
 #include <gnuradio/blocks/keep_one_in_n.h>
 #include <gnuradio/blocks/vector_sink_f.h>
+#include <gnuradio/blocks/multiply_const_ff.h>
 
 /* Qt includes */
 #include <QPair>
@@ -304,6 +305,7 @@ namespace adiscope {
 		QMap<QString, QPair<gr::basic_block_sptr,
 			gr::basic_block_sptr>> math_sinks;
 		QMap<QString, gr::basic_block_sptr> math_rails;
+		std::vector<boost::shared_ptr<gr::blocks::multiply_const_ff>> math_probe_atten;
 
 		iio_manager::port_id *ids;
 		iio_manager::port_id *fft_ids;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -29,6 +29,7 @@
 #include <gnuradio/blocks/keep_one_in_n.h>
 #include <gnuradio/blocks/vector_sink_f.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
+#include <gnuradio/analog/rail_ff.h>
 
 /* Qt includes */
 #include <QPair>
@@ -304,7 +305,7 @@ namespace adiscope {
 
 		QMap<QString, QPair<gr::basic_block_sptr,
 			gr::basic_block_sptr>> math_sinks;
-		QMap<QString, gr::basic_block_sptr> math_rails;
+		QMap<QString, boost::shared_ptr<gr::analog::rail_ff>> math_rails;
 		std::vector<boost::shared_ptr<gr::blocks::multiply_const_ff>> math_probe_atten;
 
 		iio_manager::port_id *ids;

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -1436,6 +1436,7 @@ void CapturePlot::onChannelAdded(int chnIdx)
 		measure = new Measure(chnIdx, d_ydata[chnIdx - count],
 			Curve(chnIdx)->data()->size());
 	}
+
 	measure->setAdcBitCount(12);
 	d_measureObjs.push_back(measure);
 }
@@ -1511,6 +1512,11 @@ void CapturePlot::onNewDataReceived()
 			measure->setDataSource(d_ydata[chn - count],
 					Curve(chn)->data()->size());
 		}
+
+		if (isMathWaveform(Curve(chn))) {
+			measure->setAdcBitCount(0);
+		}
+
 		measure->setSampleRate(this->sampleRate());
 		measure->measure();
 	}


### PR DESCRIPTION
1) This pull request adds a fix for issue #539 . Adding a math channel that results from a division has undefined behaviour (can generate "nan" or infinity/-infinity values ). With this PR, a fix for this scenario is added. 
- On the measurement side, we skip nan values. 
- On the display/plot side, we add a paint filter attribute to handle nan values.
- Output values from math channels are limited to a known value (both positive and negative, which depends on the attenuation for each channel) .

2) On the same flow for the oscilloscope, another fix was added in this PR. Math channels use as inputs the 1st and 2nd channel. If the channels have an attenuation different from 1X, this should be taken into consideration when adding math channels. 
In order to do this, a multiply block is added as input for the math channels. The multiply block uses as constant value the value of the probe attenuation for each channel.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>