### PR TITLE
ToolLauncher: Fix the calibration button.

### DIFF
--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -156,6 +156,7 @@ private Q_SLOTS:
 	void _toolSelected(tool tool);
 	void restartToolsAfterCalibration();
 	void calibrationFailedCallback();
+	void calibrationThreadWatcherFinished();
 private:
 	QList<Tool*> calibration_saved_tools;
 	void loadToolTips(bool connected);


### PR DESCRIPTION
Disconnect the thread watcher when a device session is closed.

When the device is connected, the thread watcher is initialized and connected to the worker Q_SLOT, but not disconnected once the device gets disconnected.

This causes issues when connecting and disconnecting multiple times in a single Scopy session, and then using the "Calibrate" button to calibrate.

The calibration process gets called multiple times. Because of sync issues, it's possible that none of the calibration works. Then the device is left in an unknown state.

This should fix issue #712 .

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>