### PR TITLE
Updated Network Analyzer Tool

### DIFF
--- a/src/DisplayPlot.cc
+++ b/src/DisplayPlot.cc
@@ -65,7 +65,7 @@ void OscScaleDraw::setFloatPrecision(unsigned int numDigits)
 	m_floatPrecision = numDigits;
 }
 
-unsigned int OscScaleDraw::getFloatPrecison()
+unsigned int OscScaleDraw::getFloatPrecison() const
 {
 	return m_floatPrecision;
 }

--- a/src/DisplayPlot.h
+++ b/src/DisplayPlot.h
@@ -583,6 +583,8 @@ public:
 	void setDisplayScale(double value);
 	void setFormatter(PrefixFormatter *formatter);
 
+	void enableDeltaLabel(bool enable);
+
 protected:
 	virtual void draw(QPainter *, const QPalette &) const;
 
@@ -594,6 +596,7 @@ private:
 	double m_displayScale;
 	mutable unsigned int m_nrTicks;
 	mutable bool m_shouldDrawMiddleDelta;
+	bool m_delta;
 
 };
 

--- a/src/DisplayPlot.h
+++ b/src/DisplayPlot.h
@@ -592,6 +592,9 @@ private:
 	PrefixFormatter *m_formatter;
 	QColor m_color;
 	double m_displayScale;
+	mutable unsigned int m_nrTicks;
+	mutable bool m_shouldDrawMiddleDelta;
+
 };
 
 class OscPlotZoomer: public ExtendingPlotZoomer

--- a/src/DisplayPlot.h
+++ b/src/DisplayPlot.h
@@ -573,7 +573,7 @@ public:
 	QwtText label( double ) const;
 
 	void setFloatPrecision(unsigned int numDigits);
-	unsigned int getFloatPrecison();
+	unsigned int getFloatPrecison() const;
 
 	void setUnitType(const QString& unit);
 	QString getUnitType() const;

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -1005,6 +1005,12 @@ void TimeDomainDisplayPlot::registerReferenceWaveform(QString name, QVector<doub
 
 void TimeDomainDisplayPlot::unregisterReferenceWaveform(QString name)
 {
+	auto it = std::find(d_plot_curve.begin(), d_plot_curve.end(), d_ref_curves[name]);
+
+	if (it == d_plot_curve.end()) {
+		return;
+	}
+
 	d_plot_curve.erase(std::find(d_plot_curve.begin(), d_plot_curve.end(), d_ref_curves[name]));
 	QwtPlotCurve *curve = d_ref_curves[name];
 	d_ref_curves.remove(name);

--- a/src/cancel_dc_offset_block.cpp
+++ b/src/cancel_dc_offset_block.cpp
@@ -1,0 +1,69 @@
+#include "cancel_dc_offset_block.h"
+
+#include <gnuradio/blocks/stream_to_vector.h>
+#include <gnuradio/blocks/vector_to_stream.h>
+#include <gnuradio/blocks/moving_average_ff.h>
+#include <gnuradio/blocks/sub_ff.h>
+#include <gnuradio/blocks/skiphead.h>
+#include <gnuradio/blocks/repeat.h>
+#include <gnuradio/blocks/copy.h>
+
+#include <iostream>
+
+using namespace adiscope;
+using namespace gr;
+
+cancel_dc_offset_block::cancel_dc_offset_block(size_t buffer_size, bool enabled):
+	hier_block2("DCOFFSET",
+		    io_signature::make(1, 1, sizeof(float)),
+		    io_signature::make(1, 1, sizeof(float))),
+	d_enabled(enabled),
+	d_buffer_size(buffer_size)
+{
+	_build_and_connect_blocks();
+}
+
+cancel_dc_offset_block::~cancel_dc_offset_block()
+{
+}
+
+void cancel_dc_offset_block::set_enabled(bool enabled)
+{
+	if (d_enabled != enabled) {
+		d_enabled = enabled;
+
+		_build_and_connect_blocks();
+	}
+}
+
+void cancel_dc_offset_block::_build_and_connect_blocks()
+{
+	// Remove all connections
+	hier_block2::disconnect_all();
+
+	if (d_enabled) {
+		//////////////////////////////////////////////////////////////////
+		// this -->average -->skiphead -->repeat -->|                   //
+		//   |                                      | -->sub_ff -->this //
+		//    ------------------------------------->|                   //
+		//////////////////////////////////////////////////////////////////
+
+		auto avg = blocks::moving_average_ff::make(d_buffer_size,
+							   1.0 / (float)d_buffer_size, d_buffer_size);
+		auto sub_ff = blocks::sub_ff::make();
+		auto skip_head = blocks::skiphead::make(sizeof(float), d_buffer_size - 1);
+		auto repeat = blocks::repeat::make(sizeof(float), d_buffer_size);
+
+		hier_block2::connect(this->self(), 0, sub_ff, 0);
+		hier_block2::connect(this->self(), 0, avg, 0);
+		hier_block2::connect(avg, 0, skip_head, 0);
+		hier_block2::connect(skip_head, 0, repeat, 0);
+		hier_block2::connect(repeat, 0, sub_ff, 1);
+		hier_block2::connect(sub_ff, 0, this->self(), 0);
+	} else {
+		// Copy input to output port
+		auto copy = blocks::copy::make(sizeof(float));
+		hier_block2::connect(this->self(), 0, copy, 0);
+		hier_block2::connect(copy, 0, this->self(), 0);
+	}
+}

--- a/src/cancel_dc_offset_block.h
+++ b/src/cancel_dc_offset_block.h
@@ -3,6 +3,8 @@
 
 #include <gnuradio/hier_block2.h>
 
+#include "filter_dc_offset_block.h"
+
 namespace adiscope {
 class cancel_dc_offset_block : public gr::hier_block2
 {
@@ -12,9 +14,15 @@ public:
 
         void set_enabled(bool enabled);
 
+	void set_buffer_size(size_t buffer_size);
+
+	float get_dc_offset() const;
+
 private:
         bool d_enabled;
         size_t d_buffer_size;
+	float d_dc_offset;
+	boost::shared_ptr<filter_dc_offset_block> d_cancel_dc;
 
         void _build_and_connect_blocks();
 

--- a/src/cancel_dc_offset_block.h
+++ b/src/cancel_dc_offset_block.h
@@ -1,0 +1,24 @@
+#ifndef CANCEL_DC_OFFSET_BLOCK_H
+#define CANCEL_DC_OFFSET_BLOCK_H
+
+#include <gnuradio/hier_block2.h>
+
+namespace adiscope {
+class cancel_dc_offset_block : public gr::hier_block2
+{
+public:
+        cancel_dc_offset_block(size_t buffer_size, bool enabled);
+        ~cancel_dc_offset_block();
+
+        void set_enabled(bool enabled);
+
+private:
+        bool d_enabled;
+        size_t d_buffer_size;
+
+        void _build_and_connect_blocks();
+
+};
+}
+
+#endif // CANCEL_DC_OFFSET_BLOCK_H

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -361,8 +361,10 @@ void dBgraph::setYMin(double val)
 	setAxisScale(QwtPlot::yLeft, val, ymax);
 	ymin = val;
 	replot();
-	zoomer->setZoomBase(QRect(xmin,ymin,xmax,ymax-ymin));
 
+	double width = xmax - xmin;
+	double height = ymax - ymin;
+	zoomer->setZoomBase(QRectF(xmin, ymin, width, height));
 }
 
 void dBgraph::setYMax(double val)
@@ -370,8 +372,10 @@ void dBgraph::setYMax(double val)
 	setAxisScale(QwtPlot::yLeft, ymin, val);
 	ymax = val;
 	replot();
-	zoomer->setZoomBase(QRect(xmin,ymin,xmax,ymax-ymin));
 
+	double width = xmax - xmin;
+	double height = ymax - ymin;
+	zoomer->setZoomBase(QRectF(xmin, ymin, width, height));
 }
 
 QString dBgraph::xUnit() const

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -686,6 +686,27 @@ QVector<double> dBgraph::getYAxisData()
 	return data;
 }
 
+void dBgraph::setYAxisInterval(double min, double max, double correction)
+{
+	for (size_t i = 0; i < ydata.size(); ++i) {
+		double value = ydata[i];
+		bool modified = false;
+		if (value > max) {
+			value = value - correction;
+			modified = true;
+		} else if (value < min) {
+			value = value + correction;
+			modified = true;
+		}
+
+		if (modified) {
+			ydata[i] = value;
+			curve.setRawSamples(xdata.data(), ydata.data(), xdata.size());
+			replot();
+		}
+	}
+}
+
 void dBgraph::scaleDivChanged()
 {
 	QwtPlot *plt = static_cast<QwtPlot *>((sender())->parent());

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -83,15 +83,15 @@ void dBgraph::setupReadouts()
 }
 
 dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
-    curve("data"),
-    xmin(10),
-    xmax(10),
-    ymin(10),
-    ymax(10),
-    d_cursorsEnabled(false),
-    d_cursorsCentered(false),
-    d_plotPosition(0),
-    numSamples(0),
+	curve("data"),
+	d_cursorsCentered(false),
+	d_cursorsEnabled(false),
+	xmin(10),
+	xmax(10),
+	ymin(10),
+	ymax(10),
+	d_plotPosition(0),
+	numSamples(0)
 {
 	enableAxis(QwtPlot::xBottom, false);
 	enableAxis(QwtPlot::xTop, true);
@@ -114,14 +114,14 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	thickness = 1;
 
 	OscScaleEngine *scaleLeft = new OscScaleEngine;
-    scaleLeft->setMajorTicksCount(7);
+	scaleLeft->setMajorTicksCount(7);
 	this->setAxisScaleEngine(QwtPlot::yLeft,
-			static_cast<QwtScaleEngine *>(scaleLeft));
+				 static_cast<QwtScaleEngine *>(scaleLeft));
 
 	/* draw_x / draw_y: Outmost X / Y scales. Only draw the labels */
 	formatter = static_cast<PrefixFormatter *>(new MetricPrefixFormatter);
-    draw_x = new OscScaleDraw(formatter, "Hz");
-    draw_x->setFloatPrecision(2);
+	draw_x = new OscScaleDraw(formatter, "Hz");
+	draw_x->setFloatPrecision(2);
 	draw_x->enableComponent(QwtAbstractScaleDraw::Ticks, false);
 	draw_x->enableComponent(QwtAbstractScaleDraw::Backbone, false);
 	setAxisScaleDraw(QwtPlot::xTop, draw_x);
@@ -130,7 +130,7 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	draw_y->setFloatPrecision(0);
 	draw_y->enableComponent(QwtAbstractScaleDraw::Ticks, false);
 	draw_y->enableComponent(QwtAbstractScaleDraw::Backbone, false);
-    draw_y->setMinimumExtent(50);
+	draw_y->setMinimumExtent(50);
 	setAxisScaleDraw(QwtPlot::yLeft, draw_y);
 
 	useLogFreq(false);
@@ -138,19 +138,20 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	/* Create 4 scales within the plot itself. Only draw the ticks */
 	for (unsigned int i = 0; i < 4; i++) {
 		EdgelessPlotScaleItem *scaleItem = new EdgelessPlotScaleItem(
-				static_cast<QwtScaleDraw::Alignment>(i));
+			static_cast<QwtScaleDraw::Alignment>(i));
 
 		/* Top/bottom scales must be sync'd to xTop; left/right scales
 		 * must be sync'd to yLeft */
-		if (i < 2)
+		if (i < 2) {
 			scaleItem->setXAxis(QwtPlot::xTop);
-		else
+		} else {
 			scaleItem->setYAxis(QwtPlot::yLeft);
+		}
 
 		scaleItem->scaleDraw()->enableComponent(
-				QwtAbstractScaleDraw::Backbone, false);
+			QwtAbstractScaleDraw::Backbone, false);
 		scaleItem->scaleDraw()->enableComponent(
-				QwtAbstractScaleDraw::Labels, false);
+			QwtAbstractScaleDraw::Labels, false);
 
 		QPalette palette = scaleItem->palette();
 		palette.setBrush(QPalette::Foreground, QColor("#6E6E6F"));
@@ -162,40 +163,40 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 
 	zoomer = new XAxisScaleZoomer(canvas());
 	zoomer->setMousePattern(QwtEventPattern::MouseSelect3,
-	                        Qt::RightButton);
+				Qt::RightButton);
 	zoomer->setMousePattern(QwtEventPattern::MouseSelect2,
-	                        Qt::RightButton, Qt::ControlModifier);
+				Qt::RightButton, Qt::ControlModifier);
 
 	static_cast<QFrame *>(canvas())->setLineWidth(0);
 	setContentsMargins(10, 10, 24, 20);
 
 	picker = new PlotPickerWrapper(QwtPlot::xTop,QwtPlot::yLeft,this->canvas());
 
-    QMargins margins = contentsMargins();
-    margins.setBottom(0);
-    setContentsMargins(margins);
+	QMargins margins = contentsMargins();
+	margins.setBottom(0);
+	setContentsMargins(margins);
 
-    QwtScaleWidget *scaleWidget = axisWidget(QwtPlot::xTop);
-    const int fmw = QFontMetrics(scaleWidget->font()).width("XXXX.XX XX");
-    scaleWidget->setMinBorderDist(fmw / 2, fmw / 2);
+	QwtScaleWidget *scaleWidget = axisWidget(QwtPlot::xTop);
+	const int fmw = QFontMetrics(scaleWidget->font()).width("XXXX.XX XX");
+	scaleWidget->setMinBorderDist(fmw / 2, fmw / 2);
 
-    markerIntersection1 = new QwtPlotMarker();
-    markerIntersection2 = new QwtPlotMarker();
-    markerIntersection1->setSymbol(new QwtSymbol(
-                    QwtSymbol::Ellipse, QColor(237, 28, 36),
-                    QPen(QColor(255, 255 ,255, 140), 2, Qt::SolidLine),
-		    QSize(5, 5)));
-    markerIntersection2->setSymbol(new QwtSymbol(
-		    QwtSymbol::Ellipse, QColor(237, 28, 36),
-		    QPen(QColor(255, 255 ,255, 140), 2, Qt::SolidLine),
-		    QSize(5, 5)));
+	markerIntersection1 = new QwtPlotMarker();
+	markerIntersection2 = new QwtPlotMarker();
+	markerIntersection1->setSymbol(new QwtSymbol(
+					       QwtSymbol::Ellipse, QColor(237, 28, 36),
+					       QPen(QColor(255, 255,255, 140), 2, Qt::SolidLine),
+					       QSize(5, 5)));
+	markerIntersection2->setSymbol(new QwtSymbol(
+					       QwtSymbol::Ellipse, QColor(237, 28, 36),
+					       QPen(QColor(255, 255,255, 140), 2, Qt::SolidLine),
+					       QSize(5, 5)));
 
-    markerIntersection1->setAxes(QwtPlot::xTop, QwtPlot::yLeft);
-    markerIntersection2->setAxes(QwtPlot::xTop, QwtPlot::yLeft);
+	markerIntersection1->setAxes(QwtPlot::xTop, QwtPlot::yLeft);
+	markerIntersection2->setAxes(QwtPlot::xTop, QwtPlot::yLeft);
 
-    setupCursors();
+	setupCursors();
 
-    setupReadouts();
+	setupReadouts();
 
 }
 
@@ -208,7 +209,7 @@ dBgraph::~dBgraph()
 	delete markerIntersection1;
 	delete markerIntersection2;
 	delete formatter;
-    delete picker;
+	delete picker;
 }
 
 void dBgraph::setAxesScales(double xmin, double xmax, double ymin, double ymax)
@@ -219,16 +220,16 @@ void dBgraph::setAxesScales(double xmin, double xmax, double ymin, double ymax)
 
 void dBgraph::setAxesTitles(const QString& x, const QString& y)
 {
-    QwtText xTitle(x);
-    QwtText yTitle(y);
+	QwtText xTitle(x);
+	QwtText yTitle(y);
 
-    QFont font = axisTitle(QwtPlot::xTop).font();
-    font.setWeight(QFont::Normal);
-    xTitle.setFont(font);
-    yTitle.setFont(font);
+	QFont font = axisTitle(QwtPlot::xTop).font();
+	font.setWeight(QFont::Normal);
+	xTitle.setFont(font);
+	yTitle.setFont(font);
 
-    setAxisTitle(QwtPlot::xTop, xTitle);
-    setAxisTitle(QwtPlot::yLeft, yTitle);
+	setAxisTitle(QwtPlot::xTop, xTitle);
+	setAxisTitle(QwtPlot::yLeft, yTitle);
 }
 
 void dBgraph::plot(double x, double y)
@@ -261,6 +262,7 @@ void dBgraph::plot(double x, double y)
 		onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
 		onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
 	}
+
 	replot();
 }
 
@@ -272,17 +274,18 @@ int dBgraph::getNumSamples() const
 QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale) const
 {
 	auto *scaleDraw = static_cast<const OscScaleDraw *>(
-				axisScaleDraw(scale));
+				  axisScaleDraw(scale));
 
 	return formatter->format(value,
 				 scaleDraw->getUnitType(),
 				 scaleDraw->getFloatPrecison());
 }
 
-QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale, int precision) const
+QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale,
+				     int precision) const
 {
 	auto *scaleDraw = static_cast<const OscScaleDraw *>(
-				axisScaleDraw(scale));
+				  axisScaleDraw(scale));
 
 	return formatter->format(value,
 				 scaleDraw->getUnitType(),
@@ -291,14 +294,14 @@ QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale, int precisio
 
 void dBgraph::setShowZero(bool en)
 {
-    OscScaleEngine *scaleLeft = new OscScaleEngine();
-    scaleLeft->setMajorTicksCount(7);
-    scaleLeft->showZero(en);
+	OscScaleEngine *scaleLeft = new OscScaleEngine();
+	scaleLeft->setMajorTicksCount(7);
+	scaleLeft->showZero(en);
 
-    this->setAxisScaleEngine(QwtPlot::yLeft,
-	    static_cast<QwtScaleEngine *>(scaleLeft));
+	this->setAxisScaleEngine(QwtPlot::yLeft,
+				 static_cast<QwtScaleEngine *>(scaleLeft));
 
-    replot();
+	replot();
 }
 
 const QwtScaleWidget *dBgraph::getAxisWidget(QwtAxisId id)
@@ -339,14 +342,16 @@ const QColor& dBgraph::getColor() const
 	return this->color;
 }
 
