### PR TITLE
src/dmm.cpp: make sure to first toggle the small run button

### DIFF
--- a/src/dmm.cpp
+++ b/src/dmm.cpp
@@ -85,9 +85,9 @@ DMM::DMM(struct iio_context *ctx, Filter *filt, std::shared_ptr<GenericAdc> adc,
 	}
 
 	connect(ui->run_button, SIGNAL(toggled(bool)),
-			this, SLOT(toggleTimer(bool)));
-	connect(ui->run_button, SIGNAL(toggled(bool)),
 			runButton, SLOT(setChecked(bool)));
+	connect(ui->run_button, SIGNAL(toggled(bool)),
+			this, SLOT(toggleTimer(bool)));
 	connect(runButton, SIGNAL(toggled(bool)), ui->run_button,
 			SLOT(setChecked(bool)));
 	connect(ui->run_button, SIGNAL(toggled(bool)),


### PR DESCRIPTION
In order to stop other tools that share the m2k adc before starting the dmm.

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>