### PR TITLE
src/plot_utils.hpp: define virtual destructor

### DIFF
--- a/src/plot_utils.cpp
+++ b/src/plot_utils.cpp
@@ -37,6 +37,10 @@ PrefixFormatter::PrefixFormatter(const vector<pair<QString, double>> &prefixes):
 				[](const pair<QString, double>& element) {return element.second == 1E0;} ) - m_prefixes.begin();
 }
 
+PrefixFormatter::~PrefixFormatter()
+{
+}
+
 void PrefixFormatter::setTwoDecimalMode(bool enable)
 {
 	m_twoDecimalMode = enable;

--- a/src/plot_utils.hpp
+++ b/src/plot_utils.hpp
@@ -28,6 +28,7 @@ namespace adiscope {
 	{
 	public:
 		PrefixFormatter(const std::vector<std::pair<QString, double>>&);
+		virtual ~PrefixFormatter();
 		void setTwoDecimalMode(bool);
 		bool getTwoDecimalMode();
 		virtual QString format(double value, QString unitType, int precision) const;


### PR DESCRIPTION
G++ complains in dbgraph.cpp:
```
scopy/src/dbgraph.cpp:200:9: error: deleting object of polymorphic class type ‘adiscope::PrefixFormatter’ which has non-virtual destructor might cause undefined behavior [-Werror=delete-non-virtual-dtor]
  delete formatter;

```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>