-void dBgraph::setThickness(int index){
+void dBgraph::setThickness(int index)
+{
 	double thickness = 0.5 * (index + 1);
 	this->thickness = thickness;
 	curve.setPen(QPen(color,thickness));
 	replot();
 }
 
-double dBgraph::getThickness(){
+double dBgraph::getThickness()
+{
 	return this->thickness;
 }
 
@@ -362,25 +367,25 @@ QString dBgraph::yTitle() const
 
 void dBgraph::setXTitle(const QString& title)
 {
-    QwtText xTitle(title);
-    QFont font = axisTitle(QwtPlot::xTop).font();
-    font.setWeight(QFont::Normal);
-    xTitle.setFont(font);
+	QwtText xTitle(title);
+	QFont font = axisTitle(QwtPlot::xTop).font();
+	font.setWeight(QFont::Normal);
+	xTitle.setFont(font);
 
-    setAxisTitle(QwtPlot::xTop, xTitle);
+	setAxisTitle(QwtPlot::xTop, xTitle);
 }
 
 void dBgraph::setYTitle(const QString& title)
 {
-    QwtText yTitle(title);
-    QFont font = axisTitle(QwtPlot::xTop).font();
-    font.setWeight(QFont::Normal);
-    yTitle.setFont(font);
+	QwtText yTitle(title);
+	QFont font = axisTitle(QwtPlot::xTop).font();
+	font.setWeight(QFont::Normal);
+	yTitle.setFont(font);
 
-    setAxisTitle(QwtPlot::yLeft, yTitle);
-    d_cursorReadouts->setVoltageCursor1LabelText(title.mid(0,3)+"1= ");
-    d_cursorReadouts->setVoltageCursor2LabelText(title.mid(0,3)+"2= ");
-    d_cursorReadouts->setDeltaVoltageLabelText("Δ"+title.mid(0,3)+"= ");
+	setAxisTitle(QwtPlot::yLeft, yTitle);
+	d_cursorReadouts->setVoltageCursor1LabelText(title.mid(0,3)+"1= ");
+	d_cursorReadouts->setVoltageCursor2LabelText(title.mid(0,3)+"2= ");
+	d_cursorReadouts->setDeltaVoltageLabelText("Δ"+title.mid(0,3)+"= ");
 }
 
 void dBgraph::setXMin(double val)
@@ -458,6 +463,7 @@ void dBgraph::useLogFreq(bool use_log_freq)
 	}
 
 	this->log_freq = use_log_freq;
+
 	if (d_cursorsEnabled && isVisible()) {
 		onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
 		onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
@@ -519,18 +525,19 @@ void dBgraph::onVbar2PixelPosChanged(int pos)
 void dBgraph::toggleCursors(bool en)
 {
 	if (d_cursorsEnabled != en) {
-        if(!d_cursorsCentered){
-            d_cursorsCentered=true;
-            d_vBar1->setPixelPosition(canvas()->width()/2-30);
-            d_vBar2->setPixelPosition(canvas()->width()/2+30);
-        }
+		if (!d_cursorsCentered) {
+			d_cursorsCentered=true;
+			d_vBar1->setPixelPosition(canvas()->width()/2-30);
+			d_vBar2->setPixelPosition(canvas()->width()/2+30);
+		}
 
-        d_cursorsEnabled = en;
+		d_cursorsEnabled = en;
 		d_vBar1->setVisible(en);
 		d_vBar2->setVisible(en);
 
 		d_cursorReadouts->setTimeReadoutVisible(en);
 		d_cursorReadouts->setVoltageReadoutVisible(en);
+
 		if (en) {
 			onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
 			onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
@@ -542,9 +549,10 @@ void dBgraph::toggleCursors(bool en)
 	}
 }
 
-CustomPlotPositionButton::ReadoutsPosition dBgraph::getCursorReadoutCurrentPosition()
+CustomPlotPositionButton::ReadoutsPosition
+dBgraph::getCursorReadoutCurrentPosition()
 {
-    return d_cursorReadouts->getCurrentPosition();
+	return d_cursorReadouts->getCurrentPosition();
 }
 
 void dBgraph::onCursor1Moved(int value)
@@ -569,10 +577,11 @@ void dBgraph::onCursor1Moved(int value)
 			markerIntersection1->setValue(point.x(), d1);
 		}
 	}
+
 	replot();
 
 	d_cursorReadouts->setVoltageDeltaText(QString::number(d2-d1)+" "+
-	                                      draw_y->getUnitType());
+					      draw_y->getUnitType());
 }
 
 void dBgraph::onCursor2Moved(int value)
@@ -597,10 +606,11 @@ void dBgraph::onCursor2Moved(int value)
 			markerIntersection2->setValue(point.x(), d2);
 		}
 	}
+
 	replot();
 
 	d_cursorReadouts->setVoltageDeltaText(QString::number(d2-d1)+" "+
-	                                      draw_y->getUnitType());
+					      draw_y->getUnitType());
 }
 
 QString dBgraph::cursorIntersection(qreal freq)
@@ -636,7 +646,7 @@ QString dBgraph::cursorIntersection(qreal freq)
 		rightCustom = ydata.data()[rightIndex];
 
 		double val = (rightCustom - leftCustom)/(rightFreq - leftFreq)*
-		             (freq-leftFreq)+leftCustom;
+			     (freq-leftFreq)+leftCustom;
 
 		return QString::number(val,'f',0) +" "+ draw_y->getUnitType();
 	}
@@ -644,29 +654,34 @@ QString dBgraph::cursorIntersection(qreal freq)
 
 void dBgraph::setCursorReadoutsTransparency(int value)
 {
-    d_cursorReadouts->setTransparency(value);
+	d_cursorReadouts->setTransparency(value);
 }
 
-void dBgraph::moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition position)
+void dBgraph::moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition
+				 position)
 {
-    d_cursorReadouts->moveToPosition(position);
+	d_cursorReadouts->moveToPosition(position);
 }
 
 QVector<double> dBgraph::getXAxisData()
 {
 	QVector<double> data;
-	for (unsigned int i = 0; i < curve.data()->size(); ++i) {
+
+	for (int i = 0; i < curve.data()->size(); ++i) {
 		data.push_back(curve.data()->sample(i).x());
 	}
+
 	return data;
 }
 
 QVector<double> dBgraph::getYAxisData()
 {
 	QVector<double> data;
-	for (unsigned int i = 0; i < curve.data()->size(); ++i) {
+
+	for (int i = 0; i < curve.data()->size(); ++i) {
 		data.push_back(curve.data()->sample(i).y());
 	}
+
 	return data;
 }
 
@@ -677,8 +692,8 @@ void dBgraph::scaleDivChanged()
 	this->setAxisScale(QwtPlot::xTop, intv.minValue(), intv.maxValue());
 	this->replot();
 
-    onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
-    onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
+	onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
+	onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
 }
 
 void dBgraph::mousePressEvent(QMouseEvent *event)

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -34,18 +34,26 @@ void dBgraph::setupCursors()
 	d_vBar1 = new VertBar(this,true);
 	d_vBar2 = new VertBar(this,true);
 	d_plotBar = new VertBar(this, true);
+	d_frequencyBar = new VertBar(this, true);
 	d_symbolCtrl->attachSymbol(d_vBar1);
 	d_symbolCtrl->attachSymbol(d_vBar2);
 	d_symbolCtrl->attachSymbol(d_plotBar);
+	d_symbolCtrl->attachSymbol(d_frequencyBar);
 
 	QPen cursorsLinePen = QPen(QColor(155,155,155),1,Qt::DashLine);
 	QPen plotLinePen = QPen(QColor(211, 211, 211, 50), 5, Qt::SolidLine);
+	QPen frequencyLinePen = QPen(QColor(74, 100, 255, 150), 2, Qt::DashLine);
 
 	d_vBar1->setPen(cursorsLinePen);
 	d_vBar2->setPen(cursorsLinePen);
 	d_vBar1->setVisible(false);
 	d_vBar2->setVisible(false);
 	d_plotBar->setVisible(false);
+
+	d_frequencyBar->setPen(frequencyLinePen);
+	d_frequencyBar->setVisible(false);
+	d_frequencyBar->setMobileAxis(QwtPlot::xTop);
+	d_frequencyBar->setPixelPosition(canvas()->width()/2-30);
 
 	d_plotBar->setPen(plotLinePen);
 	d_plotBar->setMobileAxis(QwtPlot::xTop);
@@ -59,6 +67,9 @@ void dBgraph::setupCursors()
 		SLOT(onVbar2PixelPosChanged(int)));
 	connect(d_vBar2, SIGNAL(pixelPositionChanged(int)),
 		SLOT(onCursor2Moved(int)));
+
+	connect(d_frequencyBar, &VertBar::pixelPositionChanged,
+		this, &dBgraph::frequencyBarPositionChanged);
 }
 
 void dBgraph::setupReadouts()
@@ -499,6 +510,19 @@ void dBgraph::sweepDone()
 	d_plotBar->setVisible(false);
 }
 
