### PR TITLE
Oscilloscope: Fix ac coupling for XY and FFT plots

### DIFF
--- a/src/cancel_dc_offset_block.cpp
+++ b/src/cancel_dc_offset_block.cpp
@@ -1,10 +1,10 @@
 #include "cancel_dc_offset_block.h"
 
 #include <gnuradio/blocks/moving_average_ff.h>
-#include <gnuradio/blocks/skiphead.h>
 #include <gnuradio/blocks/repeat.h>
 #include <gnuradio/blocks/sub_ff.h>
 #include <gnuradio/blocks/copy.h>
+#include <gnuradio/blocks/keep_one_in_n.h>
 
 #include <iostream>
 
@@ -61,24 +61,24 @@ void cancel_dc_offset_block::_build_and_connect_blocks()
 
 	if (d_enabled) {
 		auto avg = gr::blocks::moving_average_ff::make(d_buffer_size, 1.0 / d_buffer_size, d_buffer_size);
-		auto skip = gr::blocks::skiphead::make(sizeof(float), d_buffer_size - 1);
+		auto keep = gr::blocks::keep_one_in_n::make(sizeof(float), d_buffer_size);
 		auto repeat = gr::blocks::repeat::make(sizeof(float), d_buffer_size);
 		auto sub = gr::blocks::sub_ff::make();
 
 		hier_block2::connect(this->self(), 0, avg, 0);
-		hier_block2::connect(avg, 0, skip, 0);
-		hier_block2::connect(skip, 0, d_vs, 0);
-		hier_block2::connect(skip, 0, repeat, 0);
+		hier_block2::connect(avg, 0, keep, 0);
+		hier_block2::connect(keep, 0, d_vs, 0);
+		hier_block2::connect(keep, 0, repeat, 0);
 		hier_block2::connect(this->self(), 0, sub, 0);
 		hier_block2::connect(repeat, 0, sub, 1);
 		hier_block2::connect(sub, 0, this->self(), 0);
 	} else {
 		auto avg = gr::blocks::moving_average_ff::make(d_buffer_size, 1.0 / d_buffer_size, d_buffer_size);
-		auto skip = gr::blocks::skiphead::make(sizeof(float), d_buffer_size - 1);
+		auto keep = gr::blocks::keep_one_in_n::make(sizeof(float), d_buffer_size);
 
 		hier_block2::connect(this->self(), 0, avg, 0);
-		hier_block2::connect(avg, 0, skip, 0);
-		hier_block2::connect(skip, 0, d_vs, 0);
+		hier_block2::connect(avg, 0, keep, 0);
+		hier_block2::connect(keep, 0, d_vs, 0);
 
 		auto copy = gr::blocks::copy::make(sizeof(float));
 		hier_block2::connect(this->self(), 0, copy, 0);

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1080,6 +1080,7 @@ void Oscilloscope::updateTriggerLevelValue(std::vector<float> value)
 	if (!triggerLevelSink.first) {
 		return;
 	}
+
 	triggerLevelSink.first->blockSignals(true);
 
 	float val = dc_cancel.at(triggerLevelSink.second)->get_dc_offset();
@@ -1250,6 +1251,8 @@ void Oscilloscope::activateAcCoupling(int i)
 	iio->connect(dc_cancel.at(i), 0, qt_time_block, i);
 	iio->connect(dc_cancel.at(i), 0, math_probe_atten.at(i), 0);
 
+	iio->disconnect(block, i, qt_hist_block, i);
+	iio->connect(dc_cancel.at(i), 0, qt_hist_block, i);
 
 	if (trigger && !triggerLevelSink.first) {
 		triggerLevelSink.first = boost::make_shared<signal_sample>();
@@ -1338,6 +1341,9 @@ void Oscilloscope::deactivateAcCoupling(int i)
 	iio->disconnect(dc_cancel.at(i), 0, qt_time_block, i);
 
 	iio->connect(block, i, qt_time_block, i);
+
+	iio->disconnect(dc_cancel.at(i), 0, qt_hist_block, i);
+	iio->connect(block, i, qt_hist_block, i);
 
 	if (trigger && triggerLevelSink.first) {
 		disconnect(&*triggerLevelSink.first, SIGNAL(triggered(std::vector<float>)),
@@ -1472,6 +1478,7 @@ void Oscilloscope::configureAcCoupling(int i, bool coupled)
 		deactivateAcCoupling(i);
 		activateAcCoupling(i);
 	}
+	scaleHistogramPlot();
 }
 
 void Oscilloscope::enableLabels(bool enable)

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -61,6 +61,7 @@
 #include "osc_import_settings.h"
 #include "math.hpp"
 #include "scroll_filter.hpp"
+#include "cancel_dc_offset_block.h"
 
 #include "oscilloscope_api.hpp"
 
@@ -334,8 +335,6 @@ namespace adiscope {
 
 		std::vector<bool> chnAcCoupled;
 		bool triggerAcCoupled;
-		std::vector<gr::basic_block_sptr> filterBlocks;
-		std::vector<gr::basic_block_sptr> subBlocks;
 		QPair<boost::shared_ptr<signal_sample>, int> triggerLevelSink;
 		boost::shared_ptr<gr::blocks::keep_one_in_n> keep_one;
 		boost::shared_ptr<gr::blocks::vector_sink_f> autosetFFTSink;
@@ -422,6 +421,7 @@ namespace adiscope {
 		void init_channel_settings();
 		void editMathChannelFunction(int id, const std::string &new_function);
 
+		std::vector<boost::shared_ptr<cancel_dc_offset_block>> dc_cancel;
 		std::vector<QPair<gr::basic_block_sptr, int> > xy_channels;
 		int index_x, index_y;
 		bool locked;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -313,7 +313,6 @@ namespace adiscope {
 		std::vector<boost::shared_ptr<gr::blocks::multiply_const_ff>> math_probe_atten;
 
 		iio_manager::port_id *ids;
-		iio_manager::port_id *fft_ids;
 		iio_manager::port_id *hist_ids;
 		iio_manager::port_id *autoset_id;
 
@@ -423,9 +422,12 @@ namespace adiscope {
 
 		std::vector<boost::shared_ptr<cancel_dc_offset_block>> dc_cancel;
 		std::vector<QPair<gr::basic_block_sptr, int> > xy_channels;
+		std::vector<QPair<gr::basic_block_sptr, int> > fft_channels;
 		int index_x, index_y;
 		bool locked;
 		boost::shared_ptr<gr::blocks::float_to_complex> ftc;
+		std::vector<gr::basic_block_sptr> fft_blocks;
+		std::vector<gr::basic_block_sptr> ctm_blocks;
 
 		void cancelZoom();
 


### PR DESCRIPTION
DC filtering was applied only for the Time plot, while XY and FFT plots had the original signals as input channels. 

This PR adds some changes to redirect the filtered signal to XY and FFT.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>