### PR TITLE
PatternGenerator: fix loading SPI/I2C pattern data

### DIFF
--- a/src/pg_patterns.cpp
+++ b/src/pg_patterns.cpp
@@ -320,7 +320,7 @@ Pattern *Pattern_API::fromJson(QJsonObject obj)
 		sp->setMsbFirst(params["MSB"].toBool());
 
 		for (auto val : params["v"].toArray()) {
-			sp->v.push_front(val.toInt());
+			sp->v.push_back(val.toInt());
 		}
 	} else if (ip) {
 		ip->setBytesPerFrame(params["BPF"].toInt());
@@ -331,7 +331,7 @@ Pattern *Pattern_API::fromJson(QJsonObject obj)
 		ip->setWrite(params["write"].toBool());
 
 		for (auto val : params["v"].toArray()) {
-			ip->v.push_front(val.toInt());
+			ip->v.push_back(val.toInt());
 		}
 	} else if (imp) {
 		imp->fileName = params["file"].toString();

--- a/src/pg_patterns.cpp
+++ b/src/pg_patterns.cpp
@@ -1793,11 +1793,11 @@ void I2CPatternUI::parse_ui()
 		val = str.toULongLong(&ok,16);
 
 		if (ok) {
-			while (val) {
+			do {
 				auto u8val = val & 0xff;
 				val = val >> 8;
 				b.push_back(u8val);
-			}
+			} while (val);
 
 			for (auto u8val : b) {
 				pattern->v.push_front(u8val);
@@ -2112,11 +2112,11 @@ void SPIPatternUI::parse_ui()
 		val = str.toULongLong(&ok,16);
 
 		if (ok) {
-			while (val) {
+			do {
 				auto u8val = val & 0xff;
 				val = val >> 8;
 				b.push_back(u8val);
-			}
+			} while (val);
 
 			for (auto u8val : b) {
 				pattern->v.push_front(u8val);


### PR DESCRIPTION
Loading SPI and I2C patterns was reversed on each load. This fixes it.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>