+void dBgraph::onFrequencyCursorPositionChanged(int pos)
+{
+	d_frequencyBar->setPixelPosition(pos);
+
+	Q_EMIT frequencySelected(d_frequencyBar->plotCoord().x());
+}
+
+void dBgraph::onFrequencyBarMoved(double frequency)
+{
+	auto oldY = d_frequencyBar->plotCoord().y();
+	d_frequencyBar->setPlotCoord(QPointF(frequency, oldY));
+}
+
 void dBgraph::onCursor1PositionChanged(int pos)
 {
 	pos = std::min(pos,QwtPlot::canvas()->width()-1);
@@ -525,6 +549,7 @@ void dBgraph::onVbar2PixelPosChanged(int pos)
 
 void dBgraph::toggleCursors(bool en)
 {
+	d_frequencyBar->setPixelPosition(canvas()->width()/2-30);
 	if (d_cursorsEnabled != en) {
 		if (!d_cursorsCentered) {
 			d_cursorsCentered=true;
@@ -684,6 +709,12 @@ QVector<double> dBgraph::getYAxisData()
 	}
 
 	return data;
+}
+
+void dBgraph::enableFrequencyBar(bool enable)
+{
+	d_frequencyBar->setVisible(enable);
+	d_frequencyBar->setPixelPosition(canvas()->width() / 2);
 }
 
 void dBgraph::setYAxisInterval(double min, double max, double correction)

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -243,6 +243,26 @@ int dBgraph::getNumSamples() const
 	return numSamples;
 }
 
+QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale) const
+{
+	auto *scaleDraw = static_cast<const OscScaleDraw *>(
+				axisScaleDraw(scale));
+
+	return formatter->format(value,
+				 scaleDraw->getUnitType(),
+				 scaleDraw->getFloatPrecison());
+}
+
+QString dBgraph::getScaleValueFormat(double value, QwtAxisId scale, int precision) const
+{
+	auto *scaleDraw = static_cast<const OscScaleDraw *>(
+				axisScaleDraw(scale));
+
+	return formatter->format(value,
+				 scaleDraw->getUnitType(),
+				 precision);
+}
+
 void dBgraph::setShowZero(bool en)
 {
     OscScaleEngine *scaleLeft = new OscScaleEngine();

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -91,7 +91,8 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	ymin(10),
 	ymax(10),
 	d_plotPosition(0),
-	numSamples(0)
+	numSamples(0),
+	delta_label(false)
 {
 	enableAxis(QwtPlot::xBottom, false);
 	enableAxis(QwtPlot::xTop, true);

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -98,6 +98,7 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	plotLayout()->setAlignCanvasToScales(true);
 
 	curve.attach(this);
+	curve.setRenderHint(QwtPlotItem::RenderAntialiased);
 	curve.setXAxis(QwtPlot::xTop);
 	curve.setYAxis(QwtPlot::yLeft);
 

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -51,9 +51,9 @@ void dBgraph::setupCursors()
 	d_plotBar->setVisible(false);
 
 	d_frequencyBar->setPen(frequencyLinePen);
-	d_frequencyBar->setVisible(false);
+	d_frequencyBar->setVisible(true);
 	d_frequencyBar->setMobileAxis(QwtPlot::xTop);
-	d_frequencyBar->setPixelPosition(canvas()->width()/2-30);
+	d_frequencyBar->setPixelPosition(0);
 
 	d_plotBar->setPen(plotLinePen);
 	d_plotBar->setMobileAxis(QwtPlot::xTop);
@@ -70,6 +70,15 @@ void dBgraph::setupCursors()
 
 	connect(d_frequencyBar, &VertBar::pixelPositionChanged,
 		this, &dBgraph::frequencyBarPositionChanged);
+}
+
+void dBgraph::parametersOverrange(bool enable)
+{
+	if (enable) {
+		d_plotBar->setPen(QPen(QColor(250, 0, 0, 50), 5, Qt::SolidLine));
+	} else {
+		d_plotBar->setPen(QPen(QColor(211, 211, 211, 50), 5, Qt::SolidLine));
+	}
 }
 
 void dBgraph::setupReadouts()
@@ -103,7 +112,8 @@ dBgraph::dBgraph(QWidget *parent) : QwtPlot(parent),
 	ymax(10),
 	d_plotPosition(0),
 	numSamples(0),
-	delta_label(false)
+	delta_label(false),
+	d_plotBarEnabled(true)
 {
 	enableAxis(QwtPlot::xBottom, false);
 	enableAxis(QwtPlot::xTop, true);
@@ -247,7 +257,9 @@ void dBgraph::setAxesTitles(const QString& x, const QString& y)
 void dBgraph::plot(double x, double y)
 {
 	if (!d_plotBar->isVisible() && !xdata.size()) {
-		d_plotBar->setVisible(true);
+		if (d_plotBarEnabled) {
+			d_plotBar->setVisible(true);
+		}
 	}
 
 	if (xdata.size() == numSamples) {
@@ -507,7 +519,9 @@ void dBgraph::useDeltaLabel(bool use_delta)
 
 void dBgraph::sweepDone()
 {
-	d_plotBar->setVisible(false);
+	if (d_plotBarEnabled) {
+		d_plotBar->setVisible(false);
+	}
 }
 
 void dBgraph::onFrequencyCursorPositionChanged(int pos)
@@ -549,7 +563,7 @@ void dBgraph::onVbar2PixelPosChanged(int pos)
 
 void dBgraph::toggleCursors(bool en)
 {
-	d_frequencyBar->setPixelPosition(canvas()->width()/2-30);
+	d_frequencyBar->setPixelPosition(0);
 	if (d_cursorsEnabled != en) {
 		if (!d_cursorsCentered) {
 			d_cursorsCentered=true;
@@ -714,7 +728,7 @@ QVector<double> dBgraph::getYAxisData()
 void dBgraph::enableFrequencyBar(bool enable)
 {
 	d_frequencyBar->setVisible(enable);
-	d_frequencyBar->setPixelPosition(canvas()->width() / 2);
+	d_frequencyBar->setPixelPosition(0);
 }
 
 void dBgraph::setYAxisInterval(double min, double max, double correction)
@@ -766,4 +780,9 @@ void dBgraph::showEvent(QShowEvent *event)
 	auto sw = axisWidget(QwtPlot::xTop);
 	sw->scaleDraw()->invalidateCache();
 	sw->repaint();
+}
+
+void dBgraph::setPlotBarEnabled(bool enabled)
+{
+	d_plotBarEnabled = enabled;
 }

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -424,7 +424,7 @@ void dBgraph::useLogFreq(bool use_log_freq)
 		this->setAxisScaleEngine(QwtPlot::xTop, new QwtLogScaleEngine);
 	} else {
 		auto scaleTop = new OscScaleEngine;
-		scaleTop->setMajorTicksCount(8);
+		scaleTop->setMajorTicksCount(9);
 		this->setAxisScaleEngine(QwtPlot::xTop, scaleTop);
 	}
 
@@ -433,7 +433,12 @@ void dBgraph::useLogFreq(bool use_log_freq)
 		onCursor1Moved(d_vBar1->transform(d_vBar1->plotCoord()).x());
 		onCursor2Moved(d_vBar2->transform(d_vBar2->plotCoord()).x());
 	}
+
 	replot();
+
+	auto sw = axisWidget(QwtPlot::xTop);
+	sw->scaleDraw()->invalidateCache();
+	sw->repaint();
 }
 
 void dBgraph::onCursor1PositionChanged(int pos)
@@ -635,4 +640,11 @@ void dBgraph::mousePressEvent(QMouseEvent *event)
 void dBgraph::onResetZoom()
 {
 	zoomer->resetZoom();
+}
+
+void dBgraph::showEvent(QShowEvent *event)
+{
+	auto sw = axisWidget(QwtPlot::xTop);
+	sw->scaleDraw()->invalidateCache();
+	sw->repaint();
 }

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -90,6 +90,7 @@ public:
 	QVector<double> getXAxisData();
 	QVector<double> getYAxisData();
 
+	void setYAxisInterval(double min, double max, double correction);
 Q_SIGNALS:
 	void VBar1PixelPosChanged(int);
 	void VBar2PixelPosChanged(int);

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -31,52 +31,52 @@
 #include "plotpickerwrapper.h"
 
 namespace adiscope {
-	class OscScaleDraw;
-	class PrefixFormatter;
-	class OscScaleZoomer;
+class OscScaleDraw;
+class PrefixFormatter;
+class OscScaleZoomer;
 
-	class dBgraph : public QwtPlot
-	{
-		Q_OBJECT
+class dBgraph : public QwtPlot
+{
+	Q_OBJECT
 
-		Q_PROPERTY(int numSamples
-				READ getNumSamples
-				WRITE setNumSamples
-		)
+	Q_PROPERTY(int numSamples
+		   READ getNumSamples
+		   WRITE setNumSamples
+		  )
 
-		Q_PROPERTY(QColor color
-				READ getColor
-				WRITE setColor
-		)
+	Q_PROPERTY(QColor color
+		   READ getColor
+		   WRITE setColor
+		  )
 
-		Q_PROPERTY(QString xaxis_title READ xTitle WRITE setXTitle);
-		Q_PROPERTY(QString yaxis_title READ yTitle WRITE setYTitle);
+	Q_PROPERTY(QString xaxis_title READ xTitle WRITE setXTitle);
+	Q_PROPERTY(QString yaxis_title READ yTitle WRITE setYTitle);
 
-		Q_PROPERTY(double xmin MEMBER xmin WRITE setXMin);
-		Q_PROPERTY(double xmax MEMBER xmax WRITE setXMax);
-		Q_PROPERTY(double ymin MEMBER ymin WRITE setYMin);
-		Q_PROPERTY(double ymax MEMBER ymax WRITE setYMax);
+	Q_PROPERTY(double xmin MEMBER xmin WRITE setXMin);
+	Q_PROPERTY(double xmax MEMBER xmax WRITE setXMax);
+	Q_PROPERTY(double ymin MEMBER ymin WRITE setYMin);
+	Q_PROPERTY(double ymax MEMBER ymax WRITE setYMax);
 
-		Q_PROPERTY(QString xunit READ xUnit WRITE setXUnit);
-		Q_PROPERTY(QString yunit READ yUnit WRITE setYUnit);
+	Q_PROPERTY(QString xunit READ xUnit WRITE setXUnit);
+	Q_PROPERTY(QString yunit READ yUnit WRITE setYUnit);
 
-		Q_PROPERTY(bool log_freq MEMBER log_freq WRITE useLogFreq);
+	Q_PROPERTY(bool log_freq MEMBER log_freq WRITE useLogFreq);
 
-	public:
-		explicit dBgraph(QWidget *parent = nullptr);
-		~dBgraph();
+public:
+	explicit dBgraph(QWidget *parent = nullptr);
+	~dBgraph();
 
-		void setAxesScales(double xmin, double xmax,
-				double ymin, double ymax);
-		void setAxesTitles(const QString& x, const QString& y);
+	void setAxesScales(double xmin, double xmax,
+			   double ymin, double ymax);
+	void setAxesTitles(const QString& x, const QString& y);
 
-		int getNumSamples() const;
+	int getNumSamples() const;
 
-		QString getScaleValueFormat(double value, QwtAxisId scale) const;
-		QString getScaleValueFormat(double value, QwtAxisId scale, int precision) const;
+	QString getScaleValueFormat(double value, QwtAxisId scale) const;
+	QString getScaleValueFormat(double value, QwtAxisId scale, int precision) const;
 
-        void setShowZero(bool en);
-        const QwtScaleWidget* getAxisWidget(QwtAxisId id);
+	void setShowZero(bool en);
+	const QwtScaleWidget *getAxisWidget(QwtAxisId id);
 
 	const QColor& getColor() const;
 	double getThickness();
@@ -84,7 +84,7 @@ namespace adiscope {
 	QString yTitle() const;
 
 	void toggleCursors(bool);
-    CustomPlotPositionButton::ReadoutsPosition getCursorReadoutCurrentPosition();
+	CustomPlotPositionButton::ReadoutsPosition getCursorReadoutCurrentPosition();
 
 	QString cursorIntersection(qreal text);
 	QVector<double> getXAxisData();
@@ -93,81 +93,82 @@ namespace adiscope {
 Q_SIGNALS:
 	void VBar1PixelPosChanged(int);
 	void VBar2PixelPosChanged(int);
-    void resetZoom();
 
-    public Q_SLOTS:
-		void plot(double x, double y);
-		void reset();
+	void resetZoom();
 
-		void setNumSamples(int num);
-		void setColor(const QColor& color);
-		void setThickness(int index);
-		void setXTitle(const QString& title);
-		void setYTitle(const QString& title);
-		void setXMin(double val);
-		void setXMax(double val);
-		void setYMin(double val);
-		void setYMax(double val);
+public Q_SLOTS:
+	void plot(double x, double y);
+	void reset();
 
-		QString xUnit() const;
-		QString yUnit() const;
-		void setXUnit(const QString& unit);
-		void setYUnit(const QString& unit);
+	void setNumSamples(int num);
+	void setColor(const QColor& color);
+	void setThickness(int index);
+	void setXTitle(const QString& title);
+	void setYTitle(const QString& title);
+	void setXMin(double val);
+	void setXMax(double val);
+	void setYMin(double val);
+	void setYMax(double val);
 
-		void useLogFreq(bool use_log_freq);
-		void useDeltaLabel(bool use_delta);
-		void sweepDone();
+	QString xUnit() const;
+	QString yUnit() const;
+	void setXUnit(const QString& unit);
+	void setYUnit(const QString& unit);
 
-        void onVbar1PixelPosChanged(int pos);
-        void onVbar2PixelPosChanged(int pos);
+	void useLogFreq(bool use_log_freq);
+	void useDeltaLabel(bool use_delta);
+	void sweepDone();
 
-        void onCursor1PositionChanged(int pos);
-        void onCursor2PositionChanged(int pos);
+	void onVbar1PixelPosChanged(int pos);
+	void onVbar2PixelPosChanged(int pos);
 
-        void onCursor1Moved(int);
-        void onCursor2Moved(int);
+	void onCursor1PositionChanged(int pos);
+	void onCursor2PositionChanged(int pos);
 
-        void setCursorReadoutsTransparency(int value);
-        void moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition position);
+	void onCursor1Moved(int);
+	void onCursor2Moved(int);
 
-        void scaleDivChanged();
-        void mousePressEvent(QMouseEvent *event);
-        void onResetZoom();
+	void setCursorReadoutsTransparency(int value);
+	void moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition position);
 
-	protected Q_SLOTS:
-		void showEvent(QShowEvent *event);
+	void scaleDivChanged();
+	void mousePressEvent(QMouseEvent *event);
+	void onResetZoom();
 
-	private:
-		QwtPlotCurve curve;
-		QwtPlotMarker *markerIntersection1;
-		QwtPlotMarker *markerIntersection2;
-		int numSamples;
-		double xmin, xmax, ymin, ymax;
-		QColor color;
-		double thickness;
-		bool log_freq;
-		bool delta_label;
+protected Q_SLOTS:
+	void showEvent(QShowEvent *event);
 
-        bool d_cursorsEnabled;
-        bool d_cursorsCentered;
-		OscScaleDraw *draw_x, *draw_y;
-		PrefixFormatter *formatter;
-		OscScaleZoomer *zoomer;
+private:
+	QwtPlotCurve curve;
+	QwtPlotMarker *markerIntersection1;
+	QwtPlotMarker *markerIntersection2;
+	unsigned int numSamples;
+	double xmin, xmax, ymin, ymax;
+	QColor color;
+	double thickness;
+	bool log_freq;
+	bool delta_label;
 
-		QVector<double> xdata, ydata;
-		unsigned int d_plotPosition;
+	bool d_cursorsEnabled;
+	bool d_cursorsCentered;
+	OscScaleDraw *draw_x, *draw_y;
+	PrefixFormatter *formatter;
+	OscScaleZoomer *zoomer;
 
-        SymbolController *d_symbolCtrl;
-        VertBar *d_vBar1;
-        VertBar *d_vBar2;
+	QVector<double> xdata, ydata;
+	unsigned int d_plotPosition;
+
+	SymbolController *d_symbolCtrl;
+	VertBar *d_vBar1;
+	VertBar *d_vBar2;
 	VertBar *d_plotBar;
 
-        PlotPickerWrapper* picker;
+	PlotPickerWrapper *picker;
 
-        CursorReadouts *d_cursorReadouts;
-        void setupCursors();
-        void setupReadouts();
-        };
+	CursorReadouts *d_cursorReadouts;
+	void setupCursors();
+	void setupReadouts();
+};
 }
 
 #endif /* DBGRAPH_HPP */

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -71,6 +71,10 @@ namespace adiscope {
 		void setAxesTitles(const QString& x, const QString& y);
 
 		int getNumSamples() const;
+
+		QString getScaleValueFormat(double value, QwtAxisId scale) const;
+		QString getScaleValueFormat(double value, QwtAxisId scale, int precision) const;
+
         void setShowZero(bool en);
         const QwtScaleWidget* getAxisWidget(QwtAxisId id);
 

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -132,6 +132,9 @@ Q_SIGNALS:
         void mousePressEvent(QMouseEvent *event);
         void onResetZoom();
 
+	protected Q_SLOTS:
+		void showEvent(QShowEvent *event);
+
 	private:
 		QwtPlotCurve curve;
 		QwtPlotMarker *markerIntersection1;

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -116,6 +116,7 @@ Q_SIGNALS:
 
 		void useLogFreq(bool use_log_freq);
 		void useDeltaLabel(bool use_delta);
+		void sweepDone();
 
         void onVbar1PixelPosChanged(int pos);
         void onVbar2PixelPosChanged(int pos);
@@ -153,11 +154,13 @@ Q_SIGNALS:
 		PrefixFormatter *formatter;
 		OscScaleZoomer *zoomer;
 
-		CustomFifo<double> xdata, ydata;
+		QVector<double> xdata, ydata;
+		unsigned int d_plotPosition;
 
         SymbolController *d_symbolCtrl;
         VertBar *d_vBar1;
         VertBar *d_vBar2;
+	VertBar *d_plotBar;
 
         PlotPickerWrapper* picker;
 

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -115,6 +115,7 @@ Q_SIGNALS:
 		void setYUnit(const QString& unit);
 
 		void useLogFreq(bool use_log_freq);
+		void useDeltaLabel(bool use_delta);
 
         void onVbar1PixelPosChanged(int pos);
         void onVbar2PixelPosChanged(int pos);
@@ -144,6 +145,7 @@ Q_SIGNALS:
 		QColor color;
 		double thickness;
 		bool log_freq;
+		bool delta_label;
 
         bool d_cursorsEnabled;
         bool d_cursorsCentered;

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -93,6 +93,8 @@ public:
 	void enableFrequencyBar(bool enable);
 	void setYAxisInterval(double min, double max, double correction);
 
+	void setPlotBarEnabled(bool enabled);
+	void parametersOverrange(bool enable);
 Q_SIGNALS:
 	void VBar1PixelPosChanged(int);
 	void VBar2PixelPosChanged(int);
@@ -156,6 +158,7 @@ private:
 	double thickness;
 	bool log_freq;
 	bool delta_label;
+	bool d_plotBarEnabled;
 
 	bool d_cursorsEnabled;
 	bool d_cursorsCentered;

--- a/src/dbgraph.hpp
+++ b/src/dbgraph.hpp
@@ -90,12 +90,16 @@ public:
 	QVector<double> getXAxisData();
 	QVector<double> getYAxisData();
 
+	void enableFrequencyBar(bool enable);
 	void setYAxisInterval(double min, double max, double correction);
+
 Q_SIGNALS:
 	void VBar1PixelPosChanged(int);
 	void VBar2PixelPosChanged(int);
 
 	void resetZoom();
+	void frequencySelected(double);
+	void frequencyBarPositionChanged(int);
 
 public Q_SLOTS:
 	void plot(double x, double y);
@@ -136,6 +140,9 @@ public Q_SLOTS:
 	void mousePressEvent(QMouseEvent *event);
 	void onResetZoom();
 
+	void onFrequencyCursorPositionChanged(int pos);
+	void onFrequencyBarMoved(double frequency);
+
 protected Q_SLOTS:
 	void showEvent(QShowEvent *event);
 
@@ -163,6 +170,7 @@ private:
 	VertBar *d_vBar1;
 	VertBar *d_vBar2;
 	VertBar *d_plotBar;
+	VertBar *d_frequencyBar;
 
 	PlotPickerWrapper *picker;
 

--- a/src/filter_dc_offset_block.cpp
+++ b/src/filter_dc_offset_block.cpp
@@ -1,0 +1,42 @@
+#include "filter_dc_offset_block.h"
+
+#include <volk/volk.h>
+#include <iostream>
+
+using namespace adiscope;
+
+filter_dc_offset_block::filter_dc_offset_block(unsigned int buffer_size):
+	gr::sync_block("dc_offset_filter_block",
+		       gr::io_signature::make(1, 1, buffer_size * sizeof(float)),
+		       gr::io_signature::make(1, 1, buffer_size * sizeof(float))),
+	d_buffer_size(buffer_size)
+{
+}
+
+filter_dc_offset_block::~filter_dc_offset_block()
+{
+}
+
+int filter_dc_offset_block::work(int noutput_items,
+				 gr_vector_const_void_star &input_items,
+				 gr_vector_void_star &output_items)
+{
+	float sum;
+
+	const float* in = static_cast<const float *>(input_items[0]);
+	float* out = static_cast<float *>(output_items[0]);
+
+	volk_32f_accumulator_s32f(&sum, in, d_buffer_size);
+
+	float avg = (sum / (float)d_buffer_size);
+
+	for (unsigned int i = 0 ; i < d_buffer_size; ++i) {
+		out[i] = in[i] - avg;
+	}
+
+	std::cout << "Number of items: " << d_buffer_size << std::endl;
+	std::cout << "Sum of items: " << sum << std::endl;
+	std::cout << "Average of items: " << avg << std::endl;
+
+	return noutput_items;
+}

--- a/src/filter_dc_offset_block.cpp
+++ b/src/filter_dc_offset_block.cpp
@@ -5,11 +5,11 @@
 
 using namespace adiscope;
 
-filter_dc_offset_block::filter_dc_offset_block(unsigned int buffer_size):
+filter_dc_offset_block::filter_dc_offset_block(unsigned int buffer_size, bool enabled):
 	gr::sync_block("dc_offset_filter_block",
 		       gr::io_signature::make(1, 1, buffer_size * sizeof(float)),
 		       gr::io_signature::make(1, 1, buffer_size * sizeof(float))),
-	d_buffer_size(buffer_size)
+	d_buffer_size(buffer_size), d_dc_offset(0.0), d_enabled(enabled)
 {
 }
 
@@ -17,26 +17,33 @@ filter_dc_offset_block::~filter_dc_offset_block()
 {
 }
 
+float filter_dc_offset_block::get_dc_offset() const
+{
+	return d_dc_offset;
+}
+
 int filter_dc_offset_block::work(int noutput_items,
 				 gr_vector_const_void_star &input_items,
 				 gr_vector_void_star &output_items)
 {
-	float sum;
-
 	const float* in = static_cast<const float *>(input_items[0]);
 	float* out = static_cast<float *>(output_items[0]);
 
+	float sum = 0.0;
 	volk_32f_accumulator_s32f(&sum, in, d_buffer_size);
 
 	float avg = (sum / (float)d_buffer_size);
 
-	for (unsigned int i = 0 ; i < d_buffer_size; ++i) {
-		out[i] = in[i] - avg;
+	if (d_enabled) {
+		for (unsigned int i = 0 ; i < d_buffer_size; ++i) {
+			out[i] = in[i] - avg;
+		}
+	}  else {
+		memcpy(out, in, d_buffer_size * sizeof(float));
 	}
 
-	std::cout << "Number of items: " << d_buffer_size << std::endl;
-	std::cout << "Sum of items: " << sum << std::endl;
-	std::cout << "Average of items: " << avg << std::endl;
+	// Save dc offset
+	d_dc_offset = avg;
 
 	return noutput_items;
 }

--- a/src/filter_dc_offset_block.h
+++ b/src/filter_dc_offset_block.h
@@ -1,0 +1,22 @@
+#ifndef FILTER_DC_OFFSET_BLOCK_H
+#define FILTER_DC_OFFSET_BLOCK_H
+
+#include <gnuradio/sync_block.h>
+
+namespace adiscope {
+class filter_dc_offset_block : public gr::sync_block
+{
+public:
+	explicit filter_dc_offset_block(unsigned int buffer_size);
+	~filter_dc_offset_block();
+
+	int work(int noutput_items,
+		 gr_vector_const_void_star &input_items,
+		 gr_vector_void_star &output_items);
+
+private:
+	unsigned d_buffer_size;
+};
+}
+
+#endif // FILTER_DC_OFFSET_BLOCK_H

--- a/src/filter_dc_offset_block.h
+++ b/src/filter_dc_offset_block.h
@@ -7,8 +7,10 @@ namespace adiscope {
 class filter_dc_offset_block : public gr::sync_block
 {
 public:
-	explicit filter_dc_offset_block(unsigned int buffer_size);
+	explicit filter_dc_offset_block(unsigned int buffer_size, bool enabled);
 	~filter_dc_offset_block();
+
+	float get_dc_offset() const;
 
 	int work(int noutput_items,
 		 gr_vector_const_void_star &input_items,
@@ -16,6 +18,8 @@ public:
 
 private:
 	unsigned d_buffer_size;
+	float d_dc_offset;
+	bool d_enabled;
 };
 }
 

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -1602,6 +1602,7 @@ void NetworkAnalyzer::readPreferences()
 {
 	m_dBgraph.setShowZero(prefPanel->getNa_show_zero());
 	m_phaseGraph.setShowZero(prefPanel->getNa_show_zero());
+	autoAdjustGain = prefPanel->getNaGainUpdateEnabled();
 }
 
 void NetworkAnalyzer::onGraphIndexChanged(int index)

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -72,7 +72,7 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	adc_dev(adc_dev),
 	d_cursorsEnabled(false),
 	stop(true), amp1(nullptr), amp2(nullptr),
-	wheelEventGuard(nullptr)
+	wheelEventGuard(nullptr), wasChecked(false)
 {
 	iio = iio_manager::get_instance(ctx,
 			filt->device_name(TOOL_NETWORK_ANALYZER, 2));
@@ -244,6 +244,7 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
     connect(ui->btnIsLog, SIGNAL(toggled(bool)),
             &m_phaseGraph, SLOT(useLogFreq(bool)));
 
+
     connect(ui->cbLineThickness,SIGNAL(currentIndexChanged(int)),&m_dBgraph,SLOT(setThickness(int)));
     connect(ui->cbLineThickness,SIGNAL(currentIndexChanged(int)),&m_phaseGraph,SLOT(setThickness(int)));
     connect(ui->cbLineThickness,SIGNAL(currentIndexChanged(int)),ui->nicholsgraph,SLOT(setThickness(int)));
@@ -360,6 +361,20 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	img.save(fileName, 0, -1);
     });
 
+
+    connect(ui->deltaBtn, &QPushButton::toggled,
+	    &m_dBgraph, &dBgraph::useDeltaLabel);
+    connect(ui->deltaBtn, &QPushButton::toggled,
+	    &m_phaseGraph, &dBgraph::useDeltaLabel);
+    connect(ui->btnIsLog, &QPushButton::toggled, [=](bool checked) {
+	    ui->deltaBtn->setDisabled(checked);
+	    if (checked) {
+		    wasChecked = ui->deltaBtn->isChecked();
+		    ui->deltaBtn->setChecked(false);
+	    } else {
+		    ui->deltaBtn->setChecked(wasChecked);
+	    }
+    });
 }
 
 NetworkAnalyzer::~NetworkAnalyzer()

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -335,7 +335,7 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 
 	ui->pushDelayLayout->addWidget(pushDelay);
 	ui->captureDelayLayout->addWidget(captureDelay);
-	ui->samplesCountLayout->addWidget(samplesCount);
+	startStopRange->insertWidgetIntoLayout(samplesCount, 2, 1);
 	ui->amplitudeLayout->addWidget(amplitude);
 	ui->offsetLayout->addWidget(offset);
 	ui->magMaxLayout->addWidget(magMax);

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -893,6 +893,7 @@ void NetworkAnalyzer::updateNumSamples(bool force)
 	m_phaseGraph.setNumSamples(num_samples);
 	ui->xygraph->setNumSamples(num_samples);
 	ui->nicholsgraph->setNumSamples(num_samples);
+	bufferPreviewer->setNumBuffers(num_samples);
 
 	if (QObject::sender() == samplesCount) {
 		computeIterations();
@@ -946,8 +947,6 @@ void NetworkAnalyzer::run()
 
 
 	fixedRate = sampleRates[0];
-
-	bufferPreviewer->clear();
 
 	justStarted = true;
 
@@ -1450,6 +1449,7 @@ void NetworkAnalyzer::startStop(bool pressed)
 			ui->nicholsgraph->reset();
 			updateNumSamples(true);
 		}
+		bufferPreviewer->clear();
 		configHwForNetworkAnalyzing();
 		thd = QtConcurrent::run(this, &NetworkAnalyzer::run);
 		stop = false;

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -286,6 +286,12 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	connect(span_freq, &ScaleSpinButton::valueChanged,
 		this, &NetworkAnalyzer::onCenterSpanFrequencyChanged);
 
+	connect(phaseMin, &PositionSpinButton::valueChanged,
+		this, &NetworkAnalyzer::onMinMaxPhaseChanged);
+	connect(phaseMax, &PositionSpinButton::valueChanged,
+		this, &NetworkAnalyzer::onMinMaxPhaseChanged);
+
+
 	connect(ui->cbLineThickness,SIGNAL(currentIndexChanged(int)),&m_dBgraph,
 		SLOT(setThickness(int)));
 	connect(ui->cbLineThickness,SIGNAL(currentIndexChanged(int)),&m_phaseGraph,
@@ -552,6 +558,21 @@ void NetworkAnalyzer::onCenterSpanFrequencyChanged(double value)
 	m_phaseGraph.setXMax(stop);
 	updateNumSamples();
 }
+void NetworkAnalyzer::onMinMaxPhaseChanged(double value) {
+
+	if (QObject::sender() == phaseMin) {
+		double phaseMaxValue = phaseMax->value();
+		if (qAbs(phaseMaxValue - value) > 360) {
+			phaseMax->setValue(phaseMaxValue - ((int)qAbs(phaseMaxValue - value) % 360));
+		}
+	} else {
+		double phaseMinValue = phaseMin->value();
+		if (qAbs(value - phaseMinValue) > 360) {
+			phaseMin->setValue(phaseMinValue + ((int)qAbs(value - phaseMinValue) % 360));
+		}
+	} 
+}
+
 void NetworkAnalyzer::setMinimumDistanceBetween(SpinBoxA *min, SpinBoxA *max,
 		double distance)
 {
@@ -1033,9 +1054,16 @@ void NetworkAnalyzer::plot(double frequency, double mag1, double mag2,
 	}
 
 	double phase_deg = phase * 180.0 / M_PI;
+	double adjusted_phase_deg = phase_deg;
+
+//	if (phase_deg > phaseMax->value()) {
+//		adjusted_phase_deg = (int)phase_deg - 360;
+//	} else if (phase_deg < phaseMin->value()) {
+//		adjusted_phase_deg = (int)phase_deg + 360;
+//	}
 
 	m_dBgraph.plot(frequency, mag);
-	m_phaseGraph.plot(frequency, phase_deg);
+	m_phaseGraph.plot(frequency, adjusted_phase_deg);
 	ui->xygraph->plot(frequency, mag);
 	ui->nicholsgraph->plot(phase_deg, mag);
 }

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -30,6 +30,12 @@
 #include <QtConcurrentRun>
 #include "customPushButton.hpp"
 #include "scroll_filter.hpp"
+#include <gnuradio/top_block.h>
+#include <gnuradio/blocks/head.h>
+#include <gnuradio/blocks/vector_sink_s.h>
+#include <gnuradio/analog/sig_source_f.h>
+#include <gnuradio/blocks/float_to_short.h>
+
 
 
 extern "C" {
@@ -67,46 +73,78 @@ namespace adiscope {
 
 	private:
 		Ui::NetworkAnalyzer *ui;
-		struct iio_channel *dac1, *dac2, *amp1, *amp2;
+		struct iio_channel *amp1, *amp2;
+		std::vector<iio_channel *> dac_channels;
 		struct iio_device *adc;
 		std::shared_ptr<GenericAdc> adc_dev;
 		boost::shared_ptr<iio_manager> iio;
-        dBgraph m_dBgraph;
+
+		// Sine generation blocks
+		gr::top_block_sptr top_block;
+		gr::analog::sig_source_f::sptr source_block;
+		gr::blocks::float_to_short::sptr f2s_block;
+		gr::blocks::head::sptr head_block;
+		gr::blocks::vector_sink_s::sptr vector_block;
+
+		QVector<unsigned long> sampleRates;
+		size_t fixedRate;
+
+
+
+	dBgraph m_dBgraph;
 	dBgraph m_phaseGraph;
 	bool wasChecked;
 
-        PlotLineHandleH *d_hCursorHandle1;
-        PlotLineHandleH *d_hCursorHandle2;
-        bool d_cursorsEnabled;
+	typedef struct NetworkAnalyzerIteration {
+		NetworkAnalyzerIteration():
+			frequency(0),
+			rate(0),
+			bufferSize(0) {}
+		NetworkAnalyzerIteration(double frequency,
+					 size_t rate,
+					 size_t bufferSize):
+			frequency(frequency),
+			rate(rate),
+			bufferSize(bufferSize) {}
 
-        ScaleSpinButton *samplesCount;
-        ScaleSpinButton *minFreq;
-        ScaleSpinButton *maxFreq;
-        ScaleSpinButton *amplitude;
-        PositionSpinButton *offset;
-        PositionSpinButton *magMax;
-        PositionSpinButton *magMin;
-        PositionSpinButton *phaseMax;
-        PositionSpinButton *phaseMin;
+		double frequency;
+		size_t rate;
+		size_t bufferSize;
+		size_t adcRate;
+		size_t adcBuffer;
+	} networkIteration;
+
+	QVector<networkIteration> iterations;
+
+
+	PlotLineHandleH *d_hCursorHandle1;
+	PlotLineHandleH *d_hCursorHandle2;
+	bool d_cursorsEnabled;
+
+	ScaleSpinButton *samplesCount;
+	ScaleSpinButton *minFreq;
+	ScaleSpinButton *maxFreq;
+	ScaleSpinButton *amplitude;
+	PositionSpinButton *offset;
+	PositionSpinButton *magMax;
+	PositionSpinButton *magMin;
+	PositionSpinButton *phaseMax;
+	PositionSpinButton *phaseMin;
+
 	void setMinimumDistanceBetween(SpinBoxA *min, SpinBoxA *max, double distance);
 
-        HorizHandlesArea *d_bottomHandlesArea;
+	HorizHandlesArea *d_bottomHandlesArea;
 
-        QQueue<QPair<CustomPushButton *, bool>> menuButtonActions;
+	QQueue<QPair<CustomPushButton *, bool>> menuButtonActions;
 
-        MouseWheelWidgetGuard *wheelEventGuard;
+	MouseWheelWidgetGuard *wheelEventGuard;
 
 		QFuture<void> thd;
 		bool stop;
 
 		void run();
 
-		static size_t get_sin_samples_count(
-				const struct iio_device *dev,
-				unsigned long rate,
-				double frequency);
-
-		static struct iio_buffer * generateSinWave(
+		struct iio_buffer * generateSinWave(
 				const struct iio_device *dev,
 				double frequency,
 				double amplitude,
@@ -114,29 +152,31 @@ namespace adiscope {
 				unsigned long rate,
 				size_t samples_count);
 
-		static unsigned long get_best_sample_rate(
-				const struct iio_device *dev,
-				double frequency);
 		void configHwForNetworkAnalyzing();
 
 		void triggerRightMenuToggle(CustomPushButton *btn, bool checked);
 		void toggleRightMenu(CustomPushButton *btn, bool checked);
 
+		void computeFrequencyArray();
+                void updateGainMode();
+		void computeCaptureParams(double frequency, size_t &buffer_size, size_t &adc_rate);
+
 	private Q_SLOTS:
 		void startStop(bool start);
-		void updateNumSamples();
+		void updateNumSamples(bool force = false);
+		void plot(double frequency, double mag, double mag2, double phase);
 
-        void toggleCursors(bool en);
-        void onVbar1PixelPosChanged(int pos);
-        void onVbar2PixelPosChanged(int pos);
-        void readPreferences();
-        void onGraphIndexChanged(int);
-        void on_btnExport_clicked();
-        void rightMenuFinished(bool opened);
+	void toggleCursors(bool en);
+	void onVbar1PixelPosChanged(int pos);
+	void onVbar2PixelPosChanged(int pos);
+	void readPreferences();
+	void onGraphIndexChanged(int);
+	void on_btnExport_clicked();
+	void rightMenuFinished(bool opened);
 
-        public Q_SLOTS:
+	public Q_SLOTS:
 
-        void showEvent(QShowEvent *event);
+	void showEvent(QShowEvent *event);
 
 	Q_SIGNALS:
 		void sweepDone();

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -132,6 +132,8 @@ private:
 	PositionSpinButton *magMin;
 	PositionSpinButton *phaseMax;
 	PositionSpinButton *phaseMin;
+	PositionSpinButton *pushDelay;
+	PositionSpinButton *captureDelay;
 
 	void setMinimumDistanceBetween(SpinBoxA *min, SpinBoxA *max, double distance);
 

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -46,48 +46,48 @@ extern "C" {
 }
 
 namespace Ui {
-	class NetworkAnalyzer;
+class NetworkAnalyzer;
 }
 
 class QPushButton;
 class QJSEngine;
 
 namespace adiscope {
-	class NetworkAnalyzer_API;
-	class Filter;
-	class GenericAdc;
+class NetworkAnalyzer_API;
+class Filter;
+class GenericAdc;
 
-	class NetworkAnalyzer : public Tool
-	{
-		friend class NetworkAnalyzer_API;
-		friend class ToolLauncher_API;
+class NetworkAnalyzer : public Tool
+{
+	friend class NetworkAnalyzer_API;
+	friend class ToolLauncher_API;
 
-		Q_OBJECT
+	Q_OBJECT
 
-	public:
-		explicit NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
-				std::shared_ptr<GenericAdc> &adc_dev,
-				QPushButton *runButton, QJSEngine *engine,
-				ToolLauncher *parent);
-		~NetworkAnalyzer();
+public:
+	explicit NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
+				 std::shared_ptr<GenericAdc>& adc_dev,
+				 QPushButton *runButton, QJSEngine *engine,
+				 ToolLauncher *parent);
+	~NetworkAnalyzer();
 
-	private:
-		Ui::NetworkAnalyzer *ui;
-		struct iio_channel *amp1, *amp2;
-		std::vector<iio_channel *> dac_channels;
-		struct iio_device *adc;
-		std::shared_ptr<GenericAdc> adc_dev;
-		boost::shared_ptr<iio_manager> iio;
+private:
+	Ui::NetworkAnalyzer *ui;
+	struct iio_channel *amp1, *amp2;
+	std::vector<iio_channel *> dac_channels;
+	struct iio_device *adc;
+	std::shared_ptr<GenericAdc> adc_dev;
+	boost::shared_ptr<iio_manager> iio;
 
-		// Sine generation blocks
-		gr::top_block_sptr top_block;
-		gr::analog::sig_source_f::sptr source_block;
-		gr::blocks::float_to_short::sptr f2s_block;
-		gr::blocks::head::sptr head_block;
-		gr::blocks::vector_sink_s::sptr vector_block;
+	// Sine generation blocks
+	gr::top_block_sptr top_block;
+	gr::analog::sig_source_f::sptr source_block;
+	gr::blocks::float_to_short::sptr f2s_block;
+	gr::blocks::head::sptr head_block;
+	gr::blocks::vector_sink_s::sptr vector_block;
 
-		QVector<unsigned long> sampleRates;
-		size_t fixedRate;
+	QVector<unsigned long> sampleRates;
+	size_t fixedRate;
 
 
 
@@ -139,32 +139,33 @@ namespace adiscope {
 
 	MouseWheelWidgetGuard *wheelEventGuard;
 
-		QFuture<void> thd;
-		bool stop;
+	QFuture<void> thd;
+	bool stop;
 
-		void run();
+	void run();
 
-		struct iio_buffer * generateSinWave(
-				const struct iio_device *dev,
-				double frequency,
-				double amplitude,
-				double offset,
-				unsigned long rate,
-				size_t samples_count);
+	struct iio_buffer *generateSinWave(
+		const struct iio_device *dev,
+		double frequency,
+		double amplitude,
+		double offset,
+		unsigned long rate,
+		size_t samples_count);
 
-		void configHwForNetworkAnalyzing();
+	void configHwForNetworkAnalyzing();
 
-		void triggerRightMenuToggle(CustomPushButton *btn, bool checked);
-		void toggleRightMenu(CustomPushButton *btn, bool checked);
+	void triggerRightMenuToggle(CustomPushButton *btn, bool checked);
+	void toggleRightMenu(CustomPushButton *btn, bool checked);
 
-		void computeFrequencyArray();
-                void updateGainMode();
-		void computeCaptureParams(double frequency, size_t &buffer_size, size_t &adc_rate);
+	void computeFrequencyArray();
+	void updateGainMode();
+	void computeCaptureParams(double frequency, size_t& buffer_size,
+				  size_t& adc_rate);
 
-	private Q_SLOTS:
-		void startStop(bool start);
-		void updateNumSamples(bool force = false);
-		void plot(double frequency, double mag, double mag2, double phase);
+private Q_SLOTS:
+	void startStop(bool start);
+	void updateNumSamples(bool force = false);
+	void plot(double frequency, double mag, double mag2, double phase);
 
 	void toggleCursors(bool en);
 	void onVbar1PixelPosChanged(int pos);
@@ -174,14 +175,14 @@ namespace adiscope {
 	void on_btnExport_clicked();
 	void rightMenuFinished(bool opened);
 
-	public Q_SLOTS:
+public Q_SLOTS:
 
 	void showEvent(QShowEvent *event);
 
-	Q_SIGNALS:
-		void sweepDone();
-		void showTool();
-	};
+Q_SIGNALS:
+	void sweepDone();
+	void showTool();
+};
 } /* namespace adiscope */
 
 #endif /* SCOPY_NETWORK_ANALYZER_HPP */

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -72,7 +72,8 @@ namespace adiscope {
 		std::shared_ptr<GenericAdc> adc_dev;
 		boost::shared_ptr<iio_manager> iio;
         dBgraph m_dBgraph;
-        dBgraph m_phaseGraph;
+	dBgraph m_phaseGraph;
+	bool wasChecked;
 
         PlotLineHandleH *d_hCursorHandle1;
         PlotLineHandleH *d_hCursorHandle2;

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -122,8 +122,10 @@ private:
 	bool d_cursorsEnabled;
 
 	ScaleSpinButton *samplesCount;
-	ScaleSpinButton *minFreq;
-	ScaleSpinButton *maxFreq;
+	ScaleSpinButton *start_freq;
+	ScaleSpinButton *stop_freq;
+	ScaleSpinButton *center_freq;
+	ScaleSpinButton *span_freq;
 	ScaleSpinButton *amplitude;
 	PositionSpinButton *offset;
 	PositionSpinButton *magMax;
@@ -175,6 +177,8 @@ private Q_SLOTS:
 	void on_btnExport_clicked();
 	void rightMenuFinished(bool opened);
 
+	void onStartStopFrequencyChanged(double value);
+	void onCenterSpanFrequencyChanged(double value);
 public Q_SLOTS:
 
 	void showEvent(QShowEvent *event);

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -179,6 +179,7 @@ private Q_SLOTS:
 
 	void onStartStopFrequencyChanged(double value);
 	void onCenterSpanFrequencyChanged(double value);
+	void onMinMaxPhaseChanged(double value);
 public Q_SLOTS:
 
 	void showEvent(QShowEvent *event);

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -40,6 +40,7 @@
 #include "TimeDomainDisplayPlot.h"
 
 #include "networkanalyzerbufferviewer.h"
+#include "startstoprangewidget.h"
 
 extern "C" {
 	struct iio_buffer;
@@ -135,6 +136,8 @@ private:
 	NetworkAnalyzerBufferViewer *bufferPreviewer;
 	QVector<Buffer> capturedData;
 
+	StartStopRangeWidget *startStopRange;
+
 	bool justStarted;
 	bool autoAdjustGain;
 
@@ -144,10 +147,6 @@ private:
 	bool d_cursorsEnabled;
 
 	ScaleSpinButton *samplesCount;
-	ScaleSpinButton *start_freq;
-	ScaleSpinButton *stop_freq;
-	ScaleSpinButton *center_freq;
-	ScaleSpinButton *span_freq;
 	ScaleSpinButton *amplitude;
 	PositionSpinButton *offset;
 	PositionSpinButton *magMax;
@@ -206,9 +205,6 @@ private Q_SLOTS:
 	void onGraphIndexChanged(int);
 	void on_btnExport_clicked();
 	void rightMenuFinished(bool opened);
-
-	void onStartStopFrequencyChanged(double value);
-	void onCenterSpanFrequencyChanged(double value);
 	void onMinMaxPhaseChanged(double value);
 	void onFrequencyBarMoved(int pos);
 	void toggleBufferPreview(bool toggle = false);

--- a/src/network_analyzer_api.cpp
+++ b/src/network_analyzer_api.cpp
@@ -149,11 +149,12 @@ void NetworkAnalyzer_API::setCursors(bool enabled)
 
 bool NetworkAnalyzer_API::running() const
 {
-	return net->ui->run_button->isChecked();
+	return net->ui->runSingleWidget->runButtonChecked()
+			|| net->ui->runSingleWidget->singleButtonChecked();
 }
 void NetworkAnalyzer_API::run(bool enabled)
 {
-	net->ui->run_button->setChecked(enabled);
+	net->ui->runSingleWidget->toggle(enabled);
 }
 
 int NetworkAnalyzer_API::getCursorsPosition() const

--- a/src/network_analyzer_api.cpp
+++ b/src/network_analyzer_api.cpp
@@ -9,12 +9,12 @@ void NetworkAnalyzer_API::show()
 
 double NetworkAnalyzer_API::getMinFreq() const
 {
-        return net->minFreq->value();
+	return net->start_freq->value();
 }
 
 double NetworkAnalyzer_API::getMaxFreq() const
 {
-        return net->maxFreq->value();
+	return net->stop_freq->value();
 }
 
 double NetworkAnalyzer_API::getSamplesCount() const
@@ -34,14 +34,14 @@ double NetworkAnalyzer_API::getOffset() const
 
 void NetworkAnalyzer_API::setMinFreq(double freq)
 {
-        net->minFreq->setValue(freq);
+	net->start_freq->setValue(freq);
     net->m_dBgraph.setXMin(freq);
     net->m_phaseGraph.setXMin(freq);
 }
 
 void NetworkAnalyzer_API::setMaxFreq(double freq)
 {
-        net->maxFreq->setValue(freq);
+	net->stop_freq->setValue(freq);
     net->m_dBgraph.setXMax(freq);
     net->m_phaseGraph.setXMax(freq);
 }

--- a/src/network_analyzer_api.cpp
+++ b/src/network_analyzer_api.cpp
@@ -9,12 +9,12 @@ void NetworkAnalyzer_API::show()
 
 double NetworkAnalyzer_API::getMinFreq() const
 {
-	return net->start_freq->value();
+	return net->startStopRange->getStartValue();
 }
 
 double NetworkAnalyzer_API::getMaxFreq() const
 {
-	return net->stop_freq->value();
+	return net->startStopRange->getStopValue();
 }
 
 double NetworkAnalyzer_API::getSamplesCount() const
@@ -34,14 +34,14 @@ double NetworkAnalyzer_API::getOffset() const
 
 void NetworkAnalyzer_API::setMinFreq(double freq)
 {
-	net->start_freq->setValue(freq);
+	net->startStopRange->setStartValue(freq);
     net->m_dBgraph.setXMin(freq);
     net->m_phaseGraph.setXMin(freq);
 }
 
 void NetworkAnalyzer_API::setMaxFreq(double freq)
 {
-	net->stop_freq->setValue(freq);
+	net->startStopRange->setStopValue(freq);
     net->m_dBgraph.setXMax(freq);
     net->m_phaseGraph.setXMax(freq);
 }

--- a/src/networkanalyzerbufferviewer.cpp
+++ b/src/networkanalyzerbufferviewer.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019 Analog Devices, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file LICENSE.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "networkanalyzerbufferviewer.h"
+#include "ui_networkanalyzerbufferviewer.h"
+
+using namespace adiscope;
+
+NetworkAnalyzerBufferViewer::NetworkAnalyzerBufferViewer(QWidget *parent) :
+	QWidget(parent),
+	d_ui(new Ui::NetworkAnalyzerBufferViewer),
+	d_osc(nullptr),
+	d_selectedBuffersIndex(-1)
+{
+	d_ui->setupUi(this);
+
+	d_plot = new TimeDomainDisplayPlot(d_ui->mainWidget);
+	d_ui->mainLayout->addWidget(d_plot);
+
+	connect(d_ui->viewInOsc, &QPushButton::clicked,
+		this, &NetworkAnalyzerBufferViewer::sendBufferToOscilloscope);
+	connect(d_ui->previousBtn, &QPushButton::pressed,
+		this, &NetworkAnalyzerBufferViewer::btnPreviousClicked);
+	connect(d_ui->nextBtn, &QPushButton::pressed,
+		this, &NetworkAnalyzerBufferViewer::btnNextClicked);
+
+	d_plot->insertLegend(nullptr);
+
+	d_ui->nextBtn->setDisabled(true);
+	d_ui->previousBtn->setDisabled(true);
+}
+
+NetworkAnalyzerBufferViewer::~NetworkAnalyzerBufferViewer()
+{
+	delete d_ui;
+}
+
+void NetworkAnalyzerBufferViewer::pushBuffers(QPair<Buffer, Buffer> buffers)
+{
+	d_data.push_back(buffers);
+
+	if (d_selectedBuffersIndex == -1) {
+		d_selectedBuffersIndex = 0;
+		selectBuffersAtIndex(d_selectedBuffersIndex);
+		d_ui->nextBtn->setEnabled(true);
+	}
+
+	if (d_selectedBuffersIndex < d_data.size() - 1) {
+		d_ui->nextBtn->setEnabled(true);
+	}
+}
+
+void NetworkAnalyzerBufferViewer::selectBuffersAtIndex(int index)
+{
+
+	if (d_selectedBuffersIndex == index) {
+		return;
+	}
+
+	d_selectedBuffersIndex = index;
+
+	static bool firstTime = true;
+	if (firstTime) {
+		firstTime = false;
+	} else {
+		d_plot->unregisterReferenceWaveform("data1");
+		d_plot->unregisterReferenceWaveform("data2");
+	}
+
+	QVector<double> xData;
+
+	double division = 1.0 / d_data[index].first.sampleRate;
+	int n = d_data[index].first.buffer.size() / 2;
+
+	for (int i = -n; i < n; ++i) {
+		xData.push_back(division * i);
+	}
+
+	d_currentXdata.clear();
+	d_currentXdata = xData;
+
+	QVector<double> yData1, yData2;
+	for (int i = 0; i < d_data[index].first.buffer.size(); ++i) {
+		yData1.push_back(d_data[index].first.buffer[i]);
+	}
+	for (int i = 0; i < d_data[index].second.buffer.size(); ++i) {
+		yData2.push_back(d_data[index].second.buffer[i]);
+	}
+
+	d_plot->setYaxis(-5, 5);
+	d_plot->setXaxis(-n * division, n * division);
+	d_plot->registerReferenceWaveform("data1", xData, yData1);
+	d_plot->registerReferenceWaveform("data2", xData, yData2);
+
+	// Move freq. handle on plot if prev/next button
+	// are used to navigate through the buffers
+	if (QObject::sender() == d_ui->previousBtn ||
+			QObject::sender() == d_ui->nextBtn) {
+		Q_EMIT moveHandleAt(d_data[index].first.frequency);
+	}
+
+	if (index == 0) {
+		d_ui->previousBtn->setDisabled(true);
+	} else if (index == d_data.size() - 1) {
+		d_ui->nextBtn->setDisabled(true);
+	} else {
+		d_ui->previousBtn->setEnabled(true);
+		d_ui->nextBtn->setEnabled(true);
+	}
+}
+
+void NetworkAnalyzerBufferViewer::selectBuffers(double frequency)
+{
+	int index = -1;
+	for (int i = 0; i < d_data.size() - 1; ++i) {
+		if (d_data[i].first.frequency <= frequency
+				&& frequency <= d_data[i + 1].first.frequency) {
+			index = i;
+			break;
+		}
+		if (d_data[i + 1].first.frequency < frequency) {
+			index = d_data.size() - 1;
+
+		}
+		if (frequency < d_data[i].first.frequency) {
+			index = 0;
+		}
+	}
+
+	if (index == -1) {
+		return;
+	}
+
+	if (index >= d_data.size()) {
+		return;
+	}
+
+	selectBuffersAtIndex(index);
+}
+
+void NetworkAnalyzerBufferViewer::setVisible(bool visible)
+{
+	QWidget::setVisible(visible);
+
+	if (d_data.size()) {
+		d_selectedBuffersIndex = 0;
+		selectBuffersAtIndex(d_selectedBuffersIndex);
+		d_ui->nextBtn->setEnabled(true);
+	}
+}
+
+void NetworkAnalyzerBufferViewer::setOscilloscope(Oscilloscope *osc)
+{
+	d_osc = osc;
+}
+
+void NetworkAnalyzerBufferViewer::clear()
+{
+	d_data.clear();
+	d_selectedBuffersIndex = -1;
+	d_ui->previousBtn->setDisabled(true);
+	d_ui->nextBtn->setDisabled(true);
+}
+
+void NetworkAnalyzerBufferViewer::sendBufferToOscilloscope()
+{
+	if (d_selectedBuffersIndex  < 0 || d_selectedBuffersIndex >= d_data.size()) {
+		return;
+	}
+
+	d_osc->remove_ref_waveform("NA1");
+	d_osc->remove_ref_waveform("NA2");
+
+	QVector<double> yData1, yData2;
+	auto index = d_selectedBuffersIndex;
+	for (int i = 0; i < d_data[index].first.buffer.size(); ++i) {
+		yData1.push_back(d_data[index].first.buffer[i]);
+	}
+	for (int i = 0; i < d_data[index].second.buffer.size(); ++i) {
+		yData2.push_back(d_data[index].second.buffer[i]);
+	}
+	d_osc->add_ref_waveform("NA1", d_currentXdata, yData1, d_data[index].first.sampleRate);
+	d_osc->add_ref_waveform("NA2", d_currentXdata, yData2, d_data[index].second.sampleRate);
+
+	d_osc->detached();
+}
+
+void NetworkAnalyzerBufferViewer::btnPreviousClicked()
+{
+	if (d_selectedBuffersIndex - 1 >= 0) {
+		selectBuffersAtIndex(d_selectedBuffersIndex - 1);
+	}
+
+	d_ui->nextBtn->setEnabled(true);
+
+	if (d_selectedBuffersIndex == 0) {
+		d_ui->previousBtn->setDisabled(true);
+	}
+}
+
+void NetworkAnalyzerBufferViewer::btnNextClicked()
+{
+	if (d_selectedBuffersIndex + 1 < d_data.size()) {
+		selectBuffersAtIndex(d_selectedBuffersIndex + 1);
+	}
+
+	d_ui->previousBtn->setEnabled(true);
+
+	if (d_selectedBuffersIndex == d_data.size() - 1) {
+		d_ui->nextBtn->setDisabled(true);
+	}
+}

--- a/src/networkanalyzerbufferviewer.cpp
+++ b/src/networkanalyzerbufferviewer.cpp
@@ -26,7 +26,8 @@ NetworkAnalyzerBufferViewer::NetworkAnalyzerBufferViewer(QWidget *parent) :
 	QWidget(parent),
 	d_ui(new Ui::NetworkAnalyzerBufferViewer),
 	d_osc(nullptr),
-	d_selectedBuffersIndex(-1)
+	d_selectedBuffersIndex(-1),
+	d_numBuffers(0)
 {
 	d_ui->setupUi(this);
 
@@ -51,9 +52,22 @@ NetworkAnalyzerBufferViewer::~NetworkAnalyzerBufferViewer()
 	delete d_ui;
 }
 
+void NetworkAnalyzerBufferViewer::setNumBuffers(unsigned int numBuffers)
+{
+	d_numBuffers = numBuffers;
+}
+
 void NetworkAnalyzerBufferViewer::pushBuffers(QPair<Buffer, Buffer> buffers)
 {
-	d_data.push_back(buffers);
+	if (d_data.size() < d_numBuffers) {
+		d_data.push_back(buffers);
+	} else {
+		static int currentBuffer = 0;
+		d_data[currentBuffer++] = buffers;
+		if (currentBuffer == d_numBuffers) {
+			currentBuffer = 0;
+		}
+	}
 
 	if (d_selectedBuffersIndex == -1) {
 		d_selectedBuffersIndex = 0;

--- a/src/networkanalyzerbufferviewer.h
+++ b/src/networkanalyzerbufferviewer.h
@@ -58,20 +58,23 @@ public:
 
 	QPair<Buffer, Buffer> getSelectedBuffers() const;
 
-	void selectBuffersAtIndex(int index);
+	void selectBuffersAtIndex(int index, bool moveHandle = true);
 	void selectBuffers(double frequency);
 
 	void setNumBuffers(unsigned int numBuffers);
 Q_SIGNALS:
 	void moveHandleAt(double);
+	void indexChanged(int);
 
 public Q_SLOTS:
 	void setVisible(bool visible) Q_DECL_OVERRIDE;
 
-private Q_SLOTS:
 	void sendBufferToOscilloscope();
 	void btnPreviousClicked();
 	void btnNextClicked();
+
+private:
+	void _setupPlot();
 
 private:
 	Ui::NetworkAnalyzerBufferViewer *d_ui;

--- a/src/networkanalyzerbufferviewer.h
+++ b/src/networkanalyzerbufferviewer.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Analog Devices, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file LICENSE.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef NETWORKANALYZERBUFFERVIEWER_H
+#define NETWORKANALYZERBUFFERVIEWER_H
+
+#include <QWidget>
+#include <QPushButton>
+#include "oscilloscope.hpp"
+
+#include "TimeDomainDisplayPlot.h"
+
+namespace Ui {
+class NetworkAnalyzerBufferViewer;
+}
+
+struct Buffer {
+	Buffer() {}
+	Buffer(double frequency, unsigned int sampleRate,
+	       unsigned int bufferSize, const std::vector<float> &buffer):
+		frequency(frequency), sampleRate(sampleRate),
+		bufferSize(bufferSize), buffer(buffer) {}
+
+	double frequency;
+	unsigned int sampleRate;
+	unsigned int bufferSize;
+	std::vector<float> buffer;
+};
+
+namespace adiscope {
+class NetworkAnalyzerBufferViewer : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit NetworkAnalyzerBufferViewer(QWidget *parent = nullptr);
+	~NetworkAnalyzerBufferViewer();
+
+	void clear();
+	void pushBuffers(QPair<Buffer, Buffer> buffers);
+	void setOscilloscope(Oscilloscope *osc);
+
+	QPair<Buffer, Buffer> getSelectedBuffers() const;
+
+	void selectBuffersAtIndex(int index);
+	void selectBuffers(double frequency);
+
+Q_SIGNALS:
+	void moveHandleAt(double);
+
+public Q_SLOTS:
+	void setVisible(bool visible) Q_DECL_OVERRIDE;
+
+private Q_SLOTS:
+	void sendBufferToOscilloscope();
+	void btnPreviousClicked();
+	void btnNextClicked();
+
+private:
+	Ui::NetworkAnalyzerBufferViewer *d_ui;
+	TimeDomainDisplayPlot *d_plot;
+	QVector<QPair<Buffer, Buffer>> d_data;
+	int d_selectedBuffersIndex;
+	Oscilloscope *d_osc;
+	QVector<double> d_currentXdata;
+};
+}
+
+#endif // NETWORKANALYZERBUFFERVIEWER_H

--- a/src/networkanalyzerbufferviewer.h
+++ b/src/networkanalyzerbufferviewer.h
@@ -61,6 +61,7 @@ public:
 	void selectBuffersAtIndex(int index);
 	void selectBuffers(double frequency);
 
+	void setNumBuffers(unsigned int numBuffers);
 Q_SIGNALS:
 	void moveHandleAt(double);
 
@@ -79,6 +80,7 @@ private:
 	int d_selectedBuffersIndex;
 	Oscilloscope *d_osc;
 	QVector<double> d_currentXdata;
+	int d_numBuffers;
 };
 }
 

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -114,6 +114,8 @@ namespace adiscope {
 		bool getTrigger_input() const;
 		void setTrigger_input(bool value);
 
+		void add_ref_waveform(QString name, QVector<double> xData, QVector<double> yData, unsigned int sampleRate);
+		void remove_ref_waveform(QString name);
 	Q_SIGNALS:
 		void triggerALevelChanged(double);
 		void triggerBLevelChanged(double);

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -1441,6 +1441,19 @@ void CapturePlot::onChannelAdded(int chnIdx)
 	d_measureObjs.push_back(measure);
 }
 
+void CapturePlot::computeMeasurementsForChannel(unsigned int chnIdx, unsigned int sampleRate)
+{
+	if (chnIdx >= d_measureObjs.size()) {
+		return;
+	}
+
+	Measure *measure = d_measureObjs[chnIdx];
+	measure->setSampleRate(sampleRate);
+	measure->measure();
+
+	Q_EMIT measurementsAvailable();
+}
+
 void CapturePlot::cleanUpJustBeforeChannelRemoval(int chnIdx)
 {
 	Measure *measure = measureOfChannel(chnIdx);

--- a/src/oscilloscope_plot.hpp
+++ b/src/oscilloscope_plot.hpp
@@ -128,6 +128,8 @@ namespace adiscope {
 		void setGraticuleEnabled(bool enabled);
 		void setGatingEnabled(bool enabled);
 
+		void computeMeasurementsForChannel(unsigned int chnIdx, unsigned int sampleRate);
+
 	Q_SIGNALS:
 		void timeTriggerValueChanged(double);
 		void channelOffsetChanged(double);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -49,8 +49,7 @@ Preferences::Preferences(QWidget *parent) :
 	osc_filtering_enabled(true),
 	mini_hist_enabled(false),
 	digital_decoders_enabled(true),
-	m_initialized(false),
-	na_update_gain_enabled(false)
+	m_initialized(false)
 {
 	ui->setupUi(this);
 
@@ -143,11 +142,6 @@ Preferences::Preferences(QWidget *parent) :
 		}
 	});
 
-	connect(ui->na_gainCheckBox, &QCheckBox::stateChanged, [=](int state) {
-		na_update_gain_enabled = (!state ? false : true);
-		Q_EMIT notify();
-	});
-
 	QString preference_ini_file = getPreferenceIniFile();
 	QSettings settings(preference_ini_file, QSettings::IniFormat);
 
@@ -188,7 +182,6 @@ void Preferences::showEvent(QShowEvent *event)
 	ui->oscFilteringCheckBox->setChecked(osc_filtering_enabled);
 	ui->histCheckBox->setChecked(mini_hist_enabled);
 	ui->decodersCheckBox->setChecked(digital_decoders_enabled);
-	ui->na_gainCheckBox->setChecked(na_update_gain_enabled);
 
 	QWidget::showEvent(event);
 }
@@ -223,16 +216,6 @@ bool Preferences::getDigital_decoders_enabled() const
 void Preferences::setDigital_decoders_enabled(bool value)
 {
 	digital_decoders_enabled = value;
-}
-
-bool Preferences::getNaGainUpdateEnabled() const
-{
-    return na_update_gain_enabled;
-}
-
-void Preferences::setNaGainUpdateEnabled(bool value)
-{
-    na_update_gain_enabled = value;
 }
 
 bool Preferences::getOsc_filtering_enabled() const
@@ -399,16 +382,6 @@ bool Preferences::getOsc_graticule_enabled() const
 void Preferences::setOsc_graticule_enabled(bool value)
 {
 	graticule_enabled = value;
-}
-
-bool Preferences_API::getNaGainUpdateEnabled() const
-{
-	return preferencePanel->getNaGainUpdateEnabled();
-}
-
-void Preferences_API::setNaGainUpdateEnabled(bool enabled)
-{
-	preferencePanel->setNaGainUpdateEnabled(enabled);
 }
 
 bool Preferences_API::getAnimationsEnabled() const

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -49,7 +49,8 @@ Preferences::Preferences(QWidget *parent) :
 	osc_filtering_enabled(true),
 	mini_hist_enabled(false),
 	digital_decoders_enabled(true),
-	m_initialized(false)
+	m_initialized(false),
+	na_update_gain_enabled(false)
 {
 	ui->setupUi(this);
 
@@ -142,6 +143,11 @@ Preferences::Preferences(QWidget *parent) :
 		}
 	});
 
+	connect(ui->na_gainCheckBox, &QCheckBox::stateChanged, [=](int state) {
+		na_update_gain_enabled = (!state ? false : true);
+		Q_EMIT notify();
+	});
+
 	QString preference_ini_file = getPreferenceIniFile();
 	QSettings settings(preference_ini_file, QSettings::IniFormat);
 
@@ -182,6 +188,7 @@ void Preferences::showEvent(QShowEvent *event)
 	ui->oscFilteringCheckBox->setChecked(osc_filtering_enabled);
 	ui->histCheckBox->setChecked(mini_hist_enabled);
 	ui->decodersCheckBox->setChecked(digital_decoders_enabled);
+	ui->na_gainCheckBox->setChecked(na_update_gain_enabled);
 
 	QWidget::showEvent(event);
 }
@@ -218,14 +225,24 @@ void Preferences::setDigital_decoders_enabled(bool value)
 	digital_decoders_enabled = value;
 }
 
+bool Preferences::getNaGainUpdateEnabled() const
+{
+    return na_update_gain_enabled;
+}
+
+void Preferences::setNaGainUpdateEnabled(bool value)
+{
+    na_update_gain_enabled = value;
+}
+
 bool Preferences::getOsc_filtering_enabled() const
 {
-	return osc_filtering_enabled;
+    return osc_filtering_enabled;
 }
 
 void Preferences::setOsc_filtering_enabled(bool value)
 {
-	osc_filtering_enabled = value;
+    osc_filtering_enabled = value;
 }
 
 bool Preferences::getAnimations_enabled() const
@@ -382,6 +399,16 @@ bool Preferences::getOsc_graticule_enabled() const
 void Preferences::setOsc_graticule_enabled(bool value)
 {
 	graticule_enabled = value;
+}
+
+bool Preferences_API::getNaGainUpdateEnabled() const
+{
+	return preferencePanel->getNaGainUpdateEnabled();
+}
+
+void Preferences_API::setNaGainUpdateEnabled(bool enabled)
+{
+	preferencePanel->setNaGainUpdateEnabled(enabled);
 }
 
 bool Preferences_API::getAnimationsEnabled() const

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -95,9 +95,6 @@ public:
 	bool getDigital_decoders_enabled() const;
 	void setDigital_decoders_enabled(bool value);
 
-	bool getNaGainUpdateEnabled() const;
-	void setNaGainUpdateEnabled(bool value);
-
 Q_SIGNALS:
 
 	void notify();
@@ -129,7 +126,6 @@ private:
 	bool mini_hist_enabled;
 	bool digital_decoders_enabled;
 	bool m_initialized;
-	bool na_update_gain_enabled;
 
 	Preferences_API *pref_api;
 	QString getPreferenceIniFile() const;
@@ -155,16 +151,12 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool osc_filtering_enabled READ getOscFilteringEnabled WRITE setOscFilteringEnabled)
 	Q_PROPERTY(bool mini_hist_enabled READ getMiniHist WRITE setMiniHist)
 	Q_PROPERTY(bool digital_decoders READ getDigitalDecoders WRITE setDigitalDecoders)
-	Q_PROPERTY(bool na_gain_update_enabled READ getNaGainUpdateEnabled WRITE setNaGainUpdateEnabled)
 
 public:
 
 	explicit Preferences_API(Preferences *preferencePanel) :
 		ApiObject(),
 		preferencePanel(preferencePanel) {}
-
-	bool getNaGainUpdateEnabled() const;
-	void setNaGainUpdateEnabled(bool enabled);
 
 	bool getAnimationsEnabled() const;
 	void setAnimationsEnabled(const bool& enabled);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -95,6 +95,9 @@ public:
 	bool getDigital_decoders_enabled() const;
 	void setDigital_decoders_enabled(bool value);
 
+	bool getNaGainUpdateEnabled() const;
+	void setNaGainUpdateEnabled(bool value);
+
 Q_SIGNALS:
 
 	void notify();
@@ -126,6 +129,7 @@ private:
 	bool mini_hist_enabled;
 	bool digital_decoders_enabled;
 	bool m_initialized;
+	bool na_update_gain_enabled;
 
 	Preferences_API *pref_api;
 	QString getPreferenceIniFile() const;
@@ -151,12 +155,16 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool osc_filtering_enabled READ getOscFilteringEnabled WRITE setOscFilteringEnabled)
 	Q_PROPERTY(bool mini_hist_enabled READ getMiniHist WRITE setMiniHist)
 	Q_PROPERTY(bool digital_decoders READ getDigitalDecoders WRITE setDigitalDecoders)
+	Q_PROPERTY(bool na_gain_update_enabled READ getNaGainUpdateEnabled WRITE setNaGainUpdateEnabled)
 
 public:
 
 	explicit Preferences_API(Preferences *preferencePanel) :
 		ApiObject(),
 		preferencePanel(preferencePanel) {}
+
+	bool getNaGainUpdateEnabled() const;
+	void setNaGainUpdateEnabled(bool enabled);
 
 	bool getAnimationsEnabled() const;
 	void setAnimationsEnabled(const bool& enabled);

--- a/src/startstoprangewidget.cpp
+++ b/src/startstoprangewidget.cpp
@@ -67,6 +67,11 @@ double StartStopRangeWidget::getCenterValue() const
 	return center_freq->value();
 }
 
+void StartStopRangeWidget::insertWidgetIntoLayout(QWidget *widget, int row, int column)
+{
+	ui->gridLayout->addWidget(widget, row, column);
+}
+
 void StartStopRangeWidget::setMinimumSpanValue(double value)
 {
 	minSpan = value;

--- a/src/startstoprangewidget.h
+++ b/src/startstoprangewidget.h
@@ -48,6 +48,8 @@ public:
 
 	double getCenterValue() const;
 
+	void insertWidgetIntoLayout(QWidget *widget, int row, int column);
+
 public Q_SLOTS:
 	void setMinimumSpanValue(double value);
 

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1448,13 +1448,14 @@ void adiscope::ToolLauncher::enableAdcBasedTools()
 	}
 
 	if (filter->compatible((TOOL_NETWORK_ANALYZER))) {
-		network_analyzer = new NetworkAnalyzer(ctx, filter, adc,
+		network_analyzer = new NetworkAnalyzer(ctx, filter, adc, dacs,
 			toolMenu["Network Analyzer"]->getToolStopBtn(), &js_engine, this);
 		adc_users_group.addButton(toolMenu["Network Analyzer"]->getToolStopBtn());
 		toolList.push_back(network_analyzer);
 		connect(network_analyzer, &NetworkAnalyzer::showTool, [=]() {
 			toolMenu["Network Analyzer"]->getToolBtn()->click();
 		});
+		network_analyzer->setOscilloscope(oscilloscope);
 	}
 
 	Q_EMIT adcToolsCreated();

--- a/src/x_axis_scale_zoomer.cpp
+++ b/src/x_axis_scale_zoomer.cpp
@@ -1,4 +1,7 @@
 #include "x_axis_scale_zoomer.h"
+#include "qwt_scale_draw.h"
+
+#include <dbgraph.hpp>
 
 using namespace adiscope;
 
@@ -20,5 +23,15 @@ void XAxisScaleZoomer::zoom(const QRectF& rect)
 	boundedRect.setBottom(baseRect.bottom());
 
 	QwtPlotZoomer::zoom(boundedRect);
+}
 
+QwtText XAxisScaleZoomer::trackerText(const QPoint &p) const
+{
+	QwtText t;
+	QPointF dp = QwtPlotZoomer::invTransform(p);
+
+	const dBgraph *plt = dynamic_cast<const dBgraph *>(plot());
+	t.setText(plt->getScaleValueFormat(dp.x(), QwtPlot::xTop, 4) + ", " +
+		  plt->getScaleValueFormat(dp.y(), QwtPlot::yLeft));
+	return t;
 }

--- a/src/x_axis_scale_zoomer.h
+++ b/src/x_axis_scale_zoomer.h
@@ -30,8 +30,10 @@ class XAxisScaleZoomer : public OscScaleZoomer
 public:
 	explicit XAxisScaleZoomer(QWidget *parent);
 	~XAxisScaleZoomer();
+
 protected:
 	virtual void zoom(const QRectF&);
+	virtual QwtText trackerText( const QPoint& p ) const;
 };
 }
 #endif // X_AXIS_SCALE_ZOOMER_H

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -809,7 +809,7 @@ border: 5px solid white;
                       <x>0</x>
                       <y>0</y>
                       <width>322</width>
