### PR TITLE
dmm: fix data logging

### DIFF
--- a/src/dmm.cpp
+++ b/src/dmm.cpp
@@ -386,11 +386,11 @@ void DMM::chooseFile()
 {
 	QString selectedFilter;
 
-	QString fileName = QFileDialog::getSaveFileName(this,
+	filename = QFileDialog::getSaveFileName(this,
 	    tr("Export"), "", tr("Comma-separated values files (*.csv);;All Files(*)"),
 	    &selectedFilter, (m_useNativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog));
 
-	ui->filename->setText(fileName);
+	ui->filename->setText(filename);
 
 	if(!ui->run_button->isChecked()) {
 		toggleDataLogging(data_logging);


### PR DESCRIPTION
The data logging mechanism checks the filename member of the DMM to see
where to save the data. Unfortunately this member was not set anymore so
the DMM assumed that no file was given by the user. This commit fixes this
issue

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>