### PR TITLE
Pattern Generator I2C ACK masking fix

### DIFF
--- a/src/pg_patterns.cpp
+++ b/src/pg_patterns.cpp
@@ -1616,9 +1616,14 @@ void I2CPattern::sample_address()
 
 }
 
-void I2CPattern::sample_ack()
+void I2CPattern::sample_send_ack()
 {
 	sample_bit(0);
+}
+
+void I2CPattern::sample_await_ack()
+{
+	sample_bit(1);
 }
 
 void I2CPattern::sample_payload()
@@ -1647,7 +1652,11 @@ void I2CPattern::sample_payload()
 			sample_bit(bit);
 		}
 
-		sample_ack();
+		if (read) {
+			sample_send_ack();
+		} else {
+			sample_await_ack();
+		}
 	}
 }
 
@@ -1677,7 +1686,7 @@ uint8_t I2CPattern::generate_pattern(uint32_t sample_rate,
 
 	sample_start_bit();
 	sample_address();
-	sample_ack();
+	sample_await_ack();
 	sample_payload();
 	sample_stop();
 	return 0;

--- a/src/pg_patterns.hpp
+++ b/src/pg_patterns.hpp
@@ -433,7 +433,8 @@ class I2CPattern: virtual public Pattern
 	void sample_bit(bool bit);
 	void sample_start_bit();
 	void sample_address();
-	void sample_ack();
+	void sample_send_ack();
+	void sample_await_ack();
 	void sample_payload();
 	void sample_stop();
 public:


### PR DESCRIPTION
### Issue
The pattern generator I2C implementation masks slave NACK responses by pulling the SDA line low at each ACK slot - regardless of whether the pattern gen is reading or writing.

### Context
I2C uses an open drain clock (SCL) and data (SDA) line, with each device pulling the SDA line low to communicate. At the end of each byte the sending device should wait for the receiving device to acknowledge the byte with an 'ACK', by pulling the SDA line low for one clock pulse from the master.

There are three possible communication scenarios in I2C that use an ACK that I know of:
1. Following an address byte sent from the master (the slave ACKs)
2. Following a byte written from master to slave (the slave ACKs)
3. Following a byte read from slave to master (the master ACKs)

The pattern gen in scopy is currently pulling SDA low after every byte. This means that if a slave NACKs by leaving the SDA line alone after a byte, we don't see it because the pattern gen produced its own ACK. This affects 1 and 2 above.

### Fix
This fix distinguishes between the three ACK scenarios above. When sending an address byte the SDA line is left high, allowing the slave to send an ACK; similarly, after writing each byte the SDA line is left high. However, the original behaviour is preserved for reading a byte - the SDA line is pulled low after each byte to acknowledge reciept to the slave device.

I have tried to approach this semantically in the code, as with the existing implementation - apologies if the style is not quite right, I don't do much C++. I have built and tested this against the current master branch and it appears to work just fine.