### PR TITLE
SignalGenerator: make sure the check the current sample rate vs max s…

### DIFF
--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -2228,7 +2228,7 @@ size_t SignalGenerator::get_samples_count(const struct iio_device *dev,
 			//else
 
 			// for less than max sample rates, generate at least 10 samples per period
-			if (ratio < 10.0 && sample_rate < max_sample_rate)
+			if (ratio < 10.0 && rate < max_sample_rate)
 				return 0;
 			if (ratio < 2.0) {
 				return 0;        /* rate too low */


### PR DESCRIPTION
…ample rate

when deciding wheter to jump to the next sample rate available in order to obtain more "points per period"

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>