### PR TITLE
CI/travis/before_install_linux.sh: install breakpad in deps sub-folder

### DIFF
--- a/CI/travis/before_install_linux.sh
+++ b/CI/travis/before_install_linux.sh
@@ -22,6 +22,7 @@ handle_centos_docker() {
 }
 
 install_breakpad() {
+	pushd "$WORKDIR"
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 	export PATH=$PATH:$(pwd)/depot_tools
 	mkdir breakpad && cd breakpad
@@ -30,6 +31,7 @@ install_breakpad() {
 	./configure CXXFLAGS="-Wno-error"
 	make
 	sudo make install
+	popd
 }
 
 handle_default() {


### PR DESCRIPTION
Otherwise there are risks of committing the folder since it shows up
untracked in git.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>