### PR TITLE
Add digital filters to the ADC data acquisition flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@
 cmake_minimum_required(VERSION 3.1.3)
 project(scopy LANGUAGES CXX VERSION 1.1.1)
 
+set(Python_ADDITIONAL_VERSIONS 3)
+FIND_PACKAGE(PythonInterp REQUIRED)
+set(PYTHON_VERSION python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+
 # Get the GIT hash of the latest commit
 include(FindGit OPTIONAL)
 if (GIT_FOUND)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,8 @@ build_script:
         )
     
     - set PATH=C:\msys64\%MINGW_VERSION%\bin;%PATH%
-    - C:\msys64\usr\bin\bash -lc "mkdir /c/%BUILD_FOLDER% ; cd /c/%BUILD_FOLDER% ; cmake -G 'Unix Makefiles' %RC_COMPILER% -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DBREAKPAD_HANDLER=ON /c/projects/scopy"
+    - C:\msys64\usr\bin\bash -lc "/%MINGW_VERSION%/bin/python3.exe --version"
+    - C:\msys64\usr\bin\bash -lc "mkdir /c/%BUILD_FOLDER% ; cd /c/%BUILD_FOLDER% ; cmake -G 'Unix Makefiles' %RC_COMPILER% -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DBREAKPAD_HANDLER=ON -DPYTHON_EXECUTABLE=/%MINGW_VERSION%/bin/python3.exe /c/projects/scopy"
     - C:\msys64\usr\bin\bash -lc "cd /c/%BUILD_FOLDER%/resources && sed -i 's/^\(FILEVERSION .*\)$/\1,0,"{build}"/' properties.rc"
     - C:\msys64\usr\bin\bash -lc "cd /c/build_%ARCH_BIT% && make -j3"
 

--- a/scopy-32.iss.cmakein
+++ b/scopy-32.iss.cmakein
@@ -1,7 +1,7 @@
 #define AppExeName "Scopy.exe"
 #define AppName "Scopy"
 #define AppDev "Analog Devices"
