### PR TITLE
NetworkAnalyzer: set adc_buffer to nullptr after deleting it

### DIFF
--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -1125,6 +1125,7 @@ void NetworkAnalyzer::goertzel()
 		size_t ret = iio_buffer_refill(adc_buffer);
 		if (m_stop) {
 			iio_buffer_destroy(adc_buffer);
+			adc_buffer = nullptr;
 			for (auto& buffer : buffers) {
 				iio_buffer_destroy(buffer);
 			}
@@ -1187,6 +1188,7 @@ void NetworkAnalyzer::goertzel()
 		}
 
 		iio_buffer_destroy(adc_buffer);
+		adc_buffer = nullptr;
 
 		// Process was cancelled
 		if (m_stop) {


### PR DESCRIPTION
Fixes issue #667 

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>