### PR TITLE
Disable auto screen scaling on Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,11 @@ using namespace adiscope;
 
 int main(int argc, char **argv)
 {
+#ifdef Q_OS_WIN
 	/* Set environment variable QT_AUTO_SCREEN_SCALE_FACTOR to 1(true) thus
 	 * making Scopy aware of the scaling settings set by the OS */
 	qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", QString("1").toLocal8Bit());
+#endif
 #if BREAKPAD_HANDLER
 #ifdef Q_OS_LINUX
 	google_breakpad::MinidumpDescriptor descriptor("/tmp");


### PR DESCRIPTION
The env. variable for auto scaling breaks things on linux. This fixes the issue.

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>