-#define Python "python3.7"
+#define Python "@PYTHON_VERSION@"
 
 [Setup]
 AppId={{02A7A7F9-F068-4B1C-85F6-B6D325938E19}

--- a/scopy-64.iss.cmakein
+++ b/scopy-64.iss.cmakein
@@ -1,7 +1,7 @@
 #define AppExeName "Scopy.exe"
 #define AppName "Scopy"
 #define AppDev "Analog Devices"
-#define Python "python3.7"
+#define Python "@PYTHON_VERSION@"
 
 [Setup]
 AppId={{02A7A7F9-F068-4B1C-85F6-B6D325938E19}

--- a/scopy.iss.cmakein
+++ b/scopy.iss.cmakein
@@ -1,7 +1,7 @@
 #define AppExeName "Scopy.exe"
 #define AppName "Scopy"
 #define AppDev "Analog Devices"
-#define Python "python3.7"
+#define Python "@PYTHON_VERSION@"
 
 [Setup]
 AppId={{02A7A7F9-F068-4B1C-85F6-B6D325938E19}

--- a/src/frequency_compensation_filter.h
+++ b/src/frequency_compensation_filter.h
@@ -38,14 +38,14 @@ namespace adiscope {
        * \param itemsize the item size of the stream
        * \param nstreams number of streams to combine into a vector (vector size)
        */
-      static sptr make(bool enable = true, float TC = 1, float gain = -1,
+      static sptr make(bool enable = true, float TC = 1, float gain = 0,
 		       float sample_rate = 100000000);
-      virtual void set_enable(bool en) = 0;
-      virtual bool get_enable() = 0;
-      virtual void set_TC(float TC) = 0;
-      virtual float get_TC() = 0;
-      virtual void set_gain(float gain) = 0;
-      virtual float get_gain() = 0;
+      virtual void set_enable(bool en, int gain_mode = 2) = 0;
+      virtual bool get_enable(int gain_mode = 2) = 0;
+      virtual void set_TC(float TC, int gain_mode = 2) = 0;
+      virtual float get_TC(int gain_mode = 2) = 0;
+      virtual void set_filter_gain(float gain, int gain_mode = 2) = 0;
+      virtual float get_filter_gain(int gain_mode = 2) = 0;
       virtual void set_sample_rate(float sample_rate) = 0;
       virtual bool get_high_gain() = 0;
       virtual void set_high_gain(bool en) = 0;

--- a/src/frequency_compensation_filter.h
+++ b/src/frequency_compensation_filter.h
@@ -47,6 +47,8 @@ namespace adiscope {
       virtual void set_gain(float gain) = 0;
       virtual float get_gain() = 0;
       virtual void set_sample_rate(float sample_rate) = 0;
+      virtual bool get_high_gain() = 0;
+      virtual void set_high_gain(bool en) = 0;
     };
 
 } /* namespace adiscope */

--- a/src/frequency_compensation_filter.h
+++ b/src/frequency_compensation_filter.h
@@ -1,0 +1,53 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 Analog Devices Inc.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_OVERSHOOT_FILTER_H
+#define INCLUDED_BLOCKS_OVERSHOOT_FILTER_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace adiscope {
+
+    class frequency_compensation_filter : virtual public gr::sync_block
+    {
+    public:
+      // gr::blocks::streams_to_vector::sptr
+      typedef boost::shared_ptr<frequency_compensation_filter> sptr;
+
+      /*!
+       * Make a stream-to-vector block.
+       *
+       * \param itemsize the item size of the stream
+       * \param nstreams number of streams to combine into a vector (vector size)
+       */
+      static sptr make(bool enable = true, float TC = 1, float gain = -1,
+		       float sample_rate = 100000000);
+      virtual void set_enable(bool en) = 0;
+      virtual bool get_enable() = 0;
+      virtual void set_TC(float TC) = 0;
+      virtual float get_TC() = 0;
+      virtual void set_gain(float gain) = 0;
+      virtual float get_gain() = 0;
+      virtual void set_sample_rate(float sample_rate) = 0;
+    };
+
+} /* namespace adiscope */
+#endif /* INCLUDED_BLOCKS_STREAMS_TO_SHORT_H */

--- a/src/frequency_compensation_filter.h
+++ b/src/frequency_compensation_filter.h
@@ -26,30 +26,33 @@
 
 namespace adiscope {
 
-    class frequency_compensation_filter : virtual public gr::sync_block
-    {
-    public:
-      // gr::blocks::streams_to_vector::sptr
-      typedef boost::shared_ptr<frequency_compensation_filter> sptr;
+class frequency_compensation_filter : virtual public gr::sync_block
+{
+public:
+	// gr::blocks::streams_to_vector::sptr
+	typedef boost::shared_ptr<frequency_compensation_filter> sptr;
 
-      /*!
-       * Make a stream-to-vector block.
-       *
-       * \param itemsize the item size of the stream
-       * \param nstreams number of streams to combine into a vector (vector size)
-       */
-      static sptr make(bool enable = true, float TC = 1, float gain = 0,
-		       float sample_rate = 100000000);
-      virtual void set_enable(bool en, int gain_mode = 2) = 0;
-      virtual bool get_enable(int gain_mode = 2) = 0;
-      virtual void set_TC(float TC, int gain_mode = 2) = 0;
-      virtual float get_TC(int gain_mode = 2) = 0;
-      virtual void set_filter_gain(float gain, int gain_mode = 2) = 0;
-      virtual float get_filter_gain(int gain_mode = 2) = 0;
-      virtual void set_sample_rate(float sample_rate) = 0;
-      virtual bool get_high_gain() = 0;
-      virtual void set_high_gain(bool en) = 0;
-    };
+	/*!
+	 * Make a frequency_compensation_filter block
+	 *
+	 * These parameters apply on both high and low gain settings
+	 * \param enable - enable state of the filter
+	 * \param TC - time constant in uS
+	 * \param gain - gain of the filter
+	 * \param sample_rate - sample rate used in filter response
+	 */
+	static sptr make(bool enable = true, float TC = 1, float gain = 0,
+			 float sample_rate = 100000000);
+	virtual void set_enable(bool en, int gain_mode = 2) = 0;
+	virtual bool get_enable(int gain_mode = 2) = 0;
+	virtual void set_TC(float TC, int gain_mode = 2) = 0;
+	virtual float get_TC(int gain_mode = 2) = 0;
+	virtual void set_filter_gain(float gain, int gain_mode = 2) = 0;
+	virtual float get_filter_gain(int gain_mode = 2) = 0;
+	virtual void set_sample_rate(float sample_rate) = 0;
+	virtual bool get_high_gain() = 0;
+	virtual void set_high_gain(bool en) = 0;
+};
 
 } /* namespace adiscope */
 #endif /* INCLUDED_BLOCKS_STREAMS_TO_SHORT_H */

--- a/src/frequency_compensation_filter_impl.cc
+++ b/src/frequency_compensation_filter_impl.cc
@@ -1,0 +1,116 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 Analog Devices Inc.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "frequency_compensation_filter_impl.h"
+#include <gnuradio/io_signature.h>
+#include <gnuradio/blocks/char_to_short.h>
+
+using namespace gr;
+
+namespace adiscope
+{
+    frequency_compensation_filter_impl::frequency_compensation_filter_impl(bool enable, float TC, float gain,
+						 float sample_rate)
+
+	: sync_block("overshoot_filter",
+		io_signature::make(1,1, sizeof(float)),
+		io_signature::make (1, 1, sizeof(float))),
+	  enable(enable), TC(TC), gain(gain), sample_rate(sample_rate)
+
+    {
+    }
+
+    frequency_compensation_filter::sptr
+    frequency_compensation_filter::make(bool enable, float TC, float gain,
+			   float sample_rate)
+    {
+        return gnuradio::get_initial_sptr
+		(new frequency_compensation_filter_impl(enable, TC, gain,
+					   sample_rate));
+    }
+
+    int
+    frequency_compensation_filter_impl::work(int noutput_items,
+                       gr_vector_const_void_star &input_items,
+                       gr_vector_void_star &output_items)
+    {
+	const float *in = (const float*) input_items[0];
+	float *out = (float*) output_items[0];
+
+	float delta = 1.0 / sample_rate;
+	float TC1 = TC * float(1.0E-6);
+	float Alpha = TC1/(TC1+delta);
+	out[0]=(in[1]-in[0]);
+
+	int i = 1;
+
+	if(enable)
+	{
+		for(i = 1; i < noutput_items; i++) {
+			out[i]=Alpha*(out[i-1]+(in[i]-in[i-1]));
+		}
+
+		for(i = 0; i < noutput_items;i++){
+			out[i]=in[i]+(out[i]*gain);
+		}
+
+	}
+	else
+	{
+		memcpy(out,in,noutput_items*sizeof(float));
+	}
+        return noutput_items;
+    }
+
+    void frequency_compensation_filter_impl::set_enable(bool en)
+    {
+	    this->enable = en;
+    }
+
+    bool frequency_compensation_filter_impl::get_enable()
+    {
+	    return this->enable;
+    }
+
+    void frequency_compensation_filter_impl::set_TC(float TC)
+    {
+	    this->TC = TC;
+    }
+
+    float frequency_compensation_filter_impl::get_TC()
+    {
+	    return this->TC;
+    }
+
+    void frequency_compensation_filter_impl::set_gain(float gain)
+    {
+	    this->gain = gain;
+    }
+
+    float frequency_compensation_filter_impl::get_gain()
+    {
+	    return this->gain;
+    }
+
+    void frequency_compensation_filter_impl::set_sample_rate(float sample_rate)
+    {
+	    this->sample_rate = sample_rate;
+    }
+}

--- a/src/frequency_compensation_filter_impl.cc
+++ b/src/frequency_compensation_filter_impl.cc
@@ -24,42 +24,43 @@
 
 using namespace gr;
 
-namespace adiscope
-{
-frequency_compensation_filter_impl::frequency_compensation_filter_impl(bool enable, float TC, float gain,
-								       float sample_rate)
+namespace adiscope {
+frequency_compensation_filter_impl::frequency_compensation_filter_impl(
+	bool enable, float TC, float gain,
+	float sample_rate)
 
 	: sync_block("overshoot_filter",
 		     io_signature::make(1,1, sizeof(short)),
-		     io_signature::make (1, 1, sizeof(short))),
+		     io_signature::make(1, 1, sizeof(short))),
 	  sample_rate(sample_rate), high_gain(false)
 
-    {
-	for(auto i=0;i<2;i++) {
+{
+	for (auto i=0; i < 2; i++) {
 		config[i].enable = enable;
 		config[i].TC = TC;
 		config[i].gain = gain;
 	}
+
 	set_history(1);
-    }
+}
 
-    frequency_compensation_filter::sptr
-    frequency_compensation_filter::make(bool enable, float TC, float gain,
-			   float sample_rate)
-    {
-        return gnuradio::get_initial_sptr
-		(new frequency_compensation_filter_impl(enable, TC, gain,
-					   sample_rate));
-    }
+frequency_compensation_filter::sptr
+frequency_compensation_filter::make(bool enable, float TC, float gain,
+				    float sample_rate)
+{
+	return gnuradio::get_initial_sptr
+	       (new frequency_compensation_filter_impl(enable, TC, gain,
+			       sample_rate));
+}
 
-    int
-    frequency_compensation_filter_impl::work(int noutput_items,
-                       gr_vector_const_void_star &input_items,
-                       gr_vector_void_star &output_items)
-    {
-	const short *in = (const short*) input_items[0];
+int
+frequency_compensation_filter_impl::work(int noutput_items,
+		gr_vector_const_void_star& input_items,
+		gr_vector_void_star& output_items)
+{
+	const short *in = (const short *) input_items[0];
 	float *out_f = new float[noutput_items];
-	short *out = (short*) output_items[0];
+	short *out = (short *) output_items[0];
 
 	float delta = 1.0 / sample_rate;
 	float TC1 = config[high_gain].TC * float(1.0E-6);
@@ -67,72 +68,89 @@ frequency_compensation_filter_impl::frequency_compensation_filter_impl(bool enab
 	out_f[0]=(in[1]-in[0]);
 	int i = 1;
 
-	if(config[high_gain].enable)
-	{
-		for(i = 1; i < noutput_items; i++) {
+	if (config[high_gain].enable) {
+		for (i = 1; i < noutput_items; i++) {
 			out_f[i]=(Alpha*(out_f[i-1]+(float)(in[i]-in[i-1])));
 		}
 
-		for(i = 0; i < noutput_items;i++){
+		for (i = 0; i < noutput_items; i++) {
 			out[i]=in[i]+(short)((out_f[i])*config[high_gain].gain);
 		}
 
-	}
-	else
-	{
+	} else {
 		memcpy(out,in,noutput_items*sizeof(short));
 	}
+
 	delete []out_f;
-        return noutput_items;
-    }
+	return noutput_items;
+}
 
-    void frequency_compensation_filter_impl::set_enable(bool en, int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    this->config[gain_mode].enable = en;
-    }
+void frequency_compensation_filter_impl::set_enable(bool en, int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
 
-    bool frequency_compensation_filter_impl::get_enable(int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    return this->config[gain_mode].enable;
-    }
+	this->config[gain_mode].enable = en;
+}
 
-    void frequency_compensation_filter_impl::set_TC(float TC, int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    this->config[gain_mode].TC = TC;
-    }
+bool frequency_compensation_filter_impl::get_enable(int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
 
-    float frequency_compensation_filter_impl::get_TC(int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    return this->config[gain_mode].TC;
-    }
+	return this->config[gain_mode].enable;
+}
 
-    void frequency_compensation_filter_impl::set_filter_gain(float gain, int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    this->config[gain_mode].gain = gain;
-    }
+void frequency_compensation_filter_impl::set_TC(float TC, int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
 
-    float frequency_compensation_filter_impl::get_filter_gain(int gain_mode)
-    {
-	    if(gain_mode == 2) gain_mode = high_gain;
-	    return this->config[gain_mode].gain;
-    }
+	this->config[gain_mode].TC = TC;
+}
 
-    void frequency_compensation_filter_impl::set_sample_rate(float sample_rate)
-    {
-	    this->sample_rate = sample_rate;
-    }
+float frequency_compensation_filter_impl::get_TC(int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
 
-    bool frequency_compensation_filter_impl::get_high_gain()
-    {
-	    return this->high_gain;
-    }
-    void frequency_compensation_filter_impl::set_high_gain(bool en)
-    {
-	    this->high_gain=en;
-    }
+	return this->config[gain_mode].TC;
+}
+
+void frequency_compensation_filter_impl::set_filter_gain(float gain,
+		int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
+
+	this->config[gain_mode].gain = gain;
+}
+
+float frequency_compensation_filter_impl::get_filter_gain(int gain_mode)
+{
+	if (gain_mode == 2) {
+		gain_mode = high_gain;
+	}
+
+	return this->config[gain_mode].gain;
+}
+
+void frequency_compensation_filter_impl::set_sample_rate(float sample_rate)
+{
+	this->sample_rate = sample_rate;
+}
+
+bool frequency_compensation_filter_impl::get_high_gain()
+{
+	return this->high_gain;
+}
+void frequency_compensation_filter_impl::set_high_gain(bool en)
+{
+	this->high_gain=en;
+}
 }

--- a/src/frequency_compensation_filter_impl.h
+++ b/src/frequency_compensation_filter_impl.h
@@ -34,6 +34,7 @@ namespace adiscope {
 	    float TC, gain;
 	    float sample_rate;
 	    int iterations;
+	    bool high_gain;
 
     public:
 	typedef boost::shared_ptr<frequency_compensation_filter> sptr;
@@ -50,6 +51,8 @@ namespace adiscope {
 	void set_gain(float gain);
 	float get_gain() override;
 	void set_sample_rate(float sample_rate);
+	bool get_high_gain() override;
+	void set_high_gain(bool en);
     };
 }
 #endif

--- a/src/frequency_compensation_filter_impl.h
+++ b/src/frequency_compensation_filter_impl.h
@@ -1,0 +1,55 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 Analog Devices Inc.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef OVERSHOOT_FILTER_HPP
+#define OVERSHOOT_FILTER_HPP
+
+#include "frequency_compensation_filter.h"
+#include <inttypes.h>
+
+using namespace gr;
+
+namespace adiscope {
+    class frequency_compensation_filter_impl : public frequency_compensation_filter
+    {
+    private:
+	    bool enable;
+	    float TC, gain;
+	    float sample_rate;
+	    int iterations;
+
+    public:
+	typedef boost::shared_ptr<frequency_compensation_filter> sptr;
+	frequency_compensation_filter_impl(bool enable, float TC, float gain,
+			      float sample_rate);
+        int work(int noutput_items,
+             gr_vector_const_void_star &input_items,
+             gr_vector_void_star &output_items);
+
+	void set_enable(bool en);
+	bool get_enable() override;
+	void set_TC(float TC);
+	float get_TC() override;
+	void set_gain(float gain);
+	float get_gain() override;
+	void set_sample_rate(float sample_rate);
+    };
+}
+#endif

--- a/src/frequency_compensation_filter_impl.h
+++ b/src/frequency_compensation_filter_impl.h
@@ -30,10 +30,13 @@ namespace adiscope {
     class frequency_compensation_filter_impl : public frequency_compensation_filter
     {
     private:
+	    typedef struct {
 	    bool enable;
 	    float TC, gain;
-	    float sample_rate;
-	    int iterations;
+	    } filter_config_t;
+
+	    filter_config_t config[2];
+	    float sample_rate;	    
 	    bool high_gain;
 
     public:
@@ -44,12 +47,12 @@ namespace adiscope {
              gr_vector_const_void_star &input_items,
              gr_vector_void_star &output_items);
 
-	void set_enable(bool en);
-	bool get_enable() override;
-	void set_TC(float TC);
-	float get_TC() override;
-	void set_gain(float gain);
-	float get_gain() override;
+	void set_enable(bool en, int gain_mode);
+	bool get_enable(int gain_mode) override;
+	void set_TC(float TC, int gain_mode);
+	float get_TC(int gain_mode) override;
+	void set_filter_gain(float gain, int gain_mode);
+	float get_filter_gain(int gain_mode) override;
 	void set_sample_rate(float sample_rate);
 	bool get_high_gain() override;
 	void set_high_gain(bool en);

--- a/src/frequency_compensation_filter_impl.h
+++ b/src/frequency_compensation_filter_impl.h
@@ -27,25 +27,25 @@
 using namespace gr;
 
 namespace adiscope {
-    class frequency_compensation_filter_impl : public frequency_compensation_filter
-    {
-    private:
-	    typedef struct {
-	    bool enable;
-	    float TC, gain;
-	    } filter_config_t;
+class frequency_compensation_filter_impl : public frequency_compensation_filter
+{
+private:
+	typedef struct {
+		bool enable;
+		float TC, gain;
+	} filter_config_t;
 
-	    filter_config_t config[2];
-	    float sample_rate;	    
-	    bool high_gain;
+	filter_config_t config[2];
+	float sample_rate;
+	bool high_gain;
 
-    public:
+public:
 	typedef boost::shared_ptr<frequency_compensation_filter> sptr;
 	frequency_compensation_filter_impl(bool enable, float TC, float gain,
-			      float sample_rate);
-        int work(int noutput_items,
-             gr_vector_const_void_star &input_items,
-             gr_vector_void_star &output_items);
+					   float sample_rate);
+	int work(int noutput_items,
+		 gr_vector_const_void_star& input_items,
+		 gr_vector_void_star& output_items);
 
 	void set_enable(bool en, int gain_mode);
 	bool get_enable(int gain_mode) override;
@@ -56,6 +56,6 @@ namespace adiscope {
 	void set_sample_rate(float sample_rate);
 	bool get_high_gain() override;
 	void set_high_gain(bool en);
-    };
+};
 }
 #endif

--- a/src/iio_manager.cpp
+++ b/src/iio_manager.cpp
@@ -211,7 +211,7 @@ void iio_manager::set_filter_parameters(int channel, int index, bool enable, flo
 {
 	freq_comp_filt[channel][index]->set_enable(enable);
 	freq_comp_filt[channel][index]->set_TC(TC);
-	freq_comp_filt[channel][index]->set_gain(gain);
+	freq_comp_filt[channel][index]->set_filter_gain(gain);
 	freq_comp_filt[channel][index]->set_sample_rate(sample_rate);
 }
 

--- a/src/iio_manager.hpp
+++ b/src/iio_manager.hpp
@@ -27,6 +27,7 @@
 #include <gnuradio/iio/device_source.h>
 #include <gnuradio/blocks/copy.h>
 #include <gnuradio/blocks/float_to_complex.h>
+#include <frequency_compensation_filter.h>
 
 #include <mutex>
 
@@ -87,6 +88,7 @@ namespace adiscope {
 		/* Change the buffer size at runtime.
 		 * Warning: the flowgraph needs to be locked first! */
 		void set_buffer_size(port_id id, unsigned long size);
+		void set_filter_parameters(int channel, int index, bool enable, float TC, float gain, float sample_rate );
 
 		/* VERY ugly hack. The reconfiguration that happens after
 		 * locking/unlocking the flowgraph is sort of broken; the tags
@@ -98,6 +100,8 @@ namespace adiscope {
 
 		/* Set the timeout for the source device */
 		void set_device_timeout(unsigned int mseconds);
+
+		adiscope::frequency_compensation_filter::sptr freq_comp_filt[2][2];
 
 	private:
 		static std::map<const std::string, map_entry> dev_map;
@@ -111,6 +115,7 @@ namespace adiscope {
 		std::vector<std::pair<port_id, unsigned long> > copy_blocks;
 
 		gr::iio::device_source::sptr iio_block;
+		unsigned int nb_channels;
 
 		struct connection {
 			gr::basic_block_sptr src;

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -1037,10 +1037,10 @@ void NetworkAnalyzer::setFilterParameters()
 	f21->set_TC(iio->freq_comp_filt[1][0]->get_TC());
 	f22->set_TC(iio->freq_comp_filt[1][1]->get_TC());
 
-	f11->set_gain(iio->freq_comp_filt[0][0]->get_gain());
-	f12->set_gain(iio->freq_comp_filt[0][1]->get_gain());
-	f21->set_gain(iio->freq_comp_filt[1][0]->get_gain());
-	f22->set_gain(iio->freq_comp_filt[1][1]->get_gain());
+	f11->set_filter_gain(iio->freq_comp_filt[0][0]->get_filter_gain());
+	f12->set_filter_gain(iio->freq_comp_filt[0][1]->get_filter_gain());
+	f21->set_filter_gain(iio->freq_comp_filt[1][0]->get_filter_gain());
+	f22->set_filter_gain(iio->freq_comp_filt[1][1]->get_filter_gain());
 
 	f11->set_sample_rate(m2k_adc->sampleRate());
 	f12->set_sample_rate(m2k_adc->sampleRate());

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -49,6 +49,7 @@
 #include <gnuradio/blocks/skiphead.h>
 #include "cancel_dc_offset_block.h"
 #include <gnuradio/blocks/vector_source_s.h>
+#include "frequency_compensation_filter.h"
 
 #include "oscilloscope.hpp"
 
@@ -166,6 +167,7 @@ private:
 	gr::top_block_sptr capture_top_block;
 	gr::blocks::vector_source_s::sptr capture1;
 	gr::blocks::vector_source_s::sptr capture2;
+	adiscope::frequency_compensation_filter::sptr f11,f12,f21,f22;
 	gr::blocks::short_to_float::sptr s2f1;
 	gr::blocks::short_to_float::sptr s2f2;
 	gr::fft::goertzel_fc::sptr goertzel1;
@@ -236,6 +238,7 @@ private:
 	QVector<QVector<double>> m_importData;
 
 	void goertzel();
+	void setFilterParameters();
 
 	struct iio_buffer *generateSinWave(
 		const struct iio_device *dev,

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -271,13 +271,24 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 			m2k_adc->chnCorrectionGain(1));
 	}
 
+	freq_comp_filt[0][0] = adiscope::frequency_compensation_filter::make();
+	freq_comp_filt[0][1] = adiscope::frequency_compensation_filter::make();
+	freq_comp_filt[1][0] = adiscope::frequency_compensation_filter::make();
+	freq_comp_filt[1][1] = adiscope::frequency_compensation_filter::make();
+
+	freq_comp_filt[0][1]->set_enable(false);
+	freq_comp_filt[1][1]->set_enable(false);
 
 	for (unsigned int i = 0; i < nb_channels; i++) {
 		ids[i] = iio->connect(adc_samp_conv, i, i,
 				true, qt_time_block->nsamps());
-		iio->connect(adc_samp_conv, i, qt_time_block, i);
 
-		iio->connect(adc_samp_conv, i, qt_hist_block, i);
+		iio->connect(adc_samp_conv, i , freq_comp_filt[i][0], 0);
+		iio->connect(freq_comp_filt[i][0], 0 , freq_comp_filt[i][1], 0);
+
+		iio->connect(freq_comp_filt[i][1], 0, qt_time_block, i);
+
+		iio->connect(freq_comp_filt[i][1], 0, qt_hist_block, i);
 	}
 
 	adc_samp_conv_block = adc_samp_conv;
@@ -444,6 +455,45 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 	Util::retainWidgetSizeWhenHidden(ch_ui->probeWidget);
 
 	init_channel_settings();
+
+	connect(ch_ui->filter_en, &QCheckBox::toggled, [&](bool en) {
+			freq_comp_filt[current_ch_widget][0]->set_enable(en);
+	});
+	connect(ch_ui->filter_TC, &QLineEdit::textChanged, [&](QString str) {
+		bool ok;
+		float val = str.toFloat(&ok);
+		if(!ok)
+			return;
+		freq_comp_filt[current_ch_widget][0]->set_TC(val);
+
+	});
+	connect(ch_ui->filter_gain, &QLineEdit::textChanged, [&](QString str) {
+		bool ok;
+		float val = str.toFloat(&ok);
+		if(!ok)
+			return;
+		freq_comp_filt[current_ch_widget][0]->set_gain(val);
+	});
+
+
+	connect(ch_ui->filter2_en, &QCheckBox::toggled, [&](bool en) {
+			freq_comp_filt[current_ch_widget][1]->set_enable(en);
+	});
+	connect(ch_ui->filter2_TC, &QLineEdit::textChanged, [&](QString str) {
+		bool ok;
+		float val = str.toFloat(&ok);
+		if(!ok)
+			return;
+		freq_comp_filt[current_ch_widget][1]->set_TC(val);
+
+	});
+	connect(ch_ui->filter2_gain, &QLineEdit::textChanged, [&](QString str) {
+		bool ok;
+		float val = str.toFloat(&ok);
+		if(!ok)
+			return;
+		freq_comp_filt[current_ch_widget][1]->set_gain(val);
+	});
 
 	timeBase->setValue(plot.HorizUnitsPerDiv());
 	voltsPerDiv->setValue(plot.VertUnitsPerDiv());
@@ -3086,6 +3136,11 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 		last_set_sample_count = active_plot_sample_count;
 
 		adc->setSampleRate(active_sample_rate);
+		for(auto i=0;i<nb_channels;i++)
+		{
+			freq_comp_filt[i][0]->set_sample_rate(active_sample_rate);
+			freq_comp_filt[i][1]->set_sample_rate(active_sample_rate);
+		}
 		trigger_settings.setTriggerDelay(active_trig_sample_count);
 		last_set_time_pos = active_time_pos;
 
@@ -3267,6 +3322,11 @@ void adiscope::Oscilloscope::onTimePositionChanged(double value)
 		last_set_sample_count = active_plot_sample_count;
 
 		adc->setSampleRate(active_sample_rate);
+		for(auto i=0;i<nb_channels;i++)
+		{
+			freq_comp_filt[i][0]->set_sample_rate(active_sample_rate);
+			freq_comp_filt[i][1]->set_sample_rate(active_sample_rate);
+		}
 	}
 
 	for (unsigned int i = 0; i < nb_channels; i++) {
@@ -3423,6 +3483,8 @@ void Oscilloscope::update_chn_settings_panel(int id)
 	ch_ui->cmbChnLineWidth->setCurrentIndex(cmbIdx);
 
 	if (chn_widget->isMathChannel()) {
+		ch_ui->filter1->setVisible(false);
+		ch_ui->filter2->setVisible(false);
 		ch_ui->math_settings_widget->setVisible(true);
 		ch_ui->btnAutoset->setVisible(false);
 		ch_ui->function_2->setText(chn_widget->function());
@@ -3433,6 +3495,8 @@ void Oscilloscope::update_chn_settings_panel(int id)
 		ch_ui->snapshotBtn->setText("Snapshot");
 
 	} else if (chn_widget->isReferenceChannel()) {
+		ch_ui->filter1->setVisible(false);
+		ch_ui->filter2->setVisible(false);
 
 		ch_ui->snapshotBtn->setText("Export");
 
@@ -3443,6 +3507,8 @@ void Oscilloscope::update_chn_settings_panel(int id)
 
 
 	} else {
+		ch_ui->filter1->setVisible(true);
+		ch_ui->filter2->setVisible(true);
 		ch_ui->math_settings_widget->setVisible(false);
 		ch_ui->btnAutoset->setVisible(autosetEnabled);
 		ch_ui->wCoupling->setVisible(true);
@@ -3476,6 +3542,12 @@ void Oscilloscope::update_chn_settings_panel(int id)
 		ch_ui->label_3->setVisible(true);
 		ch_ui->cmbMemoryDepth->setVisible(true);
 		ch_ui->btnAutoset->setVisible(true);
+		ch_ui->filter_TC->setText(QString::number(freq_comp_filt[current_ch_widget][0]->get_TC()));
+		ch_ui->filter2_TC->setText(QString::number(freq_comp_filt[current_ch_widget][1]->get_TC()));
+		ch_ui->filter_gain->setText(QString::number(freq_comp_filt[current_ch_widget][0]->get_gain()));
+		ch_ui->filter2_gain->setText(QString::number(freq_comp_filt[current_ch_widget][1]->get_gain()));
+		ch_ui->filter_en->setChecked(freq_comp_filt[current_ch_widget][0]->get_enable());
+		ch_ui->filter2_en->setChecked(freq_comp_filt[current_ch_widget][1]->get_enable());
 	}
 
 	auto max_elem = max_element(probe_attenuation.begin(), probe_attenuation.begin() + nb_channels);
@@ -4597,6 +4669,11 @@ void Oscilloscope::writeAllSettingsToHardware()
 			"oversampling_ratio", 1);*/
 
 		m2k_adc->setSampleRate(active_sample_rate);
+	}
+	for(auto i=0;i<nb_channels;i++)
+	{
+		freq_comp_filt[i][0]->set_sample_rate(active_sample_rate);
+		freq_comp_filt[i][1]->set_sample_rate(active_sample_rate);
 	}
 
 	// Writes all trigger settings to hardware

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -465,7 +465,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		float val = str.toFloat(&ok);
 		if(!ok)
 			return;
-		iio->freq_comp_filt[current_ch_widget][0]->set_gain(val);
+		iio->freq_comp_filt[current_ch_widget][0]->set_filter_gain(val);
 	});
 
 
@@ -485,7 +485,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		float val = str.toFloat(&ok);
 		if(!ok)
 			return;
-		iio->freq_comp_filt[current_ch_widget][1]->set_gain(val);
+		iio->freq_comp_filt[current_ch_widget][1]->set_filter_gain(val);
 	});
 
 	timeBase->setValue(plot.HorizUnitsPerDiv());
@@ -3562,8 +3562,10 @@ void Oscilloscope::update_chn_settings_panel(int id)
 		ch_ui->btnAutoset->setVisible(true);
 		ch_ui->filter_TC->setText(QString::number(iio->freq_comp_filt[current_ch_widget][0]->get_TC()));
 		ch_ui->filter2_TC->setText(QString::number(iio->freq_comp_filt[current_ch_widget][1]->get_TC()));
-		ch_ui->filter_gain->setText(QString::number(iio->freq_comp_filt[current_ch_widget][0]->get_gain()));
-		ch_ui->filter2_gain->setText(QString::number(iio->freq_comp_filt[current_ch_widget][1]->get_gain()));
+		ch_ui->filter_gain->setText(QString::number(iio->freq_comp_filt[current_ch_widget][0]->get_filter_gain()));
+		ch_ui->filter2_gain->setText(QString::number(iio->freq_comp_filt[current_ch_widget][1]->get_filter_gain()));
+		ch_ui->filter_en->setText(tr("Filter 1 - Enable - ") + getChannelRangeStringVDivHelper(id));
+		ch_ui->filter2_en->setText(tr("Filter 2 - Enable - ") + getChannelRangeStringVDivHelper(id));
 		ch_ui->filter_en->setChecked(iio->freq_comp_filt[current_ch_widget][0]->get_enable());
 		ch_ui->filter2_en->setChecked(iio->freq_comp_filt[current_ch_widget][1]->get_enable());
 	}
@@ -4636,6 +4638,7 @@ void Oscilloscope::setGainMode(uint chnIdx, M2kAdc::GainMode gain_mode)
 	block->setHardwareGain(chnIdx, m2k_adc->gainAt(gain_mode));
 	iio->freq_comp_filt[chnIdx][0]->set_high_gain(gain_mode);
 	iio->freq_comp_filt[chnIdx][1]->set_high_gain(gain_mode);
+	update_chn_settings_panel(chnIdx);
 	trigger_settings.updateHwVoltLevels(chnIdx);
 }
 

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -438,6 +438,9 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 	ch_ui = new Ui::ChannelSettings();
 	ch_ui->setupUi(ui->channelSettings);
 
+	ch_ui->filter1->setVisible(prefPanel->getShowADCFilters());
+	ch_ui->filter2->setVisible(prefPanel->getShowADCFilters());
+
 	ch_ui->horizontal->insertWidget(1, timeBase, 0, Qt::AlignLeft);
 	ch_ui->horizontal->insertWidget(2, timePosition, 0, Qt::AlignLeft);
 	ch_ui->vertical->insertWidget(1, voltsPerDiv, 0, Qt::AlignLeft);
@@ -3522,8 +3525,8 @@ void Oscilloscope::update_chn_settings_panel(int id)
 
 
 	} else {
-		ch_ui->filter1->setVisible(true);
-		ch_ui->filter2->setVisible(true);
+		ch_ui->filter1->setVisible(prefPanel->getShowADCFilters());
+		ch_ui->filter2->setVisible(prefPanel->getShowADCFilters());
 		ch_ui->math_settings_widget->setVisible(false);
 		ch_ui->btnAutoset->setVisible(autosetEnabled);
 		ch_ui->wCoupling->setVisible(true);

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -682,7 +682,9 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 			QLabel *label = static_cast<QLabel *>(
 			                        ui->chn_scales->itemAt(i)->widget());
 			double value = probe_attenuation[i] * plot.VertUnitsPerDiv(i);
-			label->setText(vertMeasureFormat.format(value, "V/div", 3));
+			QString str = vertMeasureFormat.format(value, "V/div", 3);
+			str.append(getChannelRangeStringVDivHelper(i));
+			label->setText(str);
 		}
 
 		if (zoom_level == 0) {
@@ -728,7 +730,9 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 			QLabel *label = static_cast<QLabel *>(
 						ui->chn_scales->itemAt(i)->widget());
 			double value = probe_attenuation[i] * plot.VertUnitsPerDiv(i);
-			label->setText(vertMeasureFormat.format(value, "V/div", 3));
+			QString str = vertMeasureFormat.format(value, "V/div", 3);
+			str.append(getChannelRangeStringVDivHelper(i));
+			label->setText(str);
 		}
 
 		if (channelWidgetAtId(current_ch_widget)->isMathChannel()) {
@@ -779,7 +783,9 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		QLabel *label = static_cast<QLabel *>(
 					ui->chn_scales->itemAt(i)->widget());
 		double value = probe_attenuation[i] * plot.VertUnitsPerDiv(i);
-		label->setText(vertMeasureFormat.format(value, "V/div", 3));
+		QString str = vertMeasureFormat.format(value, "V/div", 3);
+		str.append(getChannelRangeStringVDivHelper(i));
+		label->setText(str);
 	}
 
 	for (unsigned int i = nb_channels; i < nb_channels + nb_math_channels; i++) {
@@ -2912,7 +2918,10 @@ void Oscilloscope::cancelZoom()
 		QLabel *label = static_cast<QLabel *>(
 					ui->chn_scales->itemAt(i)->widget());
 		double value = probe_attenuation[i] * plot.VertUnitsPerDiv(i);
-		label->setText(vertMeasureFormat.format(value, "V/div", 3));
+		QString str = vertMeasureFormat.format(value, "V/div", 3);
+		str.append(getChannelRangeStringVDivHelper(i));
+		label->setText(str);
+
 	}
 }
 
@@ -2921,6 +2930,19 @@ void adiscope::Oscilloscope::onChannelCouplingChanged(bool en)
 	if (en && chnAcCoupled.at(current_ch_widget))
 		return;
 	configureAcCoupling(current_ch_widget, en);
+}
+
+QString adiscope::Oscilloscope::getChannelRangeStringVDivHelper(int ch)
+{
+	QString str ="";
+	if(ch >= 0 && ch < nb_channels)
+	{
+		str = " (±";
+		double range = (high_gain_modes[ch])? 2.5 : 25;
+		range = range * probe_attenuation[ch];
+		str += QString::number(range,'f',1) + ")";
+	}
+	return str;
 }
 
 void adiscope::Oscilloscope::onVertScaleValueChanged(double value)
@@ -2958,7 +2980,7 @@ void adiscope::Oscilloscope::onVertScaleValueChanged(double value)
 			ui->chn_scales->itemAt(current_ch_widget)->widget());
 	double labelValue = probe_attenuation[current_ch_widget]
 			* plot.VertUnitsPerDiv(current_ch_widget);
-	label->setText(vertMeasureFormat.format(labelValue, "V/div", 3));
+	QString str = vertMeasureFormat.format(labelValue, "V/div", 3);
 
 	// Switch between high and low gain modes only for the M2K channels
 	if (m2k_adc && current_ch_widget < nb_channels) {
@@ -2967,6 +2989,8 @@ void adiscope::Oscilloscope::onVertScaleValueChanged(double value)
 			voltsPosition->value());
 		trigger_settings.updateHwVoltLevels(current_ch_widget);
 	}
