### PR TITLE
Logic Analyzer: Fix the trigger delay loading process.

### DIFF
--- a/src/logic_analyzer_api.cpp
+++ b/src/logic_analyzer_api.cpp
@@ -73,6 +73,7 @@ double LogicAnalyzer_API::getTimePos() const
 void LogicAnalyzer_API::setTimePos(double value)
 {
 	lga->timePosition->setValue(value);
+	lga->initialised = true;
 }
 
 double LogicAnalyzer_API::getTimeBase() const


### PR DESCRIPTION
If the .ini file had no info about the delay, it would be automatically
initialised to a default value in the Logic Analyzer. This commit makes
sure that it's not set to the default value if something was loaded from
the .ini file.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>