### PR TITLE
build,travis: make ubuntu version check more robust

### DIFF
--- a/CI/travis/before_install_linux.sh
+++ b/CI/travis/before_install_linux.sh
@@ -53,15 +53,7 @@ handle_default() {
 sudo apt-get -qq update
 sudo apt-get install -y build-essential g++ bison flex libxml2-dev libglibmm-2.4-dev \
 	libmatio-dev libglib2.0-dev libzip-dev libfftw3-dev libusb-dev doxygen \
-	python-cheetah
-
-# Trusty has an old boost and a newer boost; 1.55 is the minimum for Scopy
-if [ "$(get_codename)" == "trusty" ] ; then
-	sudo apt-get install -y cmake3
-	BOOST_VER=1.55
-else
-	sudo apt-get install -y cmake
-fi
+	python-cheetah cmake
 
 BOOST_PACKAGES_BASE="libboost libboost-regex libboost-date-time
 	libboost-program-options libboost-test libboost-filesystem

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -12,13 +12,26 @@ fi
 
 export PYTHON3=python3
 
+version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+version_le() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; }
+version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
+version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
 get_codename() {
-	lsb_release -a 2>/dev/null | grep Codename | cut -f2
+	lsb_release -c -s
+}
+
+get_dist_id() {
+	lsb_release -i -s
+}
+
+get_version() {
+	lsb_release -r -s
 }
 
 is_new_ubuntu() {
-	[ "$(uname -s)" == "Linux" ] || return 1
-	[ "$(get_codename)" == "bionic" ]
+	[ "$(get_dist_id)" == "Ubuntu" ] || return 1
+	version_ge "$(get_version)" "18.04"
 }
 
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-'./'}


### PR DESCRIPTION
The version check functions were picked up from:
  http://ask.xmodulo.com/compare-two-version-numbers.html

The previous check would only check for Ubuntu Bionic (18.04) and disregard
18.10 & 19.04.

This check should work to include anything starting with 18.04 and newer.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>