### PR TITLE
Oscilloscope: Fixes bug where wrong channel is selected on startup

### DIFF
--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1149,6 +1149,7 @@ void Oscilloscope::settingsLoaded()
 		if (channelWidgetAtId(i)->menuButton()->isChecked() &&
 				!channelWidgetAtId(i)->isReferenceChannel()) {
 			current_ch_widget = i;
+			channelWidgetAtId(i)->menuButton()->setChecked(true);
 			break;
 		}
 

--- a/src/oscilloscope_api.cpp
+++ b/src/oscilloscope_api.cpp
@@ -436,7 +436,9 @@ void Oscilloscope_API::setCurrentChannel(int chn_id)
 
 	if (chn_widget->enableButton()->isChecked()) {
 		osc->setChannelWidgetIndex(chn_id);
+		osc->current_channel = chn_id;
 		chn_widget->nameButton()->setChecked(true);
+		chn_widget->menuButton()->setChecked(true);
 	}
 }
 


### PR DESCRIPTION
This bug occurs when saving a configuration with different channels
and channel widget enables. On startup, a different channel will be
selected in Scopy as the one shown in the GUI, causing confusion when
controlling channel specific parameters (such as v/div)


Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>