-                      <height>557</height>
+                      <height>574</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1081,7 +1081,7 @@ color: rgba(255,255,255,51);
                        <property name="spacing">
                         <number>15</number>
                        </property>
-                       <item row="3" column="0">
+                       <item row="4" column="0">
                         <spacer name="verticalSpacer_2">
                          <property name="orientation">
                           <enum>Qt::Vertical</enum>
@@ -1097,15 +1097,8 @@ color: rgba(255,255,255,51);
                          </property>
                         </spacer>
                        </item>
-                       <item row="1" column="1">
-                        <widget class="QRadioButton" name="isLinear">
-                         <property name="text">
-                          <string>Linear</string>
-                         </property>
-                         <attribute name="buttonGroup">
-                          <string notr="true">buttonGroup</string>
-                         </attribute>
-                        </widget>
+                       <item row="2" column="0">
+                        <layout class="QVBoxLayout" name="minFreqLayout"/>
                        </item>
                        <item row="1" column="0">
                         <widget class="QRadioButton" name="isLog">
@@ -1120,14 +1113,21 @@ color: rgba(255,255,255,51);
                          </attribute>
                         </widget>
                        </item>
-                       <item row="3" column="1">
+                       <item row="4" column="1">
                         <layout class="QVBoxLayout" name="samplesCountLayout"/>
