### PR TITLE
CMake: Only build breakpad by default on appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,13 +81,18 @@ if (NOT "${OUT_CONSTEXPR}" STREQUAL "-1")
 endif()
 
 
-option(BREAKPAD_HANDLER "Build with breakpad exception handler " ON)
-set(BREAKPAD_HANDLER_BOOL 0)
-if (BREAKPAD_HANDLER)
+option(BREAKPAD_HANDLER "Build with breakpad exception handler " OFF)
+if (${BREAKPAD_HANDLER})
 	set(BREAKPAD_HANDLER_BOOL 1)
 	find_library(BREAKPAD_LIBRARIES NAMES breakpad)
 	find_library(BREAKPADCLIENT_LIBRARIES NAMES breakpad_client)
 	find_path(BREAKPAD_INCLUDE_DIRS breakpad)
+else()
+	set(BREAKPAD_HANDLER_BOOL 0)
+	SET(BREAKPAD_LIBRARIES "")
+	SET(BREAKPAD_INCLUDE_DIRS "")
+	SET(BREAKPADCLIENT_LIBRARIES "")
+
 endif()
 
 find_package(Qt5Widgets REQUIRED)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ build_script:
         )
     
     - set PATH=C:\msys64\%MINGW_VERSION%\bin;%PATH%
-    - C:\msys64\usr\bin\bash -lc "mkdir /c/%BUILD_FOLDER% ; cd /c/%BUILD_FOLDER% ; cmake -G 'Unix Makefiles' %RC_COMPILER% -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe /c/projects/scopy"
+    - C:\msys64\usr\bin\bash -lc "mkdir /c/%BUILD_FOLDER% ; cd /c/%BUILD_FOLDER% ; cmake -G 'Unix Makefiles' %RC_COMPILER% -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DBREAKPAD_HANDLER=ON /c/projects/scopy"
     - C:\msys64\usr\bin\bash -lc "cd /c/%BUILD_FOLDER%/resources && sed -i 's/^\(FILEVERSION .*\)$/\1,0,"{build}"/' properties.rc"
     - C:\msys64\usr\bin\bash -lc "cd /c/build_%ARCH_BIT% && make -j3"
 


### PR DESCRIPTION
This pull request will install breakpad only on the appveyor build. This will not be built on development machines as the library does not add value for development builds.
Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>