+	str.append(getChannelRangeStringVDivHelper(current_ch_widget));
+	label->setText(str);
 }
 
 

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -100,6 +100,7 @@ namespace adiscope {
 	{
 		friend class Oscilloscope_API;
 		friend class Channel_API;
+		friend class Channel_Digital_Filter_API;
 		friend class ToolLauncher_API;
 
 		Q_OBJECT

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -314,8 +314,6 @@ namespace adiscope {
 		QMap<QString, boost::shared_ptr<gr::analog::rail_ff>> math_rails;
 		std::vector<boost::shared_ptr<gr::blocks::multiply_const_ff>> math_probe_atten;
 
-		adiscope::frequency_compensation_filter::sptr freq_comp_filt[2][2];
-
 		iio_manager::port_id *ids;
 		iio_manager::port_id *hist_ids;
 		iio_manager::port_id *autoset_id;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -63,7 +63,7 @@
 #include "math.hpp"
 #include "scroll_filter.hpp"
 #include "cancel_dc_offset_block.h"
-
+#include "frequency_compensation_filter.h"
 #include "oscilloscope_api.hpp"
 
 /*Generated UI */
@@ -313,6 +313,8 @@ namespace adiscope {
 			gr::basic_block_sptr>> math_sinks;
 		QMap<QString, boost::shared_ptr<gr::analog::rail_ff>> math_rails;
 		std::vector<boost::shared_ptr<gr::blocks::multiply_const_ff>> math_probe_atten;
+
+		adiscope::frequency_compensation_filter::sptr freq_comp_filt[2][2];
 
 		iio_manager::port_id *ids;
 		iio_manager::port_id *hist_ids;

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -394,6 +394,7 @@ namespace adiscope {
 		unsigned int find_curve_number();
 		ChannelWidget *channelWidgetAtId(int id);
 		void update_measure_for_channel(int ch_idx);
+		QString getChannelRangeStringVDivHelper(int ch);
 		void setAllSinksSampleCount(unsigned long sample_count);
 		void autosetFFT();
 

--- a/src/oscilloscope_api.cpp
+++ b/src/oscilloscope_api.cpp
@@ -639,6 +639,17 @@ QVariantList Oscilloscope_API::getChannels()
 	return list;
 }
 
+QVariantList Channel_API::getDigFilters() const
+{
+	QVariantList list;
+
+	for (Channel_Digital_Filter_API *each : digFilters)
+		list.append(QVariant::fromValue(each));
+	return list;
+}
+
+
+
 /*
  * Channel_API
  */
@@ -825,53 +836,54 @@ void Channel_API::setAcCoupling(bool val)
 	}
 }
 
-bool Channel_API::filter1Enable() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][0]->get_enable();
+
+bool Channel_Digital_Filter_API::isEnableLow() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_enable(0);
 }