-                       </item>
-                       <item row="2" column="0">
-                        <layout class="QVBoxLayout" name="minFreqLayout"/>
                        </item>
                        <item row="2" column="1">
                         <layout class="QVBoxLayout" name="maxFreqLayout"/>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QRadioButton" name="isLinear">
+                         <property name="text">
+                          <string>Linear</string>
+                         </property>
+                         <attribute name="buttonGroup">
+                          <string notr="true">buttonGroup</string>
+                         </attribute>
+                        </widget>
                        </item>
                        <item row="1" column="0" colspan="2">
                         <widget class="adiscope::CustomSwitch" name="btnIsLog">
@@ -1214,6 +1214,12 @@ color: rgba(255,255,255,51);
                           <number>0</number>
                          </property>
                         </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <layout class="QVBoxLayout" name="centerFreqLayout"/>
+                       </item>
+                       <item row="3" column="1">
+                        <layout class="QVBoxLayout" name="spanFreqLayout"/>
                        </item>
                       </layout>
                      </item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -807,9 +807,9 @@ border: 5px solid white;
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>-45</y>
+                      <y>-115</y>
                       <width>322</width>
-                      <height>613</height>
+                      <height>661</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1376,11 +1376,27 @@ color: rgba(255,255,255,51);
                        <item row="0" column="1">
                         <layout class="QVBoxLayout" name="phaseMinLayout"/>
                        </item>
