### PR TITLE
measure.cpp: add explicit parantheses to logical condition check

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -687,11 +687,11 @@ void Measure::measure()
 			CrossPoint &p0 = crossSequence[i - 1];
 			CrossPoint &p1 = crossSequence[i];
 			if ((p1.m_bufIdx == p0.m_bufIdx) && (p1.m_onRising == p0.m_onRising)) {
-				if (p0.m_name == "MR" && p1.m_name == "LR" ||
-						p0.m_name == "HR" && p1.m_name == "MR")
+				if ((p0.m_name == "MR" && p1.m_name == "LR") ||
+						(p0.m_name == "HR" && p1.m_name == "MR"))
 					crossSequence.swap(i, i - 1);
-				else if (p0.m_name == "MF" && p1.m_name == "HF" ||
-						p0.m_name == "LF" && p1.m_name == "MF")
+				else if ((p0.m_name == "MF" && p1.m_name == "HF") ||
+						(p0.m_name == "LF" && p1.m_name == "MF"))
 					crossSequence.swap(i, i - 1);
 			}
 		}


### PR DESCRIPTION
Compiler warning is:
````
<scopy>/src/measure.cpp:690:27: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
     if (p0.m_name == "MR" && p1.m_name == "LR" ||
         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
<scopy>/src/measure.cpp:693:32: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
     else if (p0.m_name == "MF" && p1.m_name == "HF" ||
```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>