### PR TITLE
powercontrol.ui: set lower limit to 0

### DIFF
--- a/ui/powercontrol.ui
+++ b/ui/powercontrol.ui
@@ -694,7 +694,7 @@ QSlider::sub-page:horizontal {
 }</string>
           </property>
           <property name="minimum">
-           <number>1</number>
+           <number>0</number>
           </property>
           <property name="maximum">
            <number>100</number>


### PR DESCRIPTION
The tracking ratio would only go from 1 to 100, when in fact it should go from 0 to 100

Fixes: #757 

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>