-                       <item row="0" column="0">
-                        <layout class="QVBoxLayout" name="magMinLayout"/>
+                       <item row="3" column="1">
+                        <widget class="adiscope::CustomSwitch" name="dcFilterBtn">
+                         <property name="text">
+                          <string/>
+                         </property>
+                         <property name="leftText" stdset="0">
+                          <string>On</string>
+                         </property>
+                         <property name="rightText" stdset="0">
+                          <string>Off</string>
+                         </property>
+                         <property name="duration_ms" stdset="0">
+                          <number>0</number>
+                         </property>
+                         <property name="polarity" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
                        </item>
-                       <item row="1" column="1">
-                        <layout class="QVBoxLayout" name="phaseMaxLayout"/>
+                       <item row="1" column="0">
+                        <layout class="QVBoxLayout" name="magMaxLayout"/>
                        </item>
                        <item row="2" column="0">
                         <widget class="QLabel" name="label_11">
@@ -1397,9 +1413,6 @@ color: rgba(255,255,255,51);
                           <string>Delta Label</string>
                          </property>
                         </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <layout class="QVBoxLayout" name="magMaxLayout"/>
                        </item>
                        <item row="2" column="1">
                         <widget class="adiscope::CustomSwitch" name="deltaBtn">
@@ -1430,24 +1443,27 @@ color: rgba(255,255,255,51);
                          </property>
                         </widget>
                        </item>
-                       <item row="3" column="1">
-                        <widget class="adiscope::CustomSwitch" name="dcFilterBtn">
+                       <item row="0" column="0">
+                        <layout class="QVBoxLayout" name="magMinLayout"/>
+                       </item>
+                       <item row="1" column="1">
+                        <layout class="QVBoxLayout" name="phaseMaxLayout"/>
+                       </item>
+                       <item row="5" column="0">
+                        <widget class="QLabel" name="label_13">
+                         <property name="styleSheet">
+                          <string notr="true">font-size: 13px;</string>
+                         </property>
                          <property name="text">
                           <string/>
                          </property>
-                         <property name="leftText" stdset="0">
-                          <string>On</string>
-                         </property>
-                         <property name="rightText" stdset="0">
-                          <string>Off</string>
-                         </property>
-                         <property name="duration_ms" stdset="0">
-                          <number>0</number>
-                         </property>
-                         <property name="polarity" stdset="0">
-                          <bool>false</bool>
-                         </property>
                         </widget>
+                       </item>
+                       <item row="4" column="0">
+                        <layout class="QVBoxLayout" name="pushDelayLayout"/>
+                       </item>
+                       <item row="4" column="1">
+                        <layout class="QVBoxLayout" name="captureDelayLayout"/>
                        </item>
                       </layout>
                      </item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -703,6 +703,12 @@ border: 5px solid white;
              </property>
              <item>
               <widget class="QStackedWidget" name="stackedWidget_2">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="minimumSize">
                 <size>
                  <width>60</width>
@@ -710,7 +716,7 @@ border: 5px solid white;
                 </size>
                </property>
                <property name="currentIndex">
-                <number>1</number>
+                <number>0</number>
                </property>
                <widget class="QWidget" name="page_3">
                 <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -755,7 +761,7 @@ border: 5px solid white;
                       <x>0</x>
                       <y>0</y>
                       <width>322</width>
-                      <height>514</height>
+                      <height>557</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1307,11 +1313,14 @@ color: rgba(255,255,255,51);
                        <property name="topMargin">
                         <number>0</number>
                        </property>
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
                        <property name="spacing">
                         <number>15</number>
                        </property>
-                       <item row="1" column="0">
-                        <layout class="QVBoxLayout" name="magMaxLayout"/>
+                       <item row="0" column="1">
+                        <layout class="QVBoxLayout" name="phaseMinLayout"/>
                        </item>
                        <item row="0" column="0">
                         <layout class="QVBoxLayout" name="magMinLayout"/>
@@ -1319,8 +1328,43 @@ color: rgba(255,255,255,51);
                        <item row="1" column="1">
                         <layout class="QVBoxLayout" name="phaseMaxLayout"/>
                        </item>