-bool Channel_API::filter2Enable() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][1]->get_enable();
+bool Channel_Digital_Filter_API::isEnableHigh() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_enable(1);
 }
-void Channel_API::setFilter1Enable(bool en) {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][0]->set_enable(en);
+void Channel_Digital_Filter_API::setEnableLow(bool en) {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_enable(en, 0);
 }
-void Channel_API::setFilter2Enable(bool en){
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][1]->set_enable(en);
+void Channel_Digital_Filter_API::setEnableHigh(bool en){
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_enable(en, 1);
 }
-float Channel_API::filter1TC() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][0]->get_TC();
+float Channel_Digital_Filter_API::TCLow() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_TC(0);
 }
-float Channel_API::filter2TC() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][1]->get_TC();
+float Channel_Digital_Filter_API::TCHigh() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_TC(1);
 }
-void Channel_API::setFilter1TC(float tc){
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][0]->set_TC(tc);
+void Channel_Digital_Filter_API::setTCLow(float tc){
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_TC(tc, 0);
 }
-void Channel_API::setFilter2TC(float tc){
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][1]->set_TC(tc);
+void Channel_Digital_Filter_API::setTCHigh(float tc){
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_TC(tc, 1);
 }
-float Channel_API::filter1Gain() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][0]->get_gain();
+float Channel_Digital_Filter_API::gainLow() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_filter_gain(0);
 }
