### PR TITLE
Digital instruments: Disable digital decoders support.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 	bool nogui = parser.isSet("nogui");
 	bool nodecoders = parser.isSet("nodecoders");
 	if (nodecoders) {
-		launcher.setUse_decoders(false);
+		launcher.setUseDecoders(false);
 	}
 	QString script = parser.value("script");
 	if (nogui) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ int main(int argc, char **argv)
 	parser.addOptions({
 		{ {"s", "script"}, "Run given script.", "script" },
 		{ {"n", "nogui"}, "Run Scopy without GUI" },
+		{ {"d", "nodecoders"}, "Run Scopy without digital decoders"}
 	});
 
 	parser.process(app);
@@ -67,6 +68,10 @@ int main(int argc, char **argv)
 	ToolLauncher launcher;
 
 	bool nogui = parser.isSet("nogui");
+	bool nodecoders = parser.isSet("nodecoders");
+	if (nodecoders) {
+		launcher.setUse_decoders(false);
+	}
 	QString script = parser.value("script");
 	if (nogui) {
 		launcher.hide();

--- a/src/pattern_generator.cpp
+++ b/src/pattern_generator.cpp
@@ -58,6 +58,7 @@
 #include "filter.hpp"
 #include "pattern_generator.hpp"
 #include "dynamicWidget.hpp"
+#include "tool_launcher.hpp"
 #include "pattern_generator_api.hpp"
 
 // Generated UI
@@ -242,6 +243,7 @@ PatternGenerator::PatternGenerator(struct iio_context *ctx, Filter *filt,
 	chmui = new PatternGeneratorChannelManagerUI(ui->channelManagerWidget, main_win,
 	                &chm, cgSettings, this);
 
+	setUse_decoders(parent->getUse_decoders());
 	ui->channelManagerWidgetLayout->addWidget(chmui);
 	ui->btnChSettings->setChecked(true);
 	ui->rightWidget->setCurrentIndex(1);
@@ -446,6 +448,19 @@ void PatternGenerator::enableCgSettings(bool en)
 	colour_button_edge->setEnabled(en);
 	colour_button_high->setEnabled(en);
 	colour_button_low->setEnabled(en);
+}
+
+bool PatternGenerator::getUse_decoders() const
+{
+	return m_use_decoders;
+}
+
+void PatternGenerator::setUse_decoders(bool use_decoders)
+{
+	m_use_decoders = use_decoders;
+	if (chmui) {
+		chmui->setUse_decoders(m_use_decoders);
+	}
 }
 
 void PatternGenerator::checkEnabledChannels()

--- a/src/pattern_generator.cpp
+++ b/src/pattern_generator.cpp
@@ -243,7 +243,7 @@ PatternGenerator::PatternGenerator(struct iio_context *ctx, Filter *filt,
 	chmui = new PatternGeneratorChannelManagerUI(ui->channelManagerWidget, main_win,
 	                &chm, cgSettings, this);
 
-	setUse_decoders(parent->getUse_decoders());
+	setUseDecoders(parent->getUseDecoders());
 	ui->channelManagerWidgetLayout->addWidget(chmui);
 	ui->btnChSettings->setChecked(true);
 	ui->rightWidget->setCurrentIndex(1);
@@ -450,16 +450,16 @@ void PatternGenerator::enableCgSettings(bool en)
 	colour_button_low->setEnabled(en);
 }
 
-bool PatternGenerator::getUse_decoders() const
+bool PatternGenerator::getUseDecoders() const
 {
 	return m_use_decoders;
 }
 
-void PatternGenerator::setUse_decoders(bool use_decoders)
+void PatternGenerator::setUseDecoders(bool use_decoders)
 {
 	m_use_decoders = use_decoders;
 	if (chmui) {
-		chmui->setUse_decoders(m_use_decoders);
+		chmui->setUseDecoders(m_use_decoders);
 	}
 }
 

--- a/src/pattern_generator.hpp
+++ b/src/pattern_generator.hpp
@@ -101,6 +101,9 @@ public:
 	void settingsLoaded();
 	bool suppressCGSettingsUpdate;
 
+	bool getUse_decoders() const;
+	void setUse_decoders(bool use_decoders);
+
 private Q_SLOTS:
 
 	void generatePattern();
@@ -189,6 +192,8 @@ private:
 	void createSettingsWidget();
 	void showColorSettings(bool check);
 	void enableCgSettings(bool en);
+
+	bool m_use_decoders;
 
 private Q_SLOTS:
 

--- a/src/pattern_generator.hpp
+++ b/src/pattern_generator.hpp
@@ -101,8 +101,8 @@ public:
 	void settingsLoaded();
 	bool suppressCGSettingsUpdate;
 
-	bool getUse_decoders() const;
-	void setUse_decoders(bool use_decoders);
+	bool getUseDecoders() const;
+	void setUseDecoders(bool use_decoders);
 
 private Q_SLOTS:
 

--- a/src/pg_channel_manager.cpp
+++ b/src/pg_channel_manager.cpp
@@ -893,7 +893,7 @@ void PatternGeneratorChannelGroupUI::setupUARTDecoder()
 	if(uart==nullptr)
 		return;
 
-	if (getManagerUi()->getUse_decoders()) {
+	if (getManagerUi()->getUseDecoders()) {
 		auto chMap = setupDecoder("uart",ids);
 
 		auto uartdecoderstack = decodeTrace->decoder()->stack();
@@ -960,7 +960,7 @@ void PatternGeneratorChannelGroupUI::setupParallelDecoder()
 		ids.push_back(chg->get_channel(i)->get_id());
 	}
 
-	if (getManagerUi()->getUse_decoders()) {
+	if (getManagerUi()->getUseDecoders()) {
 		auto chMap = setupDecoder("parallel",ids);
 
 		decodeTrace->set_channel_map(chMap);
@@ -980,7 +980,7 @@ void PatternGeneratorChannelGroupUI::setupSPIDecoder()
 			ids.push_back(chg->get_channel(2)->get_id());
 		}
 
-		if (getManagerUi()->getUse_decoders()) {
+		if (getManagerUi()->getUseDecoders()) {
 			auto chMap = setupDecoder("spi",ids);
 			auto spidecoder = decodeTrace->decoder()->stack().front();
 			auto spipattern = dynamic_cast<SPIPattern *>(getChannelGroup()->pattern);
@@ -1030,7 +1030,7 @@ void PatternGeneratorChannelGroupUI::setupI2CDecoder()
 		ids.push_back(chg->get_channel(1)->get_id());
 
 
-		if (getManagerUi()->getUse_decoders()) {
+		if (getManagerUi()->getUseDecoders()) {
 			auto chMap = setupDecoder("i2c",ids);
 
 			auto i2cdecoder = decodeTrace->decoder()->stack().front();
@@ -1556,12 +1556,12 @@ QFrame *PatternGeneratorChannelManagerUI::addSeparator(QVBoxLayout *lay,
 	return line;
 }
 
-bool PatternGeneratorChannelManagerUI::getUse_decoders() const
+bool PatternGeneratorChannelManagerUI::getUseDecoders() const
 {
 	return m_use_decoders;
 }
 
-void PatternGeneratorChannelManagerUI::setUse_decoders(bool use_decoders)
+void PatternGeneratorChannelManagerUI::setUseDecoders(bool use_decoders)
 {
 	m_use_decoders = use_decoders;
 }

--- a/src/pg_channel_manager.hpp
+++ b/src/pg_channel_manager.hpp
@@ -296,8 +296,12 @@ public:
 
 	std::vector<PatternGeneratorChannelGroupUI*> getEnabledChannelGroups();
 
+	bool getUse_decoders() const;
+	void setUse_decoders(bool use_decoders);
+
 private:
 	QFrame *addSeparator(QVBoxLayout *lay, int pos);
+	bool m_use_decoders;
 
 Q_SIGNALS:
 	void channelsChanged();

--- a/src/pg_channel_manager.hpp
+++ b/src/pg_channel_manager.hpp
@@ -296,8 +296,8 @@ public:
 
 	std::vector<PatternGeneratorChannelGroupUI*> getEnabledChannelGroups();
 
-	bool getUse_decoders() const;
-	void setUse_decoders(bool use_decoders);
+	bool getUseDecoders() const;
+	void setUseDecoders(bool use_decoders);
 
 private:
 	QFrame *addSeparator(QVBoxLayout *lay, int pos);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -48,7 +48,8 @@ Preferences::Preferences(QWidget *parent) :
 	animations_enabled(true),
 	osc_filtering_enabled(true),
 	mini_hist_enabled(false),
-	digital_decoders_enabled(true)
+	digital_decoders_enabled(true),
+	m_initialized(false)
 {
 	ui->setupUi(this);
 
@@ -131,6 +132,14 @@ Preferences::Preferences(QWidget *parent) :
 	connect(ui->decodersCheckBox, &QCheckBox::stateChanged, [=](int state){
 		digital_decoders_enabled = (!state ? false : true);
 		Q_EMIT notify();
+
+		if (m_initialized) {
+			QMessageBox info(this);
+			info.setText("This changes will be applied only after a Scopy reset.");
+			info.exec();
+		} else {
+			m_initialized = true;
+		}
 	});
 
 	QString preference_ini_file = getPreferenceIniFile();
@@ -518,7 +527,7 @@ bool Preferences_API::getDigitalDecoders() const
 	return preferencePanel->digital_decoders_enabled;
 }
 
-void Preferences_API::setDigitalDecoders(const bool &enabled)
+void Preferences_API::setDigitalDecoders(bool enabled)
 {
 	preferencePanel->digital_decoders_enabled = enabled;
 }

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -47,7 +47,8 @@ Preferences::Preferences(QWidget *parent) :
 	graticule_enabled(false),
 	animations_enabled(true),
 	osc_filtering_enabled(true),
-	mini_hist_enabled(false)
+	mini_hist_enabled(false),
+	digital_decoders_enabled(true)
 {
 	ui->setupUi(this);
 
@@ -127,6 +128,10 @@ Preferences::Preferences(QWidget *parent) :
 		mini_hist_enabled = (!state ? false : true);
 		Q_EMIT notify();
 	});
+	connect(ui->decodersCheckBox, &QCheckBox::stateChanged, [=](int state){
+		digital_decoders_enabled = (!state ? false : true);
+		Q_EMIT notify();
+	});
 
 	QString preference_ini_file = getPreferenceIniFile();
 	QSettings settings(preference_ini_file, QSettings::IniFormat);
@@ -167,6 +172,7 @@ void Preferences::showEvent(QShowEvent *event)
 	ui->enableAnimCheckBox->setChecked(animations_enabled);
 	ui->oscFilteringCheckBox->setChecked(osc_filtering_enabled);
 	ui->histCheckBox->setChecked(mini_hist_enabled);
+	ui->decodersCheckBox->setChecked(digital_decoders_enabled);
 
 	QWidget::showEvent(event);
 }
@@ -191,6 +197,16 @@ void Preferences::resetScopy()
 	if (ret == QMessageBox::Ok) {
 		Q_EMIT reset();
 	}
+}
+
+bool Preferences::getDigital_decoders_enabled() const
+{
+	return digital_decoders_enabled;
+}
+
+void Preferences::setDigital_decoders_enabled(bool value)
+{
+	digital_decoders_enabled = value;
 }
 
 bool Preferences::getOsc_filtering_enabled() const
@@ -495,4 +511,14 @@ bool Preferences_API::getMiniHist() const
 void Preferences_API::setMiniHist(const bool &enabled)
 {
 	preferencePanel->mini_hist_enabled = enabled;
+}
+
+bool Preferences_API::getDigitalDecoders() const
+{
+	return preferencePanel->digital_decoders_enabled;
+}
+
+void Preferences_API::setDigitalDecoders(const bool &enabled)
+{
+	preferencePanel->digital_decoders_enabled = enabled;
 }

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -92,6 +92,9 @@ public:
 	bool getMini_hist_enabled() const;
 	void setMini_hist_enabled(bool value);
 
+	bool getDigital_decoders_enabled() const;
+	void setDigital_decoders_enabled(bool value);
+
 Q_SIGNALS:
 
 	void notify();
@@ -121,6 +124,7 @@ private:
 	bool animations_enabled;
 	bool osc_filtering_enabled;
 	bool mini_hist_enabled;
+	bool digital_decoders_enabled;
 
 	Preferences_API *pref_api;
 	QString getPreferenceIniFile() const;
@@ -145,6 +149,7 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool animations_enabled READ getAnimationsEnabled WRITE setAnimationsEnabled)
 	Q_PROPERTY(bool osc_filtering_enabled READ getOscFilteringEnabled WRITE setOscFilteringEnabled)
 	Q_PROPERTY(bool mini_hist_enabled READ getMiniHist WRITE setMiniHist)
+	Q_PROPERTY(bool digital_decoders READ getDigitalDecoders WRITE setDigitalDecoders)
 
 public:
 
@@ -193,6 +198,9 @@ public:
 
 	bool getMiniHist() const;
 	void setMiniHist(const bool& enabled);
+
+	bool getDigitalDecoders() const;
+	void setDigitalDecoders(const bool& enabled);
 
 private:
 	Preferences *preferencePanel;

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -125,6 +125,7 @@ private:
 	bool osc_filtering_enabled;
 	bool mini_hist_enabled;
 	bool digital_decoders_enabled;
+	bool m_initialized;
 
 	Preferences_API *pref_api;
 	QString getPreferenceIniFile() const;
@@ -200,7 +201,7 @@ public:
 	void setMiniHist(const bool& enabled);
 
 	bool getDigitalDecoders() const;
-	void setDigitalDecoders(const bool& enabled);
+	void setDigitalDecoders(bool enabled);
 
 private:
 	Preferences *preferencePanel;

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -281,6 +281,8 @@ ToolLauncher::ToolLauncher(QWidget *parent) :
 
 void ToolLauncher::readPreferences()
 {
+	m_use_decoders = prefPanel->getDigital_decoders_enabled();
+
 	ui->btnNotes->setVisible(prefPanel->getUser_notes_active());
 	for (auto tool : toolMenu) {
 		tool->enableDoubleClick(prefPanel->getDouble_click_to_detach());
@@ -368,6 +370,7 @@ bool ToolLauncher::getUse_decoders() const
 void ToolLauncher::setUse_decoders(bool use_decoders)
 {
 	m_use_decoders = use_decoders;
+	prefPanel->setDigital_decoders_enabled(use_decoders);
 }
 
 void ToolLauncher::loadSession()

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -83,7 +83,8 @@ ToolLauncher::ToolLauncher(QWidget *parent) :
 	indexFile(""), deviceInfo(""), pathToFile(""),
 	manual_calibration_enabled(false),
 	devices_btn_group(new QButtonGroup(this)),
-	selectedDev(nullptr)
+	selectedDev(nullptr),
+	m_use_decoders(true)
 {
 	if (!isatty(STDIN_FILENO))
 		notifier.setEnabled(false);
@@ -357,6 +358,16 @@ void ToolLauncher::allowExternalScript(bool prefEnabled)
 			js_engine.globalObject().deleteProperty("extern");
 		}
 	}
+}
+
+bool ToolLauncher::getUse_decoders() const
+{
+	return m_use_decoders;
+}
+
+void ToolLauncher::setUse_decoders(bool use_decoders)
+{
+	m_use_decoders = use_decoders;
 }
 
 void ToolLauncher::loadSession()
@@ -1545,15 +1556,24 @@ bool adiscope::ToolLauncher::switchContext(const QString& uri)
 
 	if (filter->compatible(TOOL_LOGIC_ANALYZER)
 	    || filter->compatible(TOOL_PATTERN_GENERATOR)) {
-		bool success = loadDecoders(QCoreApplication::applicationDirPath() +
-					"/decoders");
 
-		if (!success) {
+		if (!m_use_decoders) {
 			search_timer->stop();
 
-			QMessageBox error(this);
-			error.setText("There was a problem initializing libsigrokdecode. Some features may be missing");
-			error.exec();
+			QMessageBox info(this);
+			info.setText("Digital decoders support is disabled. Some features may be missing");
+			info.exec();
+		} else {
+			bool success = loadDecoders(QCoreApplication::applicationDirPath() +
+						    "/decoders");
+
+			if (!success) {
+				search_timer->stop();
+
+				QMessageBox error(this);
+				error.setText("There was a problem initializing libsigrokdecode. Some features may be missing");
+				error.exec();
+			}
 		}
 	}
 

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -362,12 +362,12 @@ void ToolLauncher::allowExternalScript(bool prefEnabled)
 	}
 }
 
-bool ToolLauncher::getUse_decoders() const
+bool ToolLauncher::getUseDecoders() const
 {
 	return m_use_decoders;
 }
 
-void ToolLauncher::setUse_decoders(bool use_decoders)
+void ToolLauncher::setUseDecoders(bool use_decoders)
 {
 	m_use_decoders = use_decoders;
 	prefPanel->setDigital_decoders_enabled(use_decoders);

--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -86,6 +86,9 @@ public:
 	Preferences *getPrefPanel() const;
 	bool eventFilter(QObject *watched, QEvent *event);
 
+	bool getUse_decoders() const;
+	void setUse_decoders(bool use_decoders);
+
 Q_SIGNALS:
 	void connectionDone(bool success);
 	void adcCalibrationDone();
@@ -245,6 +248,7 @@ private:
 	QButtonGroup *devices_btn_group;
 
 	DeviceWidget* selectedDev;
+	bool m_use_decoders;
 };
 }
 #endif // M2K_TOOL_LAUNCHER_H

--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -86,8 +86,8 @@ public:
 	Preferences *getPrefPanel() const;
 	bool eventFilter(QObject *watched, QEvent *event);
 
-	bool getUse_decoders() const;
-	void setUse_decoders(bool use_decoders);
+	bool getUseDecoders() const;
+	void setUseDecoders(bool use_decoders);
 
 Q_SIGNALS:
 	void connectionDone(bool success);

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -1517,6 +1517,62 @@ color: white;
              </layout>
             </widget>
            </item>
+           <item row="3" column="1">
+            <layout class="QHBoxLayout" name="decodersWidget">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="decodersCheckBox">
+               <property name="styleSheet">
+                <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_19">
+               <property name="text">
+                <string>Enable digital decoders</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_15">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
           </layout>
          </item>
         </layout>


### PR DESCRIPTION
This PR implements an option to choose whether the Scopy instance loads the digital decoders. The functionality may be limited for the Logic Analyzer and the Pattern Generator if the decoders are not loaded. 
There are 2 ways to disable the decoders:
- Using a command line option: **--nodecoders**
- Using the option listed in the preference panel . (In this case, Scopy needs to be reset manually.  Or should we automatically reset Scopy when the option is checked? This can be discussed here.)

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>