-                       <item row="0" column="1">
-                        <layout class="QVBoxLayout" name="phaseMinLayout"/>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_11">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="styleSheet">
+                          <string notr="true">font-size: 13px;</string>
+                         </property>
+                         <property name="text">
+                          <string>Delta Label</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <layout class="QVBoxLayout" name="magMaxLayout"/>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="adiscope::CustomSwitch" name="deltaBtn">
+                         <property name="text">
+                          <string/>
+                         </property>
+                         <property name="leftText" stdset="0">
+                          <string>On</string>
+                         </property>
+                         <property name="rightText" stdset="0">
+                          <string>Off</string>
+                         </property>
+                         <property name="duration_ms" stdset="0">
+                          <number>0</number>
+                         </property>
+                         <property name="polarity" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
                        </item>
                       </layout>
                      </item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -765,7 +765,7 @@ border: 5px solid white;
                 </size>
                </property>
                <property name="currentIndex">
-                <number>1</number>
+                <number>0</number>
                </property>
                <widget class="QWidget" name="page_3">
                 <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -810,7 +810,7 @@ border: 5px solid white;
                       <x>0</x>
                       <y>0</y>
                       <width>322</width>
-                      <height>660</height>
+                      <height>641</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1075,14 +1075,21 @@ color: rgba(255,255,255,51);
                       </layout>
                      </item>
                      <item>
-                      <layout class="QGridLayout" name="gridLayout_7">
+                      <layout class="QGridLayout" name="sweepLayout">
                        <property name="topMargin">
                         <number>0</number>
                        </property>
                        <property name="spacing">
                         <number>15</number>
                        </property>
-                       <item row="4" column="0">
+                       <item row="6" column="1">
+                        <layout class="QVBoxLayout" name="samplesCountLayout">
+                         <property name="spacing">
+                          <number>0</number>
+                         </property>
+                        </layout>
+                       </item>
+                       <item row="6" column="0">
                         <spacer name="verticalSpacer_2">
                          <property name="orientation">
                           <enum>Qt::Vertical</enum>
@@ -1097,38 +1104,6 @@ color: rgba(255,255,255,51);
                           </size>
                          </property>
                         </spacer>
-                       </item>
-                       <item row="2" column="0">
-                        <layout class="QVBoxLayout" name="minFreqLayout"/>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QRadioButton" name="isLog">
-                         <property name="text">
-                          <string>Logarithmic</string>
-                         </property>
-                         <property name="checked">
-                          <bool>true</bool>
-                         </property>
-                         <attribute name="buttonGroup">
-                          <string notr="true">buttonGroup</string>
-                         </attribute>
-                        </widget>
-                       </item>
-                       <item row="4" column="1">
-                        <layout class="QVBoxLayout" name="samplesCountLayout"/>
-                       </item>
-                       <item row="2" column="1">
-                        <layout class="QVBoxLayout" name="maxFreqLayout"/>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QRadioButton" name="isLinear">
-                         <property name="text">
-                          <string>Linear</string>
-                         </property>
-                         <attribute name="buttonGroup">
-                          <string notr="true">buttonGroup</string>
-                         </attribute>
-                        </widget>
                        </item>
                        <item row="1" column="0" colspan="2">
                         <widget class="adiscope::CustomSwitch" name="btnIsLog">
@@ -1216,11 +1191,38 @@ color: rgba(255,255,255,51);
                          </property>
                         </widget>
                        </item>
-                       <item row="3" column="0">
-                        <layout class="QVBoxLayout" name="centerFreqLayout"/>
-                       </item>
-                       <item row="3" column="1">
-                        <layout class="QVBoxLayout" name="spanFreqLayout"/>
+                       <item row="2" column="0" colspan="2">
+                        <widget class="QWidget" name="widget" native="true">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>0</width>
+                           <height>0</height>
+                          </size>
+                         </property>
+                         <layout class="QVBoxLayout" name="sweepRangeLayout">
+                          <property name="spacing">
+                           <number>0</number>
+                          </property>
+                          <property name="leftMargin">
+                           <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                           <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                           <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                           <number>0</number>
+                          </property>
+                         </layout>
+                        </widget>
                        </item>
                       </layout>
                      </item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -807,9 +807,9 @@ border: 5px solid white;
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>0</y>
+                      <y>-45</y>
                       <width>322</width>
-                      <height>574</height>
+                      <height>613</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1403,6 +1403,35 @@ color: rgba(255,255,255,51);
                        </item>
                        <item row="2" column="1">
                         <widget class="adiscope::CustomSwitch" name="deltaBtn">
+                         <property name="text">
+                          <string/>
+                         </property>
+                         <property name="leftText" stdset="0">
+                          <string>On</string>
+                         </property>
+                         <property name="rightText" stdset="0">
+                          <string>Off</string>
+                         </property>
+                         <property name="duration_ms" stdset="0">
+                          <number>0</number>
+                         </property>
+                         <property name="polarity" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_12">
+                         <property name="styleSheet">
+                          <string notr="true">font-size: 13px;</string>
+                         </property>
+                         <property name="text">
+                          <string>Dc Filtering</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="adiscope::CustomSwitch" name="dcFilterBtn">
                          <property name="text">
                           <string/>
                          </property>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -136,98 +136,7 @@ QPushButton:hover {
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="run_button">
-          <property name="layoutDirection">
-           <enum>Qt::RightToLeft</enum>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">QPushButton {
-  width: 80px;
-  height: 40px;
-  border-radius: 4px;
-  background-color: #27b34f;
-  color: white;
-  
-  font-weight: bold;
-
-  text-align: left;
-  padding-left: 20px;
-  padding-right: 20px;
-  qproperty-text: &quot;Run&quot;;
-}
-
-QPushButton[running=true] {
-  qproperty-text: &quot;Stop&quot;;
-  background-color: #F45000;
-}
-
-QPushButton:disabled {
-  background-color: grey;
-}</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../resources/resources.qrc">
-            <normaloff>:/icons/ico-play.svg</normaloff>
-            <normalon>:/icons/ico-stop.svg</normalon>:/icons/ico-play.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>8</width>
-            <height>10</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="single_button">
-          <property name="layoutDirection">
-           <enum>Qt::RightToLeft</enum>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">QPushButton {
-  width: 80px;
-  height: 40px;
-  border-radius: 4px;
-  background-color: #ff7200;
-  color: white;
-  
-  font-weight: bold;
-
-  text-align: left;
-  padding-left: 20px;
-  padding-right: 20px;
-  qproperty-text: &quot;Single&quot;;
-}
-
-QPushButton[running=true] {
-  qproperty-text: &quot;Stop&quot;;
-  background-color: #F45000;
-}
-
-QPushButton:disabled {
-  background-color: grey;
-}</string>
-          </property>
-          <property name="text">
-           <string>Single</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../resources/resources.qrc">
-            <normaloff>:/icons/ico-oneshot.svg</normaloff>:/icons/ico-oneshot.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>8</width>
-            <height>10</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
+         <widget class="adiscope::RunSingleWidget" name="runSingleWidget" native="true"/>
         </item>
         <item>
          <widget class="QWidget" name="menuButtonsWidget" native="true">