-float Channel_API::filter2Gain() const {
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	return osc->iio->freq_comp_filt[index][1]->get_gain();
+float Channel_Digital_Filter_API::gainHigh() const {
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	return osc->iio->freq_comp_filt[channel][filterIndex]->get_filter_gain(1);
 }
-void Channel_API::setFilter1Gain(float gain){
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][0]->set_gain(gain);
+void Channel_Digital_Filter_API::setGainLow(float gain){
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_filter_gain(gain, 0);
 }
-void Channel_API::setFilter2Gain(float gain){
-	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
-	osc->iio->freq_comp_filt[index][1]->set_gain(gain);
+void Channel_Digital_Filter_API::setGainHigh(float gain){
+	int channel = osc->channels_api.indexOf(const_cast<Channel_API*>(ch_api));
+	osc->iio->freq_comp_filt[channel][filterIndex]->set_filter_gain(gain, 1);
 }
 
 QList<double> Channel_API::data() const

--- a/src/oscilloscope_api.cpp
+++ b/src/oscilloscope_api.cpp
@@ -633,9 +633,9 @@ QVariantList Oscilloscope_API::getChannels()
 {
 	QVariantList list;
 
-	for (Channel_API *each : osc->channels_api)
+	for (Channel_API *each : osc->channels_api) {
 		list.append(QVariant::fromValue(each));
-
+	}
 	return list;
 }
 
@@ -643,8 +643,9 @@ QVariantList Channel_API::getDigFilters() const
 {
 	QVariantList list;
 
-	for (Channel_Digital_Filter_API *each : digFilters)
+	for (Channel_Digital_Filter_API *each : digFilters) {
 		list.append(QVariant::fromValue(each));
+	}
 	return list;
 }
 

--- a/src/oscilloscope_api.cpp
+++ b/src/oscilloscope_api.cpp
@@ -825,6 +825,55 @@ void Channel_API::setAcCoupling(bool val)
 	}
 }
 
