### PR TITLE
treewide: fix compiler warninges (series 2)

### DIFF
--- a/src/adc_sample_conv.cpp
+++ b/src/adc_sample_conv.cpp
@@ -71,14 +71,14 @@ int adc_sample_conv::work(int noutput_items,
 		float *out = static_cast<float *>(output_items[i]);
 
 		if (inverse)
-			for (unsigned int j = 0; j < noutput_items; j++)
+			for (int j = 0; j < noutput_items; j++)
 				out[j] = convVoltsToSample(in[j],
 						d_correction_gains[i],
 						d_filter_compensations[i],
 						d_offsets[i],
 						d_hardware_gains[i]);
 		else
-			for (unsigned int j = 0; j < noutput_items; j++)
+			for (int j = 0; j < noutput_items; j++)
 				out[j] = convSampleToVolts(in[j],
 					d_correction_gains[i],
 					d_filter_compensations[i],

--- a/src/info_page.cpp
+++ b/src/info_page.cpp
@@ -36,9 +36,9 @@ InfoPage::InfoPage(QString uri, Preferences *pref,
         m_ctx(ctx),
         m_advanced(false),
         prefPanel(pref),
-        m_connected(false),
         m_led_timer(new QTimer(this)),
         m_blink_timer(new QTimer(this)),
+        m_connected(false),
         m_search_interrupted(false)
 {
         ui->setupUi(this);

--- a/src/la_capture_params.cpp
+++ b/src/la_capture_params.cpp
@@ -25,16 +25,16 @@
 
 LogicAnalyzerSymmetricBufferMode::LogicAnalyzerSymmetricBufferMode() :
 	m_maxSampleRate(100000000),
+	m_current_divider(1),
+	m_timeDivsCount(10),
 	m_entireBufferMaxSize(0),
 	m_triggerBufferMaxSize(0),
 	m_timeBase(0.0),
 	m_triggerPos(0.0),
-	m_timeDivsCount(10),
 	m_sampleRate(0.0),
 	m_triggPosSR(0.0),
 	m_visibleBufferSize(0),
-	m_triggerBufferSize(0),
-	m_current_divider(1)
+	m_triggerBufferSize(0)
 {
 }
 

--- a/src/la_capture_params.cpp
+++ b/src/la_capture_params.cpp
@@ -117,7 +117,7 @@ void LogicAnalyzerSymmetricBufferMode::configParamsOnTimeBaseChanged()
 	int sr_divider = 1;
 	sampleRate = m_maxSampleRate / sr_divider;
 
-	unsigned long bufferSize = getVisibleBufferSize(sampleRate);
+	long bufferSize = getVisibleBufferSize(sampleRate);
 	while ((m_triggerBufferMaxSize < bufferSize) && (sr_divider <
 			m_maxSampleRate)) {
 		sr_divider++;

--- a/src/la_capture_params.hpp
+++ b/src/la_capture_params.hpp
@@ -55,8 +55,8 @@ private:
 	int m_current_divider;
 
 	unsigned int m_timeDivsCount;
-	unsigned long long m_entireBufferMaxSize;
-	unsigned long long m_triggerBufferMaxSize;
+	long long m_entireBufferMaxSize;
+	long long m_triggerBufferMaxSize;
 
 	double m_timeBase;
 	double m_triggerPos;

--- a/src/la_channel_manager.cpp
+++ b/src/la_channel_manager.cpp
@@ -105,7 +105,7 @@ LogicAnalyzerChannelUI::LogicAnalyzerChannelUI(LogicAnalyzerChannel *ch,
 	this->installEventFilter(this);
 
 	std::string trigger_val = chm_ui->chm->get_channel(get_channel()->get_id())->getTrigger();
-	for(int i = 0; i < chm_ui->getTriggerMapping().size(); i++)
+	for(unsigned int i = 0; i < chm_ui->getTriggerMapping().size(); i++)
 	{
 		if( trigger_val == chm_ui->getTriggerMapping(i) )
 		{
@@ -283,7 +283,7 @@ void LogicAnalyzerChannelUI::dropEvent(QDropEvent *event)
 		short from = (short)event->mimeData()->data("la/channelgroup")[1];
 		auto fromNrOfChannels = chm_ui->chm->get_channel_group(from)->get_channel_count();
 
-		for(int i = 0; i < fromNrOfChannels; i++) {
+		for(unsigned int i = 0; i < fromNrOfChannels; i++) {
 			/* Check for duplicates */
 			auto chToBeAdded = chm_ui->chm->get_channel_group(from)->get_channel(i);
 			auto ids = chm_ui->chm->get_channel_group(chgIndex)->get_ids();

--- a/src/la_channel_manager.cpp
+++ b/src/la_channel_manager.cpp
@@ -187,7 +187,7 @@ void LogicAnalyzerChannelUI::mouseMoveEvent(QMouseEvent *event)
 		drag->setPixmap(pix);
 	}
 	drag->setMimeData(mimeData);
-	Qt::DropAction dropAction = drag->exec( Qt::MoveAction );
+	drag->exec( Qt::MoveAction );
 	this->setVisible(true);
 }
 
@@ -271,8 +271,6 @@ void LogicAnalyzerChannelUI::dropEvent(QDropEvent *event)
 	auto chgIter = std::find(channelGroups->begin(), channelGroups->end(), chgroup);
 	auto chgIndex = chgIter - channelGroups->begin();
 
-	auto toNrOfChannels = (*chgIter)->get_channel_count();
-
 	auto channels = (*chgIter)->get_channels();
 	auto chIter = std::find(channels->begin(), channels->end(), lch);
 	auto chIndex = chIter - channels->begin();
@@ -324,7 +322,6 @@ void LogicAnalyzerChannelUI::dropEvent(QDropEvent *event)
 		}
 		else {
 			chgIndex = chgIndex + (chgIndex > fromChg ? -1 : 0);
-			auto chgIter = std::find(channelGroups->begin(), channelGroups->end(), chgroup);
 			chm_ui->chm->moveChannel(chgIndex, fromCh, chIndex, dropAfter);
 		}
 	}
@@ -998,7 +995,7 @@ void LogicAnalyzerChannelGroupUI::mouseMoveEvent(QMouseEvent *event)
 		drag->setPixmap(pix);
 	}
 
-	Qt::DropAction dropAction = drag->exec( Qt::MoveAction );
+	drag->exec( Qt::MoveAction );
 	this->setVisible(true);
 }
 
@@ -1480,7 +1477,6 @@ void LogicAnalyzerChannelManager::split(int index)
 void LogicAnalyzerChannelManager::removeChannel(int grIndex, int chIndex)
 {
 	auto grIt = std::next(channel_group.begin(), grIndex);
-	auto channels = (*grIt)->get_channels();
 	(*grIt)->remove_channel(chIndex);
 
 	if ((*grIt)->get_channel_count() == 0) {
@@ -1530,7 +1526,6 @@ void LogicAnalyzerChannelManager::splitChannel(int chgIndex, int chIndex)
 
 	// Use this to insert split channel after channelgroup
 	auto it = channel_group.begin() + chgIndex + 1;
-	auto subch = channel_group[chgIndex]->get_channel(chIndex);
 	auto chIt = channel_group[chgIndex]->get_channels()->begin() + chIndex;
 
 	auto newChgIndex =
@@ -2764,7 +2759,6 @@ void LogicAnalyzerChannelManagerUI::deleteSettingsWidget()
 
 void LogicAnalyzerChannelManagerUI::highlightPrevious()
 {
-	bool update = false;
 	if( chm->getHighlightedChannelGroup() ) {
 		auto chgroup = chm->getHighlightedChannelGroup();
 		auto chgIter = std::find(chm->get_channel_groups()->begin(),
@@ -2776,7 +2770,6 @@ void LogicAnalyzerChannelManagerUI::highlightPrevious()
 				showHighlight(false);
 				chm->highlightChannel(prevChgroup);
 				showHighlight(true);
-				update = true;
 			}
 		}
 	}
@@ -2794,7 +2787,6 @@ void LogicAnalyzerChannelManagerUI::highlightPrevious()
 				chm->highlightChannel(nullptr,
 					static_cast<LogicAnalyzerChannel*>(prevCh));
 				showHighlight(true);
-				update = true;
 			}
 		}
 	}
@@ -2802,7 +2794,6 @@ void LogicAnalyzerChannelManagerUI::highlightPrevious()
 
 void LogicAnalyzerChannelManagerUI::highlightNext()
 {
-	bool update = false;
 	if( chm->getHighlightedChannelGroup() ) {
 		auto chgroup = chm->getHighlightedChannelGroup();
 		auto chgIter = std::find(chm->get_channel_groups()->begin(),
@@ -2814,7 +2805,6 @@ void LogicAnalyzerChannelManagerUI::highlightNext()
 				showHighlight(false);
 				chm->highlightChannel(nextChgroup);
 				showHighlight(true);
-				update = true;
 			}
 		}
 	}
@@ -2832,7 +2822,6 @@ void LogicAnalyzerChannelManagerUI::highlightNext()
 				chm->highlightChannel(nullptr,
 					static_cast<LogicAnalyzerChannel*>(prevCh));
 				showHighlight(true);
-				update = true;
 			}
 		}
 	}