@@ -2282,6 +2191,12 @@ QLabel {
    <class>adiscope::CustomPushButton</class>
    <extends>QPushButton</extends>
    <header>customPushButton.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>adiscope::RunSingleWidget</class>
+   <extends>QWidget</extends>
+   <header>runsinglewidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::CustomSwitch</class>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -147,7 +147,7 @@ QPushButton:hover {
   border-radius: 4px;
   background-color: #27b34f;
   color: white;
-
+  
   font-weight: bold;
 
   text-align: left;
@@ -169,6 +169,54 @@ QPushButton:disabled {
            <iconset resource="../resources/resources.qrc">
             <normaloff>:/icons/ico-play.svg</normaloff>
             <normalon>:/icons/ico-stop.svg</normalon>:/icons/ico-play.svg</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>8</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="single_button">
+          <property name="layoutDirection">
+           <enum>Qt::RightToLeft</enum>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QPushButton {
+  width: 80px;
+  height: 40px;
+  border-radius: 4px;
+  background-color: #ff7200;
+  color: white;
+  
+  font-weight: bold;
+
+  text-align: left;
+  padding-left: 20px;
+  padding-right: 20px;
+  qproperty-text: &quot;Single&quot;;
+}
+
+QPushButton[running=true] {
+  qproperty-text: &quot;Stop&quot;;
+  background-color: #F45000;
+}
+
+QPushButton:disabled {
+  background-color: grey;
+}</string>
+          </property>
+          <property name="text">
+           <string>Single</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../resources/resources.qrc">
+            <normaloff>:/icons/ico-oneshot.svg</normaloff>:/icons/ico-oneshot.svg</iconset>
           </property>
           <property name="iconSize">
            <size>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -408,6 +408,98 @@ QPushButton:checked:hover {
                   <number>0</number>
                  </property>
                  <item>
+                  <widget class="QWidget" name="statusWidget" native="true">
+                   <layout class="QVBoxLayout" name="verticalLayout_18">
+                    <property name="spacing">
+                     <number>0</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <layout class="QHBoxLayout" name="status">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>10</number>
+                      </property>
+                      <item>
+                       <spacer name="horizontalSpacer_7">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeType">
+                         <enum>QSizePolicy::Fixed</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="currentSampleLabel">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string>Sample: </string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="currentFrequencyLabel">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string>Current Frequency:</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <spacer name="horizontalSpacer_6">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                     </layout>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
                   <layout class="QGridLayout" name="gridLayout_plots"/>
                  </item>
                 </layout>
@@ -764,7 +856,7 @@ border: 5px solid white;
                 </size>
                </property>
                <property name="currentIndex">
-                <number>0</number>
+                <number>1</number>
                </property>
                <widget class="QWidget" name="page_3">
                 <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -807,9 +899,9 @@ border: 5px solid white;
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>-115</y>
+                      <y>0</y>
                       <width>322</width>
-                      <height>661</height>
+                      <height>660</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1571,6 +1663,9 @@ color: rgba(255,255,255,51);
                    <property name="topMargin">
                     <number>20</number>
                    </property>
+                   <property name="bottomMargin">
+                    <number>10</number>
+                   </property>
                    <item>
                     <widget class="QLabel" name="label_6">
                      <property name="styleSheet">
@@ -1603,6 +1698,27 @@ color: rgba(255,255,255,51);
                       </property>
                      </item>
                     </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_14">
+                     <property name="bottomMargin">
+                      <number>10</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_14">
+                       <property name="text">
+                        <string>Buffer Preview</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="adiscope::CustomSwitch" name="bufferPreviewSwitch">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                   </layout>
                  </item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -335,20 +335,23 @@ QPushButton:checked:hover {
                      <number>0</number>
                     </property>
                     <item>
-                     <layout class="QHBoxLayout" name="status">
-                      <property name="spacing">
-                       <number>0</number>
-                      </property>
+                     <layout class="QGridLayout" name="gridLayout">
                       <property name="topMargin">
                        <number>10</number>
                       </property>
-                      <item>
-                       <spacer name="horizontalSpacer_7">
+                      <property name="rightMargin">
+                       <number>20</number>
+                      </property>
+                      <property name="horizontalSpacing">
+                       <number>15</number>
+                      </property>
+                      <property name="verticalSpacing">
+                       <number>0</number>
+                      </property>
+                      <item row="0" column="4">
+                       <spacer name="horizontalSpacer_6">
                         <property name="orientation">
                          <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeType">
-                         <enum>QSizePolicy::Fixed</enum>
                         </property>
                         <property name="sizeHint" stdset="0">
                          <size>
@@ -358,23 +361,17 @@ QPushButton:checked:hover {
                         </property>
                        </spacer>
                       </item>
-                      <item>
-                       <widget class="QLabel" name="currentSampleLabel">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
+                      <item row="1" column="6">
+                       <widget class="QLabel" name="statusLabel">
                         <property name="styleSheet">
                          <string notr="true">color:white;</string>
                         </property>
                         <property name="text">
-                         <string>Sample: </string>
+                         <string/>
                         </property>
                        </widget>
                       </item>
-                      <item>
+                      <item row="0" column="2">
                        <widget class="QLabel" name="currentFrequencyLabel">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -390,10 +387,82 @@ QPushButton:checked:hover {
                         </property>
                        </widget>
                       </item>
-                      <item>
-                       <spacer name="horizontalSpacer_6">
+                      <item row="1" column="1">
+                       <widget class="QLabel" name="dcLabel">
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string/>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="1">
+                       <widget class="QLabel" name="currentSampleLabel">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string>Sample: </string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="3">
+                       <widget class="QLabel" name="errorLabel">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="styleSheet">
+                         <string notr="true">font-weight: bold;
+color:  red;</string>
+                        </property>
+                        <property name="text">
+                         <string/>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="2">
+                       <widget class="QLabel" name="gainLabel">
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string/>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="0">
+                       <spacer name="horizontalSpacer_7">
                         <property name="orientation">
                          <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeType">
+                         <enum>QSizePolicy::Fixed</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item row="1" column="7">
+                       <spacer name="horizontalSpacer_8">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeType">
+                         <enum>QSizePolicy::Fixed</enum>
                         </property>
                         <property name="sizeHint" stdset="0">
                          <size>
@@ -808,9 +877,9 @@ border: 5px solid white;
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>0</y>
+                      <y>-134</y>
                       <width>322</width>
-                      <height>641</height>
+                      <height>867</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1013,6 +1082,211 @@ color: rgba(255,255,255,51);
                         <string>0</string>
                        </property>
                       </widget>
+                     </item>
+                     <item>
+                      <spacer name="verticalSpacer_6">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Fixed</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>9</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_8">
+                       <property name="topMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="spacing">
+                        <number>15</number>
+                       </property>
+                       <item row="4" column="1">
+                        <layout class="QVBoxLayout" name="captureDelayLayout">
+                         <property name="topMargin">
+                          <number>10</number>
+                         </property>
+                        </layout>
+                       </item>
+                       <item row="0" column="1">
+                        <layout class="QVBoxLayout" name="offsetLayout"/>
+                       </item>
+                       <item row="1" column="1">
+                        <layout class="QVBoxLayout" name="pushDelayLayout">
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="rightMargin">
+                          <number>0</number>
+                         </property>
+                        </layout>
+                       </item>
+                       <item row="0" column="0">
+                        <layout class="QVBoxLayout" name="amplitudeLayout"/>
+                       </item>
+                       <item row="3" column="1">
+                        <layout class="QVBoxLayout" name="verticalLayout_19">
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <widget class="QLabel" name="label_19">
+                           <property name="styleSheet">
+                            <string notr="true">font-size: 13px;</string>
+                           </property>
+                           <property name="text">
+                            <string>Gain Mode</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QComboBox" name="responseGainCmb">
+                           <item>
+                            <property name="text">
+                             <string>Automatic</string>
+                            </property>
+                           </item>
+                           <item>
+                            <property name="text">
+                             <string>Low</string>
+                            </property>
+                           </item>
+                           <item>
+                            <property name="text">
+                             <string>High</string>
+                            </property>
+                           </item>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                       <item row="2" column="0" colspan="2">
+                        <layout class="QHBoxLayout" name="horizontalLayout_21">
+                         <property name="spacing">
+                          <number>0</number>
+                         </property>
+                         <property name="topMargin">
+                          <number>25</number>
+                         </property>
+                         <property name="bottomMargin">
+                          <number>15</number>
+                         </property>
+                         <item>
+                          <widget class="QLabel" name="label_18">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QLabel {
+        font-size: 12px;
+        color: rgba(255, 255, 255, 70)
+    }
+</string>
+                           </property>
+                           <property name="text">
+                            <string>RESPONSE </string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="Line" name="line_13">
+                           <property name="maximumSize">
+                            <size>
+                             <width>16777215</width>
+                             <height>1</height>
+                            </size>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                           </property>
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                       <item row="3" column="0">
+                        <layout class="QVBoxLayout" name="verticalLayout_22">
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <widget class="QLabel" name="label_12">
+                           <property name="styleSheet">
+                            <string notr="true">font-size: 13px;</string>
+                           </property>
+                           <property name="text">
+                            <string>DC Filtering</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="adiscope::CustomSwitch" name="dcFilterBtn">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string/>
+                           </property>
+                           <property name="leftText" stdset="0">
+                            <string>On</string>
+                           </property>
+                           <property name="rightText" stdset="0">
+                            <string>Off</string>
+                           </property>
+                           <property name="duration_ms" stdset="0">
+                            <number>0</number>
+                           </property>
+                           <property name="polarity" stdset="0">
+                            <bool>false</bool>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_2">
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="spacing">
+                        <number>15</number>
+                       </property>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="verticalSpacer_18">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Fixed</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>9</height>
+                        </size>
+                       </property>
+                      </spacer>
                      </item>
                      <item>
                       <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -1227,83 +1501,6 @@ color: rgba(255,255,255,51);
                       </layout>
                      </item>
                      <item>
-                      <layout class="QHBoxLayout" name="horizontalLayout_7">
-                       <property name="spacing">
-                        <number>0</number>
-                       </property>
-                       <property name="topMargin">
-                        <number>25</number>
-                       </property>
-                       <property name="bottomMargin">
-                        <number>25</number>
-                       </property>
-                       <item>
-                        <widget class="QLabel" name="label_3">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <property name="styleSheet">
-                          <string notr="true">QLabel {
-        font-size: 12px;
-        color: rgba(255, 255, 255, 70)
-    }
-</string>
-                         </property>
-                         <property name="text">
-                          <string>WAVEFORM </string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="Line" name="line_5">
-                         <property name="minimumSize">
-                          <size>
-                           <width>0</width>
-                           <height>1</height>
-                          </size>
-                         </property>
-                         <property name="maximumSize">
-                          <size>
-                           <width>16777215</width>
-                           <height>1</height>
-                          </size>
-                         </property>
-                         <property name="styleSheet">
-                          <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
-                         </property>
-                         <property name="frameShadow">
-                          <enum>QFrame::Sunken</enum>
-                         </property>
-                         <property name="lineWidth">
-                          <number>1</number>
-                         </property>
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item>
-                      <layout class="QGridLayout" name="gridLayout_8">
-                       <property name="topMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="spacing">
-                        <number>15</number>
-                       </property>
-                       <item row="0" column="1">
-                        <layout class="QVBoxLayout" name="offsetLayout"/>
-                       </item>
-                       <item row="0" column="0">
-                        <layout class="QVBoxLayout" name="amplitudeLayout"/>
-                       </item>
-                      </layout>
-                     </item>
-                     <item>
                       <layout class="QHBoxLayout" name="horizontalLayout_8">
                        <property name="spacing">
                         <number>0</number>
@@ -1312,7 +1509,7 @@ color: rgba(255,255,255,51);
                         <number>25</number>
                        </property>
                        <property name="bottomMargin">
-                        <number>25</number>
+                        <number>19</number>
                        </property>
                        <item>
                         <widget class="QLabel" name="label_4">
@@ -1366,7 +1563,7 @@ color: rgba(255,255,255,51);
                       </layout>
                      </item>
                      <item>
-                      <layout class="QGridLayout" name="gridLayout_9">
+                      <layout class="QGridLayout" name="gridLayout_9" rowminimumheight="0,0,0,0,0,0,0">
                        <property name="topMargin">
                         <number>0</number>
                        </property>
@@ -1379,32 +1576,29 @@ color: rgba(255,255,255,51);
                        <item row="0" column="1">
                         <layout class="QVBoxLayout" name="phaseMinLayout"/>
                        </item>
-                       <item row="3" column="1">
-                        <widget class="adiscope::CustomSwitch" name="dcFilterBtn">
+                       <item row="6" column="0">
+                        <widget class="QLabel" name="label_13">
+                         <property name="styleSheet">
+                          <string notr="true">font-size: 13px;</string>
+                         </property>
                          <property name="text">
                           <string/>
                          </property>
-                         <property name="leftText" stdset="0">
-                          <string>On</string>
-                         </property>
-                         <property name="rightText" stdset="0">
-                          <string>Off</string>
-                         </property>
-                         <property name="duration_ms" stdset="0">
-                          <number>0</number>
-                         </property>
-                         <property name="polarity" stdset="0">
-                          <bool>false</bool>
-                         </property>
                         </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <layout class="QVBoxLayout" name="phaseMaxLayout"/>
+                       </item>
+                       <item row="0" column="0">
+                        <layout class="QVBoxLayout" name="magMinLayout"/>
                        </item>
                        <item row="1" column="0">
                         <layout class="QVBoxLayout" name="magMaxLayout"/>
                        </item>
-                       <item row="2" column="0">
+                       <item row="4" column="0">
                         <widget class="QLabel" name="label_11">
                          <property name="sizePolicy">
-                          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
@@ -1417,7 +1611,7 @@ color: rgba(255,255,255,51);
                          </property>
                         </widget>
                        </item>
-                       <item row="2" column="1">
+                       <item row="4" column="1">
                         <widget class="adiscope::CustomSwitch" name="deltaBtn">
                          <property name="text">
                           <string/>
@@ -1436,37 +1630,51 @@ color: rgba(255,255,255,51);
                          </property>
                         </widget>
                        </item>
-                       <item row="3" column="0">
-                        <widget class="QLabel" name="label_12">
+                      </layout>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_7">
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <widget class="QLabel" name="label_3">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
                          <property name="styleSheet">
-                          <string notr="true">font-size: 13px;</string>
+                          <string notr="true">QLabel {
+        font-size: 12px;
+        color: rgba(255, 255, 255, 70)
+    }
+</string>
                          </property>
                          <property name="text">
-                          <string>Dc Filtering</string>
+                          <string>BUFFER PREVIEWER </string>
                          </property>
                         </widget>
                        </item>
-                       <item row="0" column="0">
-                        <layout class="QVBoxLayout" name="magMinLayout"/>
-                       </item>
-                       <item row="1" column="1">
-                        <layout class="QVBoxLayout" name="phaseMaxLayout"/>
-                       </item>
-                       <item row="5" column="0">
-                        <widget class="QLabel" name="label_13">
-                         <property name="styleSheet">
-                          <string notr="true">font-size: 13px;</string>
+                       <item>
+                        <widget class="Line" name="line_5">
+                         <property name="maximumSize">
+                          <size>
+                           <width>16777215</width>
+                           <height>1</height>
+                          </size>
                          </property>
-                         <property name="text">
-                          <string/>
+                         <property name="styleSheet">
+                          <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                         </property>
+                         <property name="frameShadow">
+                          <enum>QFrame::Plain</enum>
+                         </property>
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
                          </property>
                         </widget>
-                       </item>
-                       <item row="4" column="0">
-                        <layout class="QVBoxLayout" name="pushDelayLayout"/>
-                       </item>
-                       <item row="4" column="1">
-                        <layout class="QVBoxLayout" name="captureDelayLayout"/>
                        </item>
                       </layout>
                      </item>
@@ -1482,6 +1690,236 @@ color: rgba(255,255,255,51);
                         </size>
                        </property>
                       </spacer>
+                     </item>
+                     <item>
+                      <spacer name="verticalSpacer_19">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Fixed</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>20</width>
+                         <height>19</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <layout class="QVBoxLayout" name="verticalLayout_21">
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <layout class="QHBoxLayout" name="horizontalLayout_20">
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <widget class="adiscope::CustomSwitch" name="bufferPreviewSwitch">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>100</width>
+                             <height>30</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_9">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="viewInOscBtn">
+                           <property name="enabled">
+                            <bool>false</bool>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>100</width>
+                             <height>30</height>
+                            </size>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QPushButton {
+  min-height: 30px;
+  max-height: 30px;
+
+  border: 0px;
+  border-radius: 4px;
+
+  background-color: #4a64ff;
+  color: #ffffff;
+
+  font-size: 14px;
+}
+
+QPushButton:pressed {
+  background-color: #2a44df;
+}
+
+QPushButton:hover {
+	background-color: #4a34ff;
+}
+QPushButton:disabled {
+background-color: #727273;
+}</string>
+                           </property>
+                           <property name="text">
+                            <string>ViewInOsc</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                       <item>
+                        <layout class="QHBoxLayout" name="horizontalLayout_23">
+                         <property name="bottomMargin">
+                          <number>20</number>
+                         </property>
+                         <item>
+                          <widget class="QPushButton" name="prevBtn">
+                           <property name="enabled">
+                            <bool>false</bool>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>100</width>
+                             <height>30</height>
+                            </size>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QPushButton {
+  min-height: 30px;
+  max-height: 30px;
+
+  border: 0px;
+  border-radius: 4px;
+
+  background-color: #4a64ff;
+  color: #ffffff;
+
+  font-size: 14px;
+}
+
+QPushButton:pressed {
+  background-color: #2a44df;
+}
+
+QPushButton:hover {
+	background-color: #4a34ff;
+}
+QPushButton:disabled {
+background-color: #727273;
+}</string>
+                           </property>
+                           <property name="text">
+                            <string>Previous</string>
+                           </property>
+                           <property name="icon">
+                            <iconset resource="../resources/resources.qrc">
+                             <normaloff>:/icons/ic arrow left.svg</normaloff>:/icons/ic arrow left.svg</iconset>
+                           </property>
+                           <property name="iconSize">
+                            <size>
+                             <width>12</width>
+                             <height>12</height>
+                            </size>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_10">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="nextBtn">
+                           <property name="enabled">
+                            <bool>false</bool>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>100</width>
+                             <height>30</height>
+                            </size>
+                           </property>
+                           <property name="layoutDirection">
+                            <enum>Qt::RightToLeft</enum>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QPushButton {
+  min-height: 30px;
+  max-height: 30px;
+
+  border: 0px;
+  border-radius: 4px;
+
+  background-color: #4a64ff;
+  color: #ffffff;
+
+  font-size: 14px;
+text-align: right;
+padding-left: 20px;
+}
+
+QPushButton:pressed {
+  background-color: #2a44df;
+}
+
+QPushButton:hover {
+	background-color: #4a34ff;
+}
+QPushButton:disabled {
+background-color: #727273;
+}</string>
+                           </property>
+                           <property name="text">
+                            <string>     Next</string>
+                           </property>
+                           <property name="icon">
+                            <iconset resource="../resources/resources.qrc">
+                             <normaloff>:/icons/ic arrow right.svg</normaloff>:/icons/ic arrow right.svg</iconset>
+                           </property>
+                           <property name="iconSize">
+                            <size>
+                             <width>12</width>
+                             <height>12</height>
+                            </size>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
                      </item>
                      <item>
                       <spacer name="horizontalSpacer_3">
@@ -1504,6 +1942,9 @@ color: rgba(255,255,255,51);
                </widget>
                <widget class="QWidget" name="page_4">
                 <layout class="QVBoxLayout" name="verticalLayout_16">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
                  <property name="leftMargin">
                   <number>20</number>
                  </property>
@@ -1569,134 +2010,178 @@ color: rgba(255,255,255,51);
                  <item>
                   <layout class="QVBoxLayout" name="verticalLayout_15">
                    <property name="spacing">
-                    <number>10</number>
+                    <number>0</number>
                    </property>
                    <property name="topMargin">
-                    <number>20</number>
+                    <number>25</number>
                    </property>
                    <property name="bottomMargin">
-                    <number>10</number>
+                    <number>0</number>
                    </property>
                    <item>
-                    <widget class="QLabel" name="label_6">
-                     <property name="styleSheet">
-                      <string notr="true">QLabel {
-  font-size: 14px;
-  font-family: &quot;monospace&quot;;
-  color: rgba(255, 255, 255, 153);
-}</string>
+                    <layout class="QHBoxLayout" name="horizontalLayout_15">
+                     <property name="spacing">
+                      <number>0</number>
                      </property>
-                     <property name="text">
-                      <string>Plot</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QComboBox" name="cmb_graphs">
-                     <item>
-                      <property name="text">
-                       <string>Bode</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Nyquist</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Nichols</string>
-                      </property>
-                     </item>
-                    </widget>
-                   </item>
-                   <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_14">
-                     <property name="bottomMargin">
-                      <number>10</number>
+                     <property name="topMargin">
+                      <number>0</number>
                      </property>
                      <item>
-                      <widget class="QLabel" name="label_14">
+                      <widget class="QLabel" name="label_6">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true">QLabel {
+        font-size: 12px;
+        color: rgba(255, 255, 255, 70);
+    }</string>
+                       </property>
                        <property name="text">
-                        <string>Buffer Preview</string>
+                        <string>PLOT </string>
                        </property>
                       </widget>
                      </item>
                      <item>
-                      <widget class="adiscope::CustomSwitch" name="bufferPreviewSwitch">
-                       <property name="text">
-                        <string/>
+                      <widget class="Line" name="line_9">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>1</height>
+                        </size>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>1</height>
+                        </size>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
                        </property>
                       </widget>
                      </item>
                     </layout>
                    </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_6">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Fixed</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>15</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="btnExport">
-                   <property name="styleSheet">
-                    <string notr="true">QPushButton {
-  min-height: 30px;
-  max-height: 30px;
-
-  border: 0px;
-  border-radius: 4px;
-
-  background-color: #4a64ff;
-  color: #ffffff;
-
-  font-size: 14px;
-}
-
-QPushButton:pressed {
-  background-color: #2a44df;
-}
-
-QPushButton:hover {
-	background-color: #4a34ff;
-}</string>
-                   </property>
-                   <property name="text">
-                    <string>Export</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_13">
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
                    <item>
-                    <layout class="QVBoxLayout" name="verticalLayout_12">
-                     <property name="rightMargin">
+                    <spacer name="verticalSpacer_14">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Fixed</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>15</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_17">
+                     <property name="spacing">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_16">
+                       <property name="styleSheet">
+                        <string notr="true">font-size: 13px;</string>
+                       </property>
+                       <property name="text">
+                        <string>Type</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QComboBox" name="cmb_graphs">
+                       <property name="minimumSize">
+                        <size>
+                         <width>141</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                       <item>
+                        <property name="text">
+                         <string>Bode</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>Nyquist</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>Nichols</string>
+                        </property>
+                       </item>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_13">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Fixed</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>15</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_13">
+                     <property name="spacing">
                       <number>0</number>
                      </property>
                      <property name="bottomMargin">
                       <number>0</number>
                      </property>
                      <item>
-                      <widget class="QLabel" name="label_10">
-                       <property name="text">
-                        <string>Line thickness</string>
+                      <layout class="QVBoxLayout" name="verticalLayout_12">
+                       <property name="spacing">
+                        <number>0</number>
                        </property>
-                      </widget>
+                       <property name="rightMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <widget class="QLabel" name="label_10">
+                         <property name="styleSheet">
+                          <string notr="true">font-size: 13px;</string>
+                         </property>
+                         <property name="text">
+                          <string>Line thickness</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
                      </item>
                      <item>
                       <widget class="QComboBox" name="cbLineThickness">
@@ -1764,20 +2249,110 @@ QPushButton:hover {
                     </layout>
                    </item>
                    <item>
-                    <spacer name="horizontalSpacer_5">
+                    <spacer name="verticalSpacer_16">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Vertical</enum>
                      </property>
                      <property name="sizeType">
-                      <enum>QSizePolicy::Expanding</enum>
+                      <enum>QSizePolicy::Fixed</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
-                       <width>40</width>
-                       <height>20</height>
+                       <width>20</width>
+                       <height>25</height>
                       </size>
                      </property>
                     </spacer>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_18">
+                     <property name="spacing">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_17">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true">QLabel {
+        font-size: 12px;
+        color: rgba(255, 255, 255, 70);
+    }</string>
+                       </property>
+                       <property name="text">
+                        <string>EXPORT</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="Line" name="line_11">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>1</height>
+                        </size>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_17">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Fixed</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>15</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnExport">
+                     <property name="styleSheet">
+                      <string notr="true">QPushButton {
+  min-height: 30px;
+  max-height: 30px;
+
+  border: 0px;
+  border-radius: 4px;
+
+  background-color: #4a64ff;
+  color: #ffffff;
+
+  font-size: 14px;
+}
+
+QPushButton:pressed {
+  background-color: #2a44df;
+}
+
+QPushButton:hover {
+	background-color: #4a34ff;
+}</string>
+                     </property>
+                     <property name="text">
+                      <string>Export</string>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </item>

--- a/ui/networkanalyzerbufferviewer.ui
+++ b/ui/networkanalyzerbufferviewer.ui
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NetworkAnalyzerBufferViewer</class>
+ <widget class="QWidget" name="NetworkAnalyzerBufferViewer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>40</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="mainWidget" native="true">
+     <layout class="QVBoxLayout" name="mainLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="previousBtn">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/resources.qrc">
+         <normaloff>:/icons/time_trigger_left.svg</normaloff>:/icons/time_trigger_left.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="autoRepeat">
+        <bool>true</bool>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="viewInOsc">
+       <property name="minimumSize">
+        <size>
+         <width>160</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QPushButton {
+  min-height: 30px;
+  max-height: 30px;
+
+  border: 0px;
+  border-radius: 4px;
+
+  background-color: #4a64ff;
+  color: #ffffff;
+
+  font-size: 14px;
+}
+
+QPushButton:pressed {
+  background-color: #2a44df;
+}
+
+QPushButton:hover {
+	background-color: #4a34ff;
+}</string>
+       </property>
+       <property name="text">
+        <string>View in Oscilloscope</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="nextBtn">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/resources.qrc">
+         <normaloff>:/icons/time_trigger_right.svg</normaloff>:/icons/time_trigger_right.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="autoRepeat">
+        <bool>true</bool>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/ui/networkanalyzerbufferviewer.ui
+++ b/ui/networkanalyzerbufferviewer.ui
@@ -18,7 +18,7 @@
     <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>0</number>
+    <number>40</number>
    </property>
    <property name="topMargin">
     <number>0</number>
@@ -50,130 +50,8 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="previousBtn">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/resources.qrc">
-         <normaloff>:/icons/time_trigger_left.svg</normaloff>:/icons/time_trigger_left.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>32</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="autoRepeat">
-        <bool>true</bool>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="viewInOsc">
-       <property name="minimumSize">
-        <size>
-         <width>160</width>
-         <height>30</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>30</height>
-        </size>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QPushButton {
-  min-height: 30px;
-  max-height: 30px;
-
-  border: 0px;
-  border-radius: 4px;
-
-  background-color: #4a64ff;
-  color: #ffffff;
-
-  font-size: 14px;
-}
-
-QPushButton:pressed {
-  background-color: #2a44df;
-}
-
-QPushButton:hover {
-	background-color: #4a34ff;
-}</string>
-       </property>
-       <property name="text">
-        <string>View in Oscilloscope</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="nextBtn">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/resources.qrc">
-         <normaloff>:/icons/time_trigger_right.svg</normaloff>:/icons/time_trigger_right.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>32</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="autoRepeat">
-        <bool>true</bool>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
- <resources>
-  <include location="../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -1177,6 +1177,78 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
                 </item>
                </layout>
               </item>
+              <item>
+               <spacer name="verticalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>5</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_18">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="na_gainCheckBox">
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_20">
+                  <property name="text">
+                   <string>Enable gain adjustment</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_16">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
              </layout>
             </widget>
            </item>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -1193,62 +1193,6 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
                 </property>
                </spacer>
               </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_18">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="na_gainCheckBox">
-                  <property name="styleSheet">
-                   <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_20">
-                  <property name="text">
-                   <string>Enable gain adjustment</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_16">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
              </layout>
             </widget>
            </item>

--- a/ui/startstoprangewidget.ui
+++ b/ui/startstoprangewidget.ui
@@ -21,16 +21,19 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
-    <number>6</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>6</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>6</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>6</number>
+    <number>0</number>
+   </property>
+   <property name="spacing">
+    <number>15</number>
    </property>
    <item row="0" column="1">
     <layout class="QVBoxLayout" name="stopValueLayout"/>


### PR DESCRIPTION
This pull request implements new features for the NetworkAnalyzer:
- Preview the captured buffers and send them into the Oscilloscope: #517
- Add an option for the response channel to remove the DC voltage: #518 
- More options to adjust the phase: #516
- If the response signal is to low, the user will get a warning and know if the Network Analyzer can provide quality readings: #504 
also it fixes some issues:
- less time is spent on a sweep: #194 
- an issue with the phase labeling #515 
- an issue with the plot scale: #509 