### PR TITLE
SignalGenerator: fix trapezoidal wave frequency rounding error

### DIFF
--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -836,7 +836,8 @@ void SignalGenerator::dutyChanged(double value)
 void SignalGenerator::trapezoidalComputeFrequency()
 {
 	auto ptr = getCurrentData();
-	frequency->setValue(static_cast<double>(1/(ptr->rise+ptr->fall+ptr->holdh+ptr->holdl)));
+	double value = static_cast<double>((round(1/(ptr->rise+ptr->fall+ptr->holdh+ptr->holdl))*1000)/1000);
+	frequency->setValue(value);
 }
 
 void SignalGenerator::riseChanged(double value)


### PR DESCRIPTION
fixes frequency  approximation bug when switching to trapezoidal waveform

the computed frequency is not displayed correctly causing waveforms to appear
out of sync.
Rounding the frequency using 3 decimals fixes this issue
as 3 decimals are also displayed in the spinbox.

Signed-off-by: Cristina Suteu <cristina.suteu@analog.com>