### PR TITLE
Windows installer: allow the user to change installation directory

### DIFF
--- a/scopy-32.iss.cmakein
+++ b/scopy-32.iss.cmakein
@@ -23,6 +23,7 @@ ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
+DisableDirPage=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/scopy-64.iss.cmakein
+++ b/scopy-64.iss.cmakein
@@ -23,6 +23,7 @@ ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
+DisableDirPage=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/scopy.iss.cmakein
+++ b/scopy.iss.cmakein
@@ -23,6 +23,7 @@ ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
+DisableDirPage=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Even though a default path is specified, some systems might override it.
The result is "Scopy" being installed in places where you wouldn't want
it to be installed.

Signed-off-by: Daniel Guramulta <Daniel.Guramulta@analog.com>