### PR TITLE
ToolLauncher: When the calib thread finishes, then update the UI

### DIFF
--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -199,6 +199,7 @@ private:
 	QFutureWatcher<QVector<QString>> watcher;
 	QFuture<QVector<QString>> future;
 	QFuture<void> calibration_thread;
+	QFutureWatcher<void> calibration_thread_watcher;
 
 	DMM *dmm;
 	PowerController *power_control;


### PR DESCRIPTION
Fixes: "ASSERT failure in QCoreApplication::sendEvent: "Cannot send events to objects owned by a different thread. Current thread 0x0x1bdec10. Receiver 'btnCalibrate' (of type 'QPushButton') was created in thread 0x0x149faa0", file kernel/qcoreapplication.cpp, line 563
"

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>