### PR TITLE
treewide: address a few unused warnings

### DIFF
--- a/src/DisplayPlot.cc
+++ b/src/DisplayPlot.cc
@@ -37,6 +37,8 @@
 
 using namespace adiscope;
 
+static QwtScaleDiv getEdgelessScaleDiv(const QwtScaleDiv& from_scaleDiv);
+
 /*
  * OscScaleDraw class implementation
  */
@@ -1424,7 +1426,7 @@ void DisplayPlot::bottomHorizAxisInit()
 		      this, SLOT(_onXbottomAxisWidgetScaleDivChanged()));
 }
 
-QwtScaleDiv adiscope::getEdgelessScaleDiv(const QwtScaleDiv& from_scaleDiv)
+static QwtScaleDiv getEdgelessScaleDiv(const QwtScaleDiv& from_scaleDiv)
 {
 	double lowerBound;
 	double upperBound;

--- a/src/DisplayPlot.h
+++ b/src/DisplayPlot.h
@@ -64,9 +64,6 @@ namespace adiscope {
 
 class PlotAxisConfiguration;
 
-static QwtScaleDiv getEdgelessScaleDiv(const QwtScaleDiv& from_scaleDiv);
-
-
 class ScaleDivisions: public QObject
 {
 Q_OBJECT

--- a/src/bitfieldwidget.cpp
+++ b/src/bitfieldwidget.cpp
@@ -91,7 +91,6 @@ void BitfieldWidget::createWidget()
 		/*set spinBox*/
 		ui->stackedWidget->setCurrentIndex(1);
 		int temp = (int)pow(2, width) - 1;
-		long temp2= ui->valueSpinBox->maximum();
 		ui->valueSpinBox->setMaximum(temp);
 		connect(ui->valueSpinBox, SIGNAL(valueChanged(int)), this,
 		        SLOT(setValue(int))); //connect spinBox singnal to the value changed signal

--- a/src/debugger.cpp
+++ b/src/debugger.cpp
@@ -296,7 +296,6 @@ void Debugger::on_writeRegPushButton_clicked()
 {
 	QString device = ui->DevicecomboBox->currentText();
 	uint32_t address = ui->addressSpinBox->value();
-	uint32_t value = ui->valueSpinBox->value();
 
 	reg->writeRegister(&device, address, ui->valueSpinBox->value());
 

--- a/src/external_script_api.cpp
+++ b/src/external_script_api.cpp
@@ -38,7 +38,6 @@ ExternalScript_API::ExternalScript_API(QObject *parent):
 QString ExternalScript_API::start(const QString& cmd)
 {
 	QString ret = "";
-	bool procRet;
 	if (m_external_process != nullptr) {
 		m_external_process->deleteLater();
 		m_external_process = nullptr;
@@ -51,12 +50,12 @@ QString ExternalScript_API::start(const QString& cmd)
 	m_external_process->start("/bin/sh", arguments);
 
 	if (m_process_timeout > 0) {
-		procRet = m_external_process->waitForFinished(m_process_timeout);
+		m_external_process->waitForFinished(m_process_timeout);
 		ret = m_external_process->readAll();
 		m_external_process->deleteLater();
 		m_external_process = nullptr;
 	} else {
-		procRet = m_external_process->waitForFinished(-1);
+		m_external_process->waitForFinished(-1);
 		ret = m_external_process->readAll();
 	}
 	return ret;

--- a/src/graticule.cpp
+++ b/src/graticule.cpp
@@ -124,14 +124,7 @@ GraticulePlotScaleItem::GraticulePlotScaleItem(
 {
 }
 
-void GraticulePlotScaleItem::updateScaleDiv( const QwtScaleDiv& xScaleDiv,
-    const QwtScaleDiv& yScaleDiv )
-{
-	QwtPlotScaleItem::updateScaleDiv(getGraticuleScaleDiv(xScaleDiv),
-					getGraticuleScaleDiv(yScaleDiv));
-}
-
-QwtScaleDiv adiscope::getGraticuleScaleDiv(const QwtScaleDiv& from_scaleDiv)
+static QwtScaleDiv getGraticuleScaleDiv(const QwtScaleDiv& from_scaleDiv)
 {
 	double lowerBound;
 	double upperBound;
@@ -153,5 +146,9 @@ QwtScaleDiv adiscope::getGraticuleScaleDiv(const QwtScaleDiv& from_scaleDiv)
 	return QwtScaleDiv(lowerBound, upperBound, minorTicks, mediumTicks, majorTicks);
 }
 
-
-
+void GraticulePlotScaleItem::updateScaleDiv( const QwtScaleDiv& xScaleDiv,
+    const QwtScaleDiv& yScaleDiv )
+{
+	QwtPlotScaleItem::updateScaleDiv(getGraticuleScaleDiv(xScaleDiv),
+					getGraticuleScaleDiv(yScaleDiv));
+}

--- a/src/graticule.h
+++ b/src/graticule.h
@@ -26,8 +26,6 @@
 
 namespace adiscope {
 
-static QwtScaleDiv getGraticuleScaleDiv(const QwtScaleDiv& from_scaleDiv);
-
 class Graticule : public QObject
 {
 	Q_OBJECT


### PR DESCRIPTION
These changes fixes a few unused warnings reported by G++ 7.3.
This is not the complete lists. It is a set of changes identified up to this point in time, and more will be identified in the coming days.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>