### PR TITLE
src/signal_generator: powerdown handling change

### DIFF
--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -1249,6 +1249,12 @@ void SignalGenerator::start()
 {
 	QVector<struct iio_channel *> enabled_channels;
 
+	if (amp1 && amp2) {
+		/* FIXME: TODO: Move this into a HW class / lib M2k */
+		iio_channel_attr_write_bool(amp1, "powerdown", /*!(ui->run_button->isChecked() && */ !channels[0]->enableButton()->isChecked());
+		iio_channel_attr_write_bool(amp2, "powerdown", /*!(ui->run_button->isChecked() && */ !channels[1]->enableButton()->isChecked());
+	}
+
 	/* Avoid from being started twice */
 	if (buffers.size() > 0) {
 		return;
@@ -1403,21 +1409,23 @@ void SignalGenerator::start()
 
 void SignalGenerator::stop()
 {
+
 	for (auto each : buffers) {
 		iio_buffer_destroy(each);
 	}
 
 	buffers.clear();
+
+
+	if (amp1 && amp2) {
+		/* FIXME: TODO: Move this into a HW class / lib M2k */
+		iio_channel_attr_write_bool(amp1, "powerdown", true);//!(ui->run_button->isChecked() && channels[0]->enableButton()->isChecked()));
+		iio_channel_attr_write_bool(amp2, "powerdown", true);//!(ui->run_button->isChecked() && channels[1]->enableButton()->isChecked()));
+	}
 }
 
 void SignalGenerator::startStop(bool pressed)
 {
-	if (amp1 && amp2) {
-		/* FIXME: TODO: Move this into a HW class / lib M2k */
-		iio_channel_attr_write_bool(amp1, "powerdown", !(pressed && channels[0]->enableButton()->isChecked()));
-		iio_channel_attr_write_bool(amp2, "powerdown", !(pressed && channels[1]->enableButton()->isChecked()));
-	}
-
 	if (pressed) {
 		start();
 	} else {

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -1412,17 +1412,16 @@ void SignalGenerator::stop()
 
 void SignalGenerator::startStop(bool pressed)
 {
+	if (amp1 && amp2) {
+		/* FIXME: TODO: Move this into a HW class / lib M2k */
+		iio_channel_attr_write_bool(amp1, "powerdown", !(pressed && channels[0]->enableButton()->isChecked()));
+		iio_channel_attr_write_bool(amp2, "powerdown", !(pressed && channels[1]->enableButton()->isChecked()));
+	}
 
 	if (pressed) {
 		start();
 	} else {
 		stop();
-	}
-
-	if (amp1 && amp2) {
-		/* FIXME: TODO: Move this into a HW class / lib M2k */
-		iio_channel_attr_write_bool(amp1, "powerdown", !pressed);
-		iio_channel_attr_write_bool(amp2, "powerdown", !pressed);
 	}
 
 	setDynamicProperty(ui->run_button, "running", pressed);


### PR DESCRIPTION
Related to issue #536

Enable output channels before start of DMA data output. In this way there is no delay between output channels.
Also add check and if channel is disabled from GUI don't release corresponding "powerdown" signal.

Tested on Windows 10 x64.