### PR TITLE
treewide: fix sign-compare warnings

### DIFF
--- a/src/apiObject.cpp
+++ b/src/apiObject.cpp
@@ -40,7 +40,7 @@ template <typename T> void ApiObject::save(QSettings& settings,
 {
 	settings.beginWriteArray(prop, list.size());
 
-	for (unsigned int i = 0; i < list.size(); i++) {
+	for (int i = 0; i < list.size(); i++) {
 		settings.setArrayIndex(i);
 		settings.setValue("idx", QVariant(list.at(i)));
 	}
@@ -53,7 +53,7 @@ void ApiObject::save(QSettings& settings, const QString& prop,
 {
 	settings.beginWriteArray(prop, list.size());
 
-	for (unsigned int i = 0; i < list.size(); i++) {
+	for (int i = 0; i < list.size(); i++) {
 		settings.setArrayIndex(i);
 		save_nogroup(list.at(i).value<ApiObject *>(), settings);
 	}
@@ -67,7 +67,7 @@ template <typename T> QList<T> ApiObject::load(
 	int nb = settings.beginReadArray(prop);
 	QList<T> list;
 
-	for (unsigned int i = 0; i < nb; i++) {
+	for (int i = 0; i < nb; i++) {
 		settings.setArrayIndex(i);
 		list.append(settings.value("idx").value<T>());
 	}
@@ -81,7 +81,7 @@ void ApiObject::load(QSettings& settings, const QString& prop,
 {
 	int nb = settings.beginReadArray(prop);
 
-	for (unsigned int i = 0; i < nb; i++) {
+	for (int i = 0; i < nb; i++) {
 		settings.setArrayIndex(i);
 		load_nogroup(list.at(i).value<ApiObject *>(), settings);
 	}
@@ -92,7 +92,7 @@ void ApiObject::load(QSettings& settings, const QString& prop,
 void ApiObject::load_nogroup(ApiObject *obj, QSettings& settings)
 {
 	auto meta = obj->metaObject();
-	for (unsigned int i = meta->propertyOffset();
+	for (int i = meta->propertyOffset();
 			i < meta->propertyCount(); i++) {
 		auto prop = meta->property(i);
 		if (!prop.isStored() || !prop.isReadable())
@@ -143,7 +143,7 @@ void ApiObject::load_nogroup(ApiObject *obj, QSettings& settings)
 void ApiObject::save_nogroup(ApiObject *obj, QSettings& settings)
 {
 	auto meta = obj->metaObject();
-	for (unsigned int i = meta->propertyOffset();
+	for (int i = meta->propertyOffset();
 			i < meta->propertyCount(); i++) {
 		auto prop = meta->property(i);
 

--- a/src/calibration.cpp
+++ b/src/calibration.cpp
@@ -506,7 +506,7 @@ bool Calibration::fine_tune(size_t span, int16_t centerVal0, int16_t centerVal1,
 	int16_t *dataCh0 = new int16_t[num_samples];
 	int16_t *dataCh1 = new int16_t[num_samples];
 	int16_t offset0, offset1;
-	int i, i0 = 0, i1 = 0;
+	size_t i, i0 = 0, i1 = 0;
 	bool ret = true;
 
 	offset0 = centerVal0 - span / 2;
@@ -538,7 +538,7 @@ bool Calibration::fine_tune(size_t span, int16_t centerVal0, int16_t centerVal1,
 	minAvg0 = qAbs(averagesCh0[0]);
 	minAvg1 = qAbs(averagesCh1[0]);
 
-	for (int i = 1; i < span + 1; i++) {
+	for (i = 1; i < span + 1; i++) {
 		if (averagesCh0[i] < minAvg0) {
 			minAvg0 = averagesCh0[i];
 			i0 = i;

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -262,7 +262,7 @@ const QwtScaleWidget *dBgraph::getAxisWidget(QwtAxisId id)
 
 void dBgraph::setNumSamples(int num)
 {
-	numSamples = (unsigned int) num;
+	numSamples = num;
 
 	reset();
 	ydata.reserve(numSamples + 1);

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -575,7 +575,7 @@ void dBgraph::moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition posi
 QVector<double> dBgraph::getXAxisData()
 {
 	QVector<double> data;
-	for (int i = 0; i < curve.data()->size(); ++i) {
+	for (unsigned int i = 0; i < curve.data()->size(); ++i) {
 		data.push_back(curve.data()->sample(i).x());
 	}
 	return data;
@@ -584,7 +584,7 @@ QVector<double> dBgraph::getXAxisData()
 QVector<double> dBgraph::getYAxisData()
 {
 	QVector<double> data;
-	for (int i = 0; i < curve.data()->size(); ++i) {
+	for (unsigned int i = 0; i < curve.data()->size(); ++i) {
 		data.push_back(curve.data()->sample(i).y());
 	}
 	return data;

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -132,7 +132,7 @@ Q_SIGNALS:
 		QwtPlotCurve curve;
 		QwtPlotMarker *markerIntersection1;
 		QwtPlotMarker *markerIntersection2;
-		unsigned int numSamples;
+		int numSamples;
 		double xmin, xmax, ymin, ymax;
 		QColor color;
 		double thickness;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -146,7 +146,7 @@ void Debug::scanChannelAttributes(QString devName, QString& channel)
 	struct iio_device *device;
 	struct iio_channel *ch;
 	const char *attr;
-	int Count = 0;
+	unsigned int nb_attrs;
 	bool isOutput;
 
 	if (connected) { //check if M2K is connected
@@ -166,9 +166,9 @@ void Debug::scanChannelAttributes(QString devName, QString& channel)
 		if (channel != QString("Global")) {
 			ch = iio_device_find_channel(device, channel.toLatin1().data(), isOutput);
 
-			unsigned int nb_attrs = iio_channel_get_attrs_count(ch);
+			nb_attrs = iio_channel_get_attrs_count(ch);
 
-			for (int k = 0; k < nb_attrs; k++) {
+			for (unsigned int k = 0; k < nb_attrs; k++) {
 				attr = iio_channel_get_attr(ch, k);
 
 				if (QString(attr).contains("available", Qt::CaseInsensitive)) {
@@ -179,9 +179,9 @@ void Debug::scanChannelAttributes(QString devName, QString& channel)
 				}
 			}
 		} else {
-			Count = iio_device_get_attrs_count(device);
+			nb_attrs = iio_device_get_attrs_count(device);
 
-			for (int k = 0; k < Count; k++) {
+			for (unsigned int k = 0; k < nb_attrs; k++) {
 				attr = iio_device_get_attr(device, k);
 
 				if (QString(attr).contains("available", Qt::CaseInsensitive)) {

--- a/src/digitalchannel_manager.cpp
+++ b/src/digitalchannel_manager.cpp
@@ -378,7 +378,7 @@ uint16_t ChannelGroup::get_mask()
 {
 	uint16_t mask = 0;
 
-	for (auto i=0; i<channels.size(); i++) {
+	for (unsigned int i=0; i<channels.size(); i++) {
 		mask = mask | channels[i]->get_mask();
 	}
 

--- a/src/digitalchannel_manager.cpp
+++ b/src/digitalchannel_manager.cpp
@@ -254,7 +254,7 @@ std::vector<Channel *> *ChannelGroup::get_channels()
 	return &channels;
 }
 
-Channel *ChannelGroup::get_channel(int index)
+Channel *ChannelGroup::get_channel(unsigned int index)
 {
 	if (index < channels.size()) {
 		return channels[index];

--- a/src/digitalchannel_manager.hpp
+++ b/src/digitalchannel_manager.hpp
@@ -121,7 +121,7 @@ public:
 	std::vector<uint16_t> get_ids();
 	size_t get_channel_count();
 	std::vector<Channel *> *get_channels();
-	Channel *get_channel(int index=0);
+	Channel *get_channel(unsigned int index=0);
 
 	bool is_selected() const;
 	bool is_grouped() const;

--- a/src/dmm.cpp
+++ b/src/dmm.cpp
@@ -77,7 +77,7 @@ DMM::DMM(struct iio_context *ctx, Filter *filt, std::shared_ptr<GenericAdc> adc,
 
 	ui->horizontalLayout_2->addWidget(data_logging_timer);
 
-	for(int i = 0; i < adc->numAdcChannels(); i++)
+	for (unsigned int i = 0; i < adc->numAdcChannels(); i++)
 	{
 		m_min.push_back(0);
 		m_max.push_back(0);
@@ -271,7 +271,7 @@ void DMM::displayPeakHold(bool checked)
 
 void DMM::resetPeakHold(bool clicked)
 {
-	for(int ch = 0; ch < adc->numAdcChannels(); ch++) {
+	for(unsigned int ch = 0; ch < adc->numAdcChannels(); ch++) {
 		m_min[ch] = 0;
 		m_max[ch] = 0;
 		if(ch == 0) {

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -126,7 +126,7 @@ bool Filter::usable(enum tool tool, const std::string &dev) const
 	return hdl.toArray().contains(QString::fromStdString(dev));
 }
 
-const std::string Filter::device_name(enum tool tool, unsigned int idx) const
+const std::string Filter::device_name(enum tool tool, int idx) const
 {
 	auto hdl = root[QString::fromStdString(tool_names[tool] + "-devices")];
 	if (hdl.isNull() || !hdl.isArray())
@@ -140,13 +140,13 @@ const std::string Filter::device_name(enum tool tool, unsigned int idx) const
 }
 
 struct iio_device * Filter::find_device(const struct iio_context *ctx,
-		enum tool tool, unsigned int idx) const
+		enum tool tool, int idx) const
 {
 	return iio_context_find_device(ctx, device_name(tool, idx).c_str());
 }
 
 struct iio_channel * Filter::find_channel(const struct iio_context *ctx,
-		enum tool tool, unsigned int idx, bool output) const
+		enum tool tool, int idx, bool output) const
 {
 	QString name = QString::fromStdString(device_name(tool, idx));
 

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -63,12 +63,12 @@ namespace adiscope {
 		bool compatible(enum tool tool) const;
 		bool usable(enum tool tool, const std::string &dev) const;
 		const std::string device_name(enum tool tool,
-				unsigned int idx = 0) const;
+				int idx = 0) const;
 
 		struct iio_device * find_device(const struct iio_context *ctx,
-				enum tool tool, unsigned int idx = 0) const;
+				enum tool tool, int idx = 0) const;
 		struct iio_channel * find_channel(const struct iio_context *ctx,
-				enum tool tool, unsigned int idx = 0,
+				enum tool tool, int idx = 0,
 				bool output = false) const;
 
 		static const std::string& tool_name(enum tool tool);


### PR DESCRIPTION
These changes fix sign-compare warnings reported by G++ 7.3.
This is not the complete lists. It is a set of changes identified up to this point in time, and more will be identified in the coming days.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>