--- a/src/logic_analyzer.cpp
+++ b/src/logic_analyzer.cpp
@@ -1263,9 +1263,6 @@ void LogicAnalyzer::onTimePositionSpinboxChanged(double value)
 
 void LogicAnalyzer::onTimeTriggerHandlePosChanged(int pos)
 {
-	int width = bottomHandlesArea()->geometry().width() -
-			d_bottomHandlesArea->leftPadding() -
-			d_bottomHandlesArea->rightPadding();
 	double time = pixelToTime(pos);
 	if( (time + active_plot_timebase * 10 / 2) != active_timePos )
 	{

--- a/src/logic_analyzer.cpp
+++ b/src/logic_analyzer.cpp
@@ -523,7 +523,7 @@ void LogicAnalyzer::init_export_settings()
 	exportSettings = new ExportSettings(this);
 	exportSettings->enableExportButton(false);
 	ui->verticalLayout_5->addWidget(exportSettings);
-	for(int i = 0; i < no_channels; i++){
+	for(unsigned int i = 0; i < no_channels; i++){
 		exportSettings->addChannel(i, "DIO" + QString::number(i));
 	}
 
@@ -591,7 +591,7 @@ void LogicAnalyzer::get_channel_groups_api()
 {
 	qDeleteAll(channel_groups_api);
 	channel_groups_api.clear();
-	for(int i=0; i < chm.get_channel_group_count(); i++) {
+	for(unsigned int i=0; i < chm.get_channel_group_count(); i++) {
 		channel_groups_api.append(new ChannelGroup_API(this, i, false));
 	}
 }
@@ -778,7 +778,7 @@ bool LogicAnalyzer::exportVCD(QString filename, QString startSep, QString endSep
 	out << startSep << "timescale " << QString::number(timescale) << " " << timescaleFormat << endSep;
 	out << startSep << "scope module Scopy" << endSep;
 	int counter = 0;
-	for(int ch = 0; ch < no_channels; ch++) {
+	for(unsigned int ch = 0; ch < no_channels; ch++) {
 		if( exportConfig[ch] ) {
 			char c = '!' + counter;
 			out << startSep << "var wire 1 " << c << " DIO" <<
@@ -802,7 +802,7 @@ bool LogicAnalyzer::exportVCD(QString filename, QString startSep, QString endSep
 				prev_sample = segment->get_sample(i-1);
 			timestamp_written = false;
 			p = 0;
-			for(int ch = 0; ch < no_channels; ch++) {
+			for(unsigned int ch = 0; ch < no_channels; ch++) {
 
 				current_bit = (current_sample >> ch) & 1;
 				prev_bit = (prev_sample >> ch) & 1;
@@ -839,7 +839,7 @@ bool LogicAnalyzer::exportTabCsv(QString separator, QString filename)
 	fm.open(filename, FileManager::EXPORT);
 
 	QStringList chNames;
-	for(int ch = 0; ch < no_channels; ch++) {
+	for(unsigned int ch = 0; ch < no_channels; ch++) {
 		if( exportConfig[ch] ) {
 			chNames.push_back("Channel " + QString::number(ch));
 		}
@@ -852,10 +852,10 @@ bool LogicAnalyzer::exportTabCsv(QString separator, QString filename)
 		return false;
 	} else {
 		shared_ptr<pv::data::LogicSegment> segment = logic_data->logic_segments().front();
-		for (int i = 0; i < segment->get_sample_count(); ++i) {
+		for (unsigned int i = 0; i < segment->get_sample_count(); ++i) {
 			uint64_t sample = segment->get_sample(i);
 			QVector<double> line;
-			for (int ch = 0; ch < no_channels; ++ch) {
+			for (unsigned int ch = 0; ch < no_channels; ++ch) {
 				int bit = (sample >> ch) & 1;
 				if(exportConfig[ch]) {
 					line.push_back(bit);
@@ -1703,7 +1703,7 @@ void LogicAnalyzer::setupTriggerSettingsUI(bool enabled)
 
 void LogicAnalyzer::cleanTrigger()
 {
-	for(int i = 0; i < get_no_channels(dev) + 2; i++) {
+	for(unsigned int i = 0; i < get_no_channels(dev) + 2; i++) {
 		setHWTrigger(i, trigger_mapping[0]);
 		if(i < get_no_channels(dev))
 			chm.get_channel(i)->setTrigger(trigger_mapping[0]);
@@ -1728,12 +1728,12 @@ void LogicAnalyzer::bufferSentSignal(bool lastBuffer)
 void LogicAnalyzer::autoCaptureEnable(bool check)
 {
 	if(check) {
-		for(int i = 0; i < get_no_channels(dev) + 2; i++) {
+		for(unsigned int i = 0; i < get_no_channels(dev) + 2; i++) {
 			setHWTrigger(i, trigger_cache[i]);
 		}
 	}
 	if(!check && armed){
-		for(int i = 0; i < get_no_channels(dev) + 2; i++) {
+		for(unsigned int i = 0; i < get_no_channels(dev) + 2; i++) {
 			trigger_cache[i] = get_trigger_from_device(i);
 			setHWTrigger(i, trigger_mapping[0]);
 		}
@@ -1770,7 +1770,7 @@ void LogicAnalyzer::triggerChanged(int index)
 
 void LogicAnalyzer::cleanHWParams()
 {
-	for(int i = 0; i < get_no_channels(dev) + 2; i++) {
+	for(unsigned int i = 0; i < get_no_channels(dev) + 2; i++) {
 		setHWTrigger(i, trigger_mapping[0]);
 	}
 	setHWTriggerDelay(active_triggerSampleCount);
@@ -1868,7 +1868,7 @@ void LogicAnalyzer::resetInstrumentToDefault()
 	chm.clearChannelGroups();
 	cleanHWParams();
 	chm.clearTrigger();
-	for(int i = 0; i < no_channels; i++) {
+	for(unsigned int i = 0; i < no_channels; i++) {
 		chm.add_channel_group(new LogicAnalyzerChannelGroup(chm.get_channel(i)));
 	}
 	chm.highlightChannel(chm.get_channel_group(0));

--- a/src/logic_analyzer_api.cpp
+++ b/src/logic_analyzer_api.cpp
@@ -381,7 +381,7 @@ QList<int> LogicAnalyzer_API::data() const
 		std::shared_ptr<pv::data::LogicSegment> segment = logic_data->logic_segments().front();
 		if(!segment)
 			return list;
-		for (int i = 0; i < segment->get_sample_count(); ++i) {
+		for (unsigned int i = 0; i < segment->get_sample_count(); ++i) {
 			uint64_t sample = segment->get_sample(i);
 			list.append((int)sample);
 		}

--- a/src/manual_calibration_api.cpp
+++ b/src/manual_calibration_api.cpp
@@ -82,7 +82,6 @@ int ManualCalibration_API::next()
 int ManualCalibration_API::finish()
 {
 	auto currentStory = calib->stCalibrationStory;
-	int ret;
 
 	// If a story was not yet started, return -1
 	if (step_in_progress < 0) {
@@ -91,7 +90,7 @@ int ManualCalibration_API::finish()
 
 	// Finish the story, if not all the steps are done yet
 	while (step_in_progress < currentStory.story.count()) {
-		ret = next();
+		next();
 	}
 
 	calib->TempUi->finishButton->click();

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -535,7 +535,7 @@ void Measure::measure()
 	if (using_histogram_method)
 		m_histogram = new int[adc_span]{};
 
-	for (size_t i = startIndex; i < endIndex; i++) {
+	for (ssize_t i = startIndex; i < endIndex; i++) {
 
 		if (qIsNaN(data[i])) {
 			count--;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -483,7 +483,6 @@ void Measure::measure()
 	double rms;
 	double cycle_rms;
 	double rms_ac;
-	double cycle_rms_ac;
 	double area;
 	double cycle_area;
 	double sum;

--- a/src/measure.h
+++ b/src/measure.h
@@ -130,7 +130,7 @@ namespace adiscope {
 	private:
 		int m_channel;
 		double *m_buffer;
-		size_t m_buf_length;
+		ssize_t m_buf_length;
 		double m_sample_rate;
 		unsigned int m_adc_bit_count;
 		double m_cross_level;

--- a/src/menuoption.cpp
+++ b/src/menuoption.cpp
@@ -202,7 +202,7 @@ void MenuOption::mouseMoveEvent(QMouseEvent *event)
 
 	drag->setMimeData(mimeData);
 	Q_EMIT enableInfoWidget(true);
-	Qt::DropAction dropAction = drag->exec(Qt::MoveAction);
+	drag->exec(Qt::MoveAction);
 	Q_EMIT enableInfoWidget(false);
 	this->setVisible(true);
 

--- a/src/osc_export_settings.cpp
+++ b/src/osc_export_settings.cpp
@@ -64,8 +64,6 @@ void ExportSettings::clear()
 
 void ExportSettings::onExportChannelChanged(QStandardItem *item)
 {
-	QStandardItemModel *model =
-		static_cast<QStandardItemModel *>(exportChannels->model());
 	bool en = item->data(Qt::EditRole).toBool();
 
 	if (ui->btnExportAll->isChecked()){

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -623,8 +623,6 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 			plot.setTimeBaseZoomed(false);
 	});
 	connect(plot.getZoomer(), &OscPlotZoomer::zoomFinished, [=](bool isZoomOut) {
-		ChannelWidget *channel_widget = channelWidgetAtId(current_ch_widget);
-
 		plot.setTimeBaseLabelValue(plot.HorizUnitsPerDiv());
 
 		for (int i = 0; i < nb_channels + nb_math_channels + nb_ref_channels; ++i) {
@@ -868,7 +866,6 @@ void Oscilloscope::add_ref_waveform(unsigned int chIdx)
 
 	int curve_id = nb_channels + nb_math_channels + nb_ref_channels;
 
-	unsigned int curve_number = find_curve_number();
 	QString qname = QString("REF %1").arg(nb_ref_channels + 1);
 
 	probe_attenuation.push_back(1);
@@ -977,7 +974,6 @@ void Oscilloscope::updateTriggerLevelValue(std::vector<float> value)
 	triggerLevelSink.first->blockSignals(true);
 
 	double m_dc_level = trigger_settings.dcLevel();
-	int val = value.at(0) * 1e3;
 	if ((int)(value.at(0)*1e3) == (int)(m_dc_level*1e3)) {
 		triggerLevelSink.first->blockSignals(false);
 		return;
@@ -1709,7 +1705,6 @@ void Oscilloscope::add_math_channel(const std::string& function)
 		return;
 	}
 
-	auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
 	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE, MAX_MATH_RANGE);
 	auto math = iio::iio_math::make(function, nb_channels);
 	unsigned int curve_id = nb_channels + nb_math_channels + nb_ref_channels;
@@ -2167,7 +2162,6 @@ void Oscilloscope::setChannelWidgetIndex(int chnIdx)
 
 void Oscilloscope::autosetFFT()
 {
-	bool started = iio->started();
 	auto fft = gnuradio::get_initial_sptr(
 				new fft_block(false, autoset_fft_size));
 
@@ -3256,7 +3250,6 @@ void Oscilloscope::editMathChannelFunction(int id, const std::string& new_functi
 	QString qname = chn_widget->deleteButton()->property("curve_name").toString();
 	std::string name = qname.toStdString();
 
-	auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
 	auto rail = gr::analog::rail_ff::make(MIN_MATH_RANGE, MAX_MATH_RANGE);
 	auto math = iio::iio_math::make(new_function, nb_channels);
 

--- a/src/pattern_generator.cpp
+++ b/src/pattern_generator.cpp
@@ -211,7 +211,7 @@ PatternGenerator::PatternGenerator(struct iio_context *ctx, Filter *filt,
 	connect(pgSettings->PB_Reset,SIGNAL(clicked(bool)),this,
 	        SLOT(resetPGToDefault()));
 
-	auto i=0;
+	/*auto i=0;*/
 
 	for (auto var : PatternFactory::get_ui_list()) {
 		cgSettings->CBPattern->addItem(var);
@@ -908,7 +908,6 @@ bool PatternGenerator::startPatternGeneration(bool cyclic)
 
 	buffer_created = true;
 	short *p_dat;
-	ptrdiff_t p_inc;
 
 	int i = 0;
 

--- a/src/pg_channel_manager.cpp
+++ b/src/pg_channel_manager.cpp
@@ -223,7 +223,7 @@ void PatternGeneratorChannelUI::mouseMoveEvent(QMouseEvent *event)
 	}
 
 	drag->setMimeData(mimeData);
-	Qt::DropAction dropAction = drag->exec(Qt::MoveAction);
+	drag->exec(Qt::MoveAction);
 	this->setVisible(true);
 
 }
@@ -306,8 +306,6 @@ void PatternGeneratorChannelUI::dropEvent(QDropEvent *event)
 	auto channelGroups = getManagerUi()->chm->get_channel_groups();
 	auto chgIter = std::find(channelGroups->begin(),channelGroups->end(),chg);
 	auto chgIndex = chgIter-channelGroups->begin();
-
-	auto toNrOfChannels = (*chgIter)->get_channel_count();
 
 	auto channels = (*chgIter)->get_channels();
 	auto chIter = std::find(channels->begin(),channels->end(),ch);
@@ -758,7 +756,7 @@ void PatternGeneratorChannelGroupUI::mouseMoveEvent(QMouseEvent *event)
 		drag->setPixmap(pix);
 	}
 
-	Qt::DropAction dropAction = drag->exec(Qt::MoveAction);
+	drag->exec(Qt::MoveAction);
 	this->setVisible(true);
 
 }
@@ -1033,8 +1031,7 @@ void PatternGeneratorChannelGroupUI::setupI2CDecoder()
 		if (getManagerUi()->getUseDecoders()) {
 			auto chMap = setupDecoder("i2c",ids);
 
-			auto i2cdecoder = decodeTrace->decoder()->stack().front();
-			auto i2cpattern = dynamic_cast<I2CPattern *>(getChannelGroup()->pattern);
+			decodeTrace->decoder()->stack().front();
 
 			auto decoderAnnotations = 2;
 
@@ -1416,8 +1413,7 @@ void PatternGeneratorChannelManager::commitBuffer(PatternGeneratorChannelGroup
 	uint8_t channel_mapping[16];
 	memset(channel_mapping,0x00,16*sizeof(uint8_t));
 	short *bufferPtr = chg->pattern->get_buffer();
-	int i=0,j=0;
-	auto channel_enable_mask_temp = chg->get_mask();
+	int i=0;
 	auto buffer_channel_mask = (1<<chg->get_channel_count())-1;
 
 	for (i=0; i<chg->get_channel_count(); i++) {
@@ -1570,8 +1566,6 @@ void PatternGeneratorChannelManagerUI::updateUi()
 {
 	static const int channelGroupLabelMaxLength = pg->channelGroupLabelMaxLength;
 	static const int dioLabelMaxLength = 2;
-	static const int channelComboMaxLength = 15;
-	static const int outputComboMaxLength = 5;
 
 	if (pg->getCurrentPatternUI())
 		disconnect(pg->getCurrentPatternUI(),SIGNAL(decoderChanged()),this,
@@ -1661,8 +1655,6 @@ void PatternGeneratorChannelManagerUI::updateUi()
 
 		currentChannelGroupUI->ui->ChannelGroupLabel->setText(channelGroupLabel);
 		Util::setWidgetNrOfChars(currentChannelGroupUI->ui->DioLabel, dioLabelMaxLength);
-
-		int i = 0;
 
 		connect(static_cast<PatternGeneratorChannelGroupUI *>(chg_ui.back()),
 		        SIGNAL(channel_enabled()),this,SIGNAL(channelsChanged())); // TEMP

--- a/src/pg_channel_manager.cpp
+++ b/src/pg_channel_manager.cpp
@@ -935,8 +935,6 @@ void PatternGeneratorChannelGroupUI::setupUARTDecoder()
 
 		// Add the decoder rows
 
-		auto decc = uartdecoder->decoder();
-
 		auto decoderAnnotations = 3;
 
 		for (auto i=0; i<decoderAnnotations; i++) {
@@ -1006,7 +1004,6 @@ void PatternGeneratorChannelGroupUI::setupSPIDecoder()
 			spidecoder->set_option("cpha", g_variant_new_int64(!spipattern->getCPHA()));
 			//spidecoder->set_option("wordsize", g_variant_new_int64(spipattern->getBytesPerFrame()*8));
 
-			auto decc = spidecoder->decoder();
 			auto decoderAnnotations = 3;
 
 			for (auto i=0; i<decoderAnnotations; i++) {

--- a/src/pg_patterns.cpp
+++ b/src/pg_patterns.cpp
@@ -449,9 +449,7 @@ uint8_t ClockPattern::generate_pattern(uint32_t sample_rate,
 
 
 	int period_number_of_samples = (int)round(f_period_number_of_samples);
-	int number_of_periods = (int)round(f_number_of_periods);
 	int low_number_of_samples = (int)round(f_low_number_of_samples);
-	int high_number_of_samples = (int)round(f_high_number_of_samples);
 
 	if (period_number_of_samples==0) {
 		period_number_of_samples=1;
@@ -539,9 +537,6 @@ void ClockPatternUI::destroy_ui()
 
 void ClockPatternUI::parse_ui()
 {
-	bool ok =0;
-
-
 	QObject *obj = sender();
 
 	bool freqStepDown = false;
@@ -1019,7 +1014,7 @@ Pattern *BinaryCounterPatternUI::get_pattern()
 
 void BinaryCounterPatternUI::parse_ui()
 {
-	bool ok = false;
+	/*bool ok = false;*/
 	pattern->set_frequency(frequencySpinButton->value());
 
 
@@ -1117,7 +1112,7 @@ void GrayCounterPatternUI::destroy_ui()
 
 void GrayCounterPatternUI::parse_ui()
 {
-	bool ok = false;
+	/*bool ok = false;*/
 	pattern->set_frequency(frequencySpinButton->value());
 
 
@@ -1361,7 +1356,6 @@ uint8_t UARTPattern::generate_pattern(uint32_t sample_rate,
                                       uint32_t number_of_samples, uint16_t number_of_channels)
 {
 	delete_buffer();
-	uint16_t number_of_frames = str.length();
 	uint32_t samples_per_bit = sample_rate/baud_rate;
 	qDebug()<< "samples_per_bit - "<<(float)sample_rate/(float)baud_rate;
 	uint16_t bits_per_frame;
@@ -1369,7 +1363,6 @@ uint8_t UARTPattern::generate_pattern(uint32_t sample_rate,
 	uint32_t samples_per_frame = samples_per_bit * bits_per_frame;
 
 	buffer = new short[number_of_samples]; // no need to recreate buffer
-	auto buffersize = (number_of_samples)*sizeof(short);
 	memset(buffer, 0xff, (number_of_samples)*sizeof(short));
 
 	short *buf_ptr = buffer;
@@ -1638,8 +1631,6 @@ void I2CPattern::sample_payload()
 			val = *it;
 		}
 
-		bool oldbit;
-
 		for (auto j=0; j<8; j++) {
 			bool bit;
 
@@ -1676,7 +1667,6 @@ uint8_t I2CPattern::generate_pattern(uint32_t sample_rate,
 
 	buffer = new short[number_of_samples]; // no need to recreate buffer
 	buf_ptr = buffer;
-	auto buffersize = (number_of_samples)*sizeof(short);
 	memset(buffer, (0xff), (number_of_samples)*sizeof(short));
 
 	samples_per_bit = 2*(sample_rate/clkFrequency);
@@ -1890,7 +1880,6 @@ uint8_t SPIPattern::generate_pattern(uint32_t sample_rate,
 	delete_buffer();
 
 	buffer = new short[number_of_samples]; // no need to recreate buffer
-	auto buffersize = (number_of_samples)*sizeof(short);
 
 	auto clkActiveBit = 0;
 	auto outputBit = 1;
@@ -2228,7 +2217,6 @@ bool JSPattern::is_periodic()
 
 uint8_t JSPattern::pre_generate()
 {
-	bool ok;
 	QString fileName(obj["filepath"].toString() +
 	                 obj["generate_script"].toString());
 	qDebug()<<fileName;
@@ -3330,8 +3318,6 @@ void ImportPatternUI::destroy_ui()
 
 void ImportPatternUI::parse_ui()
 {
-
-	bool ok =0;
 	QObject *obj = sender();
 	bool freqStepDown = false;
 

--- a/src/pulseview/pv/view/viewport.cpp
+++ b/src/pulseview/pv/view/viewport.cpp
@@ -350,9 +350,9 @@ void Viewport::paint_grid(QPainter &p, const ViewItemPaintParams &pp)
 
 	int division_height = divisionHeight;
 	int division_count = divisionCount;
-	int division_offset = divisionOffset;
+	/*int division_offset = divisionOffset;
 
-	int division_width = w / division_count;    
+	int division_width = w / division_count;*/
 	int row_count = view_.height() / division_height;
 
 	QPointF p1, p2;

--- a/src/scopyApplication.cpp
+++ b/src/scopyApplication.cpp
@@ -31,9 +31,6 @@ QString ScopyApplication::initBreakPadHandler(QString crashDumpPath) {
 
 	}
 
-	QByteArray ba = qd.path().toLocal8Bit();
-	const char *appDirStr = ba.data();
-
 #ifdef Q_OS_LINUX
 	descriptor = new google_breakpad::MinidumpDescriptor(qd.path().toStdString().c_str());
 	handler->set_minidump_descriptor(*descriptor);

--- a/src/scopyApplication.hpp
+++ b/src/scopyApplication.hpp
@@ -45,6 +45,6 @@ private:
 	google_breakpad::ExceptionHandler *handler;
 #ifdef Q_OS_LINUX
 	google_breakpad::MinidumpDescriptor *descriptor;
-#endif;
+#endif
 };
 #endif

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -109,8 +109,6 @@ bool SignalGenerator::chunkCompare(chunk_header_t& ptr,const char *id2)
 	return true;
 }
 
-static double temp_sample_rate;
-
 SignalGenerator::SignalGenerator(struct iio_context *_ctx,
                                  QList<std::shared_ptr<GenericDac>> dacs, Filter *filt,
                                  QPushButton *runButton, QJSEngine *engine, ToolLauncher *parent) :
@@ -1449,7 +1447,6 @@ basic_block_sptr SignalGenerator::getSignalSource(gr::top_block_sptr top,
 		double samp_rate, struct signal_generator_data& data,
                 double phase_correction)
 {
-	bool inv_saw_wave = data.waveform == SG_INV_SAW_WAVE;
 	analog::gr_waveform_t waveform;
 	double phase;
 	double amplitude;
@@ -1670,7 +1667,6 @@ gr::basic_block_sptr SignalGenerator::getSource(QWidget *obj,
 				break;
 			}
 
-			auto ratio=ptr->file_sr/samp_rate;
 			auto mult = blocks::multiply_const_ff::make(ptr->file_amplitude);
 			top->connect(buffer,0,mult,0);
 			auto add = blocks::add_const_ff::make(ptr->file_offset);
@@ -1680,7 +1676,7 @@ gr::basic_block_sptr SignalGenerator::getSource(QWidget *obj,
 
 			if (preview) {
 				auto ratio = sample_rate/ptr->file_sr;
-				long m,n,integral;
+				long m,n;
 				bool ok=false;
 				for(auto precision=8;precision<2048;precision<<=1)
 				{

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -586,8 +586,6 @@ void ToolLauncher::updateListOfDevices(const QVector<QString>& uris)
 		if (!uri.startsWith("usb:"))
 			continue;
 
-		bool found = false;
-
 		auto dev = getDevice(uri);
 
 		if (!dev)
@@ -995,7 +993,6 @@ void ToolLauncher::setupAddPage()
 	connectWidget = new ConnectDialog(ui->stackedWidget);
 	connect(connectWidget, &ConnectDialog::newContext,
 		[=](const QString& uri) {
-		bool found = false;
 		auto dev = getDevice(uri);
 		if (dev) {
 			highlightDevice(dev->deviceButton());


### PR DESCRIPTION
Some bits have been commented out only [vs being removed].
That's because, there is code there that was commented-out instead of being removed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>