+bool Channel_API::filter1Enable() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][0]->get_enable();
+}
+bool Channel_API::filter2Enable() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][1]->get_enable();
+}
+void Channel_API::setFilter1Enable(bool en) {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][0]->set_enable(en);
+}
+void Channel_API::setFilter2Enable(bool en){
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][1]->set_enable(en);
+}
+float Channel_API::filter1TC() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][0]->get_TC();
+}
+float Channel_API::filter2TC() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][1]->get_TC();
+}
+void Channel_API::setFilter1TC(float tc){
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][0]->set_TC(tc);
+}
+void Channel_API::setFilter2TC(float tc){
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][1]->set_TC(tc);
+}
+float Channel_API::filter1Gain() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][0]->get_gain();
+}
+float Channel_API::filter2Gain() const {
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	return osc->iio->freq_comp_filt[index][1]->get_gain();
+}
+void Channel_API::setFilter1Gain(float gain){
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][0]->set_gain(gain);
+}
+void Channel_API::setFilter2Gain(float gain){
+	int index = osc->channels_api.indexOf(const_cast<Channel_API*>(this));
+	osc->iio->freq_comp_filt[index][1]->set_gain(gain);
+}
+
 QList<double> Channel_API::data() const
 {
 	QList<double> list;

--- a/src/oscilloscope_api.hpp
+++ b/src/oscilloscope_api.hpp
@@ -308,6 +308,14 @@ public:
 	Q_PROPERTY(double pos_duty READ measured_pos_duty)
 	Q_PROPERTY(double neg_duty READ measured_neg_duty)
 	Q_PROPERTY(QList<double> data READ data STORED false)
+	Q_PROPERTY(bool filter1_en READ filter1Enable WRITE setFilter1Enable)
+	Q_PROPERTY(float filter1_tc READ filter1TC WRITE setFilter1TC)
+	Q_PROPERTY(float filter1_gain READ filter1Gain WRITE setFilter1Gain)
+	Q_PROPERTY(bool filter2_en READ filter2Enable WRITE setFilter2Enable)
+	Q_PROPERTY(float filter2_tc READ filter2TC WRITE setFilter2TC)
+	Q_PROPERTY(float filter2_gain READ filter2Gain WRITE setFilter2Gain)
+
+
 public:
 	explicit Channel_API(Oscilloscope *osc) :
 		ApiObject(), osc(osc) {}
@@ -356,6 +364,20 @@ public:
 	double measured_pos_duty() const;
 	double measured_neg_duty() const;
 	QList<double> data() const;
+	bool filter1Enable() const;
+	bool filter2Enable() const;
+	void setFilter1Enable(bool en);
+	void setFilter2Enable(bool en);
+	float filter1TC() const;
+	float filter2TC() const;
+	void setFilter1TC(float tc);
+	void setFilter2TC(float tc);
+	float filter1Gain() const;
+	float filter2Gain() const;
+	void setFilter1Gain(float gain);
+	void setFilter2Gain(float gain);
+
+
 
 	Q_INVOKABLE void setColor(int, int, int, int a = 255);
 

--- a/src/oscilloscope_api.hpp
+++ b/src/oscilloscope_api.hpp
@@ -26,6 +26,7 @@ namespace adiscope {
 
 class ApiObject;
 class Oscilloscope;
+class Channel_API;
 /**
   * @brief osc object
   */
@@ -263,6 +264,40 @@ public:
 		Oscilloscope *osc;
 	};
 
+	class Channel_Digital_Filter_API : public ApiObject
+	{
+		Q_OBJECT
+
+		Q_PROPERTY(bool enLow READ isEnableLow WRITE setEnableLow)
+		Q_PROPERTY(float tcLow READ TCLow WRITE setTCLow)
+		Q_PROPERTY(float gainLow READ gainLow WRITE setGainLow)
+		Q_PROPERTY(bool enHigh READ isEnableHigh WRITE setEnableHigh)
+		Q_PROPERTY(float tcHigh READ TCHigh WRITE setTCHigh)
+		Q_PROPERTY(float gainHigh READ gainHigh WRITE setGainHigh)
+	public:
+		explicit Channel_Digital_Filter_API(Oscilloscope *osc, Channel_API *ch_api, int index) :
+			ApiObject(), osc(osc), ch_api(ch_api), filterIndex(index) {}
+		~Channel_Digital_Filter_API() {}
+		bool isEnableLow() const;
+		bool isEnableHigh() const;
+		void setEnableLow(bool en);
+		void setEnableHigh(bool en);
+		float TCLow() const;
+		float TCHigh() const;
+		void setTCLow(float tc);
+		void setTCHigh(float tc);
+		float gainLow() const;
+		float gainHigh() const;
+		void setGainLow(float gain);
+		void setGainHigh(float gain);
+
+	private:
+		Oscilloscope *osc;
+		Channel_API *ch_api;
+		int filterIndex;
+	};
+
+
 	class Channel_API : public ApiObject
 	{
 		Q_OBJECT
@@ -308,18 +343,21 @@ public:
 	Q_PROPERTY(double pos_duty READ measured_pos_duty)
 	Q_PROPERTY(double neg_duty READ measured_neg_duty)
 	Q_PROPERTY(QList<double> data READ data STORED false)
-	Q_PROPERTY(bool filter1_en READ filter1Enable WRITE setFilter1Enable)
-	Q_PROPERTY(float filter1_tc READ filter1TC WRITE setFilter1TC)
-	Q_PROPERTY(float filter1_gain READ filter1Gain WRITE setFilter1Gain)
-	Q_PROPERTY(bool filter2_en READ filter2Enable WRITE setFilter2Enable)
-	Q_PROPERTY(float filter2_tc READ filter2TC WRITE setFilter2TC)
-	Q_PROPERTY(float filter2_gain READ filter2Gain WRITE setFilter2Gain)
+
+	Q_PROPERTY(QVariantList digFilter READ getDigFilters /*WRITE setDigFilter1 */)
 
 
 public:
 	explicit Channel_API(Oscilloscope *osc) :
-		ApiObject(), osc(osc) {}
-	~Channel_API() {}
+		ApiObject(), osc(osc) {
+			for(auto i=0;i<2;i++)
+				digFilters.append(new Channel_Digital_Filter_API(osc,this,i));
+		}
+
+	~Channel_API() {
+			for(auto it = digFilters.begin();it != digFilters.end(); it++ )
+				delete *it;
+		}
 
 	bool channelEn() const;
 	void setChannelEn(bool en);
@@ -364,25 +402,14 @@ public:
 	double measured_pos_duty() const;
 	double measured_neg_duty() const;
 	QList<double> data() const;
-	bool filter1Enable() const;
-	bool filter2Enable() const;
-	void setFilter1Enable(bool en);
-	void setFilter2Enable(bool en);
-	float filter1TC() const;
-	float filter2TC() const;
-	void setFilter1TC(float tc);
-	void setFilter2TC(float tc);
-	float filter1Gain() const;
-	float filter2Gain() const;
-	void setFilter1Gain(float gain);
-	void setFilter2Gain(float gain);
-
-
+	QVariantList getDigFilters() const;
 
 	Q_INVOKABLE void setColor(int, int, int, int a = 255);
 
 private:
 	Oscilloscope *osc;
+	QList<Channel_Digital_Filter_API*> digFilters;
+
 };
 }
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -63,6 +63,12 @@ Preferences::Preferences(QWidget *parent) :
 		osc_labels_enabled = (!state ? false : true);
 		Q_EMIT notify();
 	});
+
+	connect(ui->oscADCFiltersCheckBox, &QCheckBox::stateChanged, [=](int state) {
+		show_ADC_digital_filters = (!state ? false : true);
+		Q_EMIT notify();
+	});
+
 	connect(ui->sigGenNrPeriods, &QLineEdit::returnPressed, [=]() {
 		bool isNumber = false;
 		QString text = ui->sigGenNrPeriods->text();
@@ -183,6 +189,7 @@ void Preferences::showEvent(QShowEvent *event)
 	ui->oscFilteringCheckBox->setChecked(osc_filtering_enabled);
 	ui->histCheckBox->setChecked(mini_hist_enabled);
 	ui->decodersCheckBox->setChecked(digital_decoders_enabled);
+	ui->oscADCFiltersCheckBox->setChecked(show_ADC_digital_filters);
 
 	QWidget::showEvent(event);
 }
@@ -237,6 +244,17 @@ bool Preferences::getAnimations_enabled() const
 void Preferences::setAnimations_enabled(bool value)
 {
     animations_enabled = value;
+}
+
+
+bool Preferences::getShowADCFilters() const
+{
+	return show_ADC_digital_filters;
+}
+
+void Preferences::setShowADCFilters(bool value)
+{
+    show_ADC_digital_filters = value;
 }
 
 bool Preferences::getMini_hist_enabled() const
@@ -512,6 +530,17 @@ void Preferences_API::setOscFilteringEnabled(const bool &enabled)
 {
 	preferencePanel->osc_filtering_enabled = enabled;
 }
+
+bool Preferences_API::getShowADCDigitalFilters() const
+{
+	return preferencePanel->show_ADC_digital_filters;
+}
+
+void Preferences_API::setShowADCDigitalFilters(const bool &enabled)
+{
+	preferencePanel->show_ADC_digital_filters = enabled;
+}
+
 
 bool Preferences_API::getMiniHist() const
 {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -50,7 +50,8 @@ Preferences::Preferences(QWidget *parent) :
 	osc_filtering_enabled(true),
 	mini_hist_enabled(false),
 	digital_decoders_enabled(true),
-	m_initialized(false)
+	m_initialized(false),
+	show_ADC_digital_filters(false)
 {
 	ui->setupUi(this);
 

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -96,6 +96,9 @@ public:
 	bool getDigital_decoders_enabled() const;
 	void setDigital_decoders_enabled(bool value);
 
+	bool getShowADCFilters() const ;
+	void setShowADCFilters(bool value);
+
 Q_SIGNALS:
 
 	void notify();
@@ -124,6 +127,7 @@ private:
 	bool manual_calib_enabled;
 	bool animations_enabled;
 	bool osc_filtering_enabled;
+	bool show_ADC_digital_filters;
 	bool mini_hist_enabled;
 	bool digital_decoders_enabled;
 	bool m_initialized;
@@ -152,6 +156,7 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool osc_filtering_enabled READ getOscFilteringEnabled WRITE setOscFilteringEnabled)
 	Q_PROPERTY(bool mini_hist_enabled READ getMiniHist WRITE setMiniHist)
 	Q_PROPERTY(bool digital_decoders READ getDigitalDecoders WRITE setDigitalDecoders)
+	Q_PROPERTY(bool show_ADC_digital_filters READ getShowADCDigitalFilters WRITE setShowADCDigitalFilters)
 
 public:
 
@@ -197,6 +202,9 @@ public:
 
 	bool getOscFilteringEnabled() const;
 	void setOscFilteringEnabled(const bool& enabled);
+
+	bool getShowADCDigitalFilters() const;
+	void setShowADCDigitalFilters(const bool& enabled);
 
 	bool getMiniHist() const;
 	void setMiniHist(const bool& enabled);

--- a/ui/channel_settings.ui
+++ b/ui/channel_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>535</width>
-    <height>538</height>
+    <height>962</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -104,9 +104,9 @@ font-weight: normal;
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-138</y>
-        <width>461</width>
-        <height>633</height>
+        <y>0</y>
+        <width>475</width>
+        <height>919</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -777,6 +777,55 @@ color: rgba(255, 255, 255, 70);
            </item>
           </layout>
          </item>
+         <item row="0" column="1">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <property name="spacing">
+            <number>3</number>
+           </property>
+           <property name="bottomMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_4">
+             <property name="styleSheet">
+              <string notr="true">font-size: 13px;</string>
+             </property>
+             <property name="text">
+              <string>Curve Style</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="lineStyle">
+             <item>
+              <property name="text">
+               <string>Lines</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Dots</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Steps</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Sticks</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Smooth</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item row="1" column="1">
           <widget class="QWidget" name="probeWidget" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout">
@@ -849,55 +898,6 @@ Attenuation</string>
            </layout>
           </widget>
          </item>
-         <item row="0" column="1">
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="spacing">
-            <number>3</number>
-           </property>
-           <property name="bottomMargin">
-            <number>10</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="styleSheet">
-              <string notr="true">font-size: 13px;</string>
-             </property>
-             <property name="text">
-              <string>Curve Style</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="lineStyle">
-             <item>
-              <property name="text">
-               <string>Lines</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Dots</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Steps</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Sticks</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Smooth</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
        </item>
        <item>
@@ -950,6 +950,370 @@ AC Coupling</string>
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="filter1" native="true">
+         <property name="styleSheet">
+          <string notr="true">QCheckBox::indicator {
+  border: 2px solid rgb(74, 100, 255);
+  border-radius: 4px;
+  width: 16px;
+  height: 16px;
+  subcontrol-position: left;
+}
+
+QCheckBox::indicator:checked {
+  background-color: rgb(74, 100, 255);
+}
+
+QCheckBox{
+text-align: center;
+
+}</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="Line" name="line_5">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="filter_en">
+            <property name="text">
+             <string>Filter 1 - Enabled</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_6">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>TC</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="filter_TC">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>2</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>10</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Gain</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="filter_gain">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>2</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>0.1</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="filter2" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>10</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="Line" name="line_6">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="filter2_en">
+            <property name="styleSheet">
+             <string notr="true">QCheckBox::indicator {
+  border: 2px solid rgb(74, 100, 255);
+  border-radius: 4px;
+  width: 16px;
+  height: 16px;
+  subcontrol-position: left;
+}
+
+QCheckBox::indicator:checked {
+  background-color: rgb(74, 100, 255);
+}
+
+QCheckBox{
+text-align: center;
+
+}</string>
+            </property>
+            <property name="text">
+             <string>Filter 2 - Enabled</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_11">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>TC</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="filter2_TC">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>2</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>10</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>10</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_12">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Gain</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="filter2_gain">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>2</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>0.1</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="Line" name="line_7">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>1</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item>
         <widget class="QPushButton" name="btnAutoset">

--- a/ui/channel_settings.ui
+++ b/ui/channel_settings.ui
@@ -1056,7 +1056,7 @@ text-align: center;
                </sizepolicy>
               </property>
               <property name="text">
-               <string>10</string>
+               <string>1</string>
               </property>
              </widget>
             </item>
@@ -1102,7 +1102,7 @@ text-align: center;
                </sizepolicy>
               </property>
               <property name="text">
-               <string>0.1</string>
+               <string>0</string>
               </property>
              </widget>
             </item>
@@ -1219,7 +1219,7 @@ text-align: center;
                </sizepolicy>
               </property>
               <property name="text">
-               <string>10</string>
+               <string>1</string>
               </property>
              </widget>
             </item>
@@ -1268,7 +1268,7 @@ text-align: center;
                </sizepolicy>
               </property>
               <property name="text">
-               <string>0.1</string>
+               <string>0</string>
               </property>
              </widget>
             </item>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -180,11 +180,11 @@ color: rgba(255, 255, 255, 70);
            <property name="verticalSpacing">
             <number>10</number>
            </property>
-           <item row="5" column="0">
-            <widget class="QWidget" name="Oscilloscope_2" native="true">
-             <layout class="QVBoxLayout" name="verticalLayout_8">
+           <item row="2" column="1">
+            <widget class="QWidget" name="manualCalibWidget" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
               <property name="spacing">
-               <number>5</number>
+               <number>0</number>
               </property>
               <property name="leftMargin">
                <number>0</number>
@@ -199,73 +199,310 @@ color: rgba(255, 255, 255, 70);
                <number>0</number>
               </property>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_8">
-                <property name="spacing">
-                 <number>0</number>
+               <widget class="QCheckBox" name="manualCalibCheckBox">
+                <property name="styleSheet">
+                 <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
                 </property>
-                <property name="topMargin">
-                 <number>0</number>
+                <property name="text">
+                 <string/>
                 </property>
-                <item>
-                 <widget class="QLabel" name="label_7">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">QLabel {
-  font-size: 12px;
-color: rgba(255, 255, 255, 70);
-}</string>
-                  </property>
-                  <property name="text">
-                   <string>OSCILLOSCOPE </string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="Line" name="line_2">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
+               </widget>
               </item>
               <item>
-               <spacer name="verticalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>Scriptable manual calibration</string>
                 </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_11">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>20</width>
-                  <height>5</height>
+                  <width>40</width>
+                  <height>20</height>
                  </size>
                 </property>
                </spacer>
               </item>
-              <item>
+             </layout>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QWidget" name="Oscilloscope_2" native="true">
+             <layout class="QGridLayout" name="gridLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <property name="horizontalSpacing">
+               <number>0</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>15</number>
+              </property>
+              <item row="2" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_13">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="oscGraticuleCheckBox">
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_13">
+                  <property name="text">
+                   <string>Enable graticule</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_17">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="oscFilteringCheckBox">
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_17">
+                  <property name="text">
+                   <string>Enable sample rate filters</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_13">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="4" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_19">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="histCheckBox">
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_18">
+                  <property name="text">
+                   <string>Enable mini histogram</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_14">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="5" column="0">
+               <spacer name="verticalSpacer_14">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_20">
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="oscADCFiltersCheckBox">
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_20">
+                  <property name="text">
+                   <string>Show ADC digital filter config</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_16">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
                <layout class="QHBoxLayout" name="horizontalLayout">
                 <property name="spacing">
                  <number>0</number>
@@ -333,251 +570,67 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
                 </item>
                </layout>
               </item>
-              <item>
-               <spacer name="verticalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>5</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_13">
+              <item row="0" column="0" colspan="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_8">
                 <property name="spacing">
                  <number>0</number>
                 </property>
-                <property name="bottomMargin">
+                <property name="topMargin">
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QCheckBox" name="oscGraticuleCheckBox">
+                 <widget class="QLabel" name="label_7">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="styleSheet">
-                   <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                   <string notr="true">QLabel {
+  font-size: 12px;
+color: rgba(255, 255, 255, 70);
+}</string>
                   </property>
                   <property name="text">
-                   <string/>
+                   <string>OSCILLOSCOPE </string>
                   </property>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="label_13">
-                  <property name="text">
-                   <string>Enable graticule</string>
+                 <widget class="Line" name="line_2">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>1</height>
+                   </size>
                   </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_9">
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>1</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                  </property>
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
+                 </widget>
                 </item>
                </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_12">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>5</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_17">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="oscFilteringCheckBox">
-                  <property name="styleSheet">
-                   <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_17">
-                  <property name="text">
-                   <string>Enable oscilloscope filters</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_13">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_13">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>5</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_19">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="histCheckBox">
-                  <property name="styleSheet">
-                   <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_18">
-                  <property name="text">
-                   <string>Enable mini histogram</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_14">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_14">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
              </layout>
             </widget>
            </item>
-           <item row="3" column="0">
-            <layout class="QHBoxLayout" name="horizontalLayout_16">
+           <item row="3" column="1">
+            <layout class="QHBoxLayout" name="decodersWidget">
              <property name="spacing">
               <number>0</number>
              </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
              <item>
-              <widget class="QCheckBox" name="enableAnimCheckBox">
+              <widget class="QCheckBox" name="decodersCheckBox">
                <property name="styleSheet">
                 <string notr="true">QCheckBox {
   spacing: 8px;
@@ -606,14 +659,14 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_16">
+              <widget class="QLabel" name="label_19">
                <property name="text">
-                <string>Enable animations</string>
+                <string>Enable digital decoders</string>
                </property>
               </widget>
              </item>
              <item>
-              <spacer name="horizontalSpacer_12">
+              <spacer name="horizontalSpacer_15">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -627,112 +680,7 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
              </item>
             </layout>
            </item>
-           <item row="2" column="0">
-            <widget class="QWidget" name="extScriptWidget" native="true">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_14">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QCheckBox" name="extScriptCheckBox">
-                <property name="styleSheet">
-                 <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>Run external scripts (Experimental)</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_10">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item row="6" column="0">
-            <spacer name="verticalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>15</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="4" column="0">
-            <spacer name="verticalSpacer_8">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>15</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="7" column="0">
             <layout class="QVBoxLayout" name="verticalLayout_4">
              <property name="spacing">
               <number>0</number>
@@ -954,368 +902,6 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
              </property>
             </spacer>
            </item>
-           <item row="0" column="0">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QCheckBox" name="saveSessionCheckBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_4">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Save session when closing Scopy</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item row="7" column="1">
-            <widget class="QWidget" name="NetworkAnalyzer" native="true">
-             <layout class="QVBoxLayout" name="verticalLayout_5">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_11">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_10">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">QLabel {
-  font-size: 12px;
-color: rgba(255, 255, 255, 70);
-}</string>
-                  </property>
-                  <property name="text">
-                   <string>NETWORK ANALYZER </string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="Line" name="line_5">
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_11">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>15</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_5">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="na_zeroCheckBox">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>Always display 0db value on graph</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_5">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_15">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>5</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_12">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QCheckBox" name="userNotesCheckBox">
-               <property name="styleSheet">
-                <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Enable user notes</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_8">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item row="2" column="1">
-            <widget class="QWidget" name="manualCalibWidget" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_15">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QCheckBox" name="manualCalibCheckBox">
-                <property name="styleSheet">
-                 <string notr="true">QCheckBox {
-  spacing: 8px;
-  background-color: transparent;
-  font-size: 14px;
-  font-weight: bold;
-
-  color: rgba(255, 255, 255, 153);
-}
-
-QCheckBox::indicator {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(74,100,255);
-  border-radius: 4px;
-}
-QCheckBox::indicator:unchecked { background-color: transparent; }
-QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_15">
-                <property name="text">
-                 <string>Scriptable manual calibration</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_11">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item row="1" column="0">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <property name="spacing">
@@ -1359,6 +945,68 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
              </item>
              <item>
               <spacer name="horizontalSpacer_7">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="3" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_16">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="enableAnimCheckBox">
+               <property name="styleSheet">
+                <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_16">
+               <property name="text">
+                <string>Enable animations</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_12">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -1533,13 +1181,271 @@ color: white;
              </layout>
             </widget>
            </item>
-           <item row="3" column="1">
-            <layout class="QHBoxLayout" name="decodersWidget">
+           <item row="6" column="1">
+            <widget class="QWidget" name="NetworkAnalyzer" native="true">
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_11">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_10">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">QLabel {
+  font-size: 12px;
+color: rgba(255, 255, 255, 70);
+}</string>
+                  </property>
+                  <property name="text">
+                   <string>NETWORK ANALYZER </string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Line" name="line_5">
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>1</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>1</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">border: 1px solid rgba(255, 255, 255, 70);</string>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_11">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>15</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="na_zeroCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Always display 0db value on graph</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>5</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <spacer name="verticalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>15</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="saveSessionCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_4">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Save session when closing Scopy</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_12">
              <property name="spacing">
               <number>0</number>
              </property>
              <item>
-              <widget class="QCheckBox" name="decodersCheckBox">
+              <widget class="QCheckBox" name="userNotesCheckBox">
                <property name="styleSheet">
                 <string notr="true">QCheckBox {
   spacing: 8px;
@@ -1562,20 +1468,17 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
                <property name="text">
                 <string/>
                </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_19">
+              <widget class="QLabel" name="label_12">
                <property name="text">
-                <string>Enable digital decoders</string>
+                <string>Enable user notes</string>
                </property>
               </widget>
              </item>
              <item>
-              <spacer name="horizontalSpacer_15">
+              <spacer name="horizontalSpacer_8">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -1588,6 +1491,79 @@ QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
               </spacer>
              </item>
             </layout>
+           </item>
+           <item row="2" column="0">
+            <widget class="QWidget" name="extScriptWidget" native="true">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QCheckBox" name="extScriptCheckBox">
+                <property name="styleSheet">
+                 <string notr="true">QCheckBox {
+  spacing: 8px;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+
+  color: rgba(255, 255, 255, 153);
+}
+
+QCheckBox::indicator {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgb(74,100,255);
+  border-radius: 4px;
+}
+QCheckBox::indicator:unchecked { background-color: transparent; }
+QCheckBox::indicator:checked { background-color: rgb(74,100,255); }</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Run external scripts (Experimental)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_10">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
Filters are only enabled for lowgain mode, as high gain should be calibrated using the trimmers on the M2k. There is an option to show/hide the controls in the oscilloscope channels. The values for the filters are saved in the Scopy.ini file.