### PR TITLE
CI/appveyor/flatpak: Modify the source of the flatpak Docker.

### DIFF
--- a/CI/appveyor/build_appveyor_flatpak.sh
+++ b/CI/appveyor/build_appveyor_flatpak.sh
@@ -7,7 +7,7 @@ REPO=${2:-analogdevicesinc/scopy}
 
 sudo apt-get -qq update
 sudo service docker restart
-sudo docker pull alexandratr/scopy-flatpak-bionic:scopy
+sudo docker pull alexandratr/scopy-flatpak-bionic:latest
 
 # Start the docker in detached state
 commit_nb=$(sudo docker run -d \
@@ -16,7 +16,7 @@ commit_nb=$(sudo docker run -d \
 		-v `pwd`:/scopy:rw \
 		-e "BRANCH=$BRANCH" \
 		-e "REPO=$REPO" \
-		alexandratr/scopy-flatpak-bionic:scopy \
+		alexandratr/scopy-flatpak-bionic:latest \
 		/bin/bash -xe /scopy/CI/appveyor/inside_flatpak_docker.sh)
 
 # Attach ourselves to the running docker and wait for it to finish

--- a/CI/appveyor/docker/Dockerfile
+++ b/CI/appveyor/docker/Dockerfile
@@ -3,14 +3,12 @@ FROM ubuntu:18.04
 RUN apt-get update -y
 
 # Install base dependencies
-RUN apt-get install -y software-properties-common build-essential git
-RUN apt-get install -y sudo apt-utils
+RUN apt-get install -y software-properties-common build-essential git sudo apt-utils
 
 # Install flatpak
 RUN add-apt-repository ppa:alexlarsson/flatpak -y
 RUN apt-get update -y
-RUN apt install flatpak -y
-RUN apt install flatpak-builder -y
+RUN apt install flatpak flatpak-builder -y
 
 # Install remote
 RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/CI/appveyor/inside_flatpak_docker.sh
+++ b/CI/appveyor/inside_flatpak_docker.sh
@@ -5,7 +5,7 @@ apt-get install -y jq
 REPO_URL=https://github.com/"$REPO"
 REPO_LOCAL=/home/docker/scopy-flatpak
 cd "$REPO_LOCAL"
-git checkout master && git pull
+git pull && git checkout master
 
 # check the number of elements in the json file in order to get the last element, which is Scopy
 cnt=$( echo `jq '.modules | length' org.adi.Scopy.json` )


### PR DESCRIPTION
The "latest" Docker image tag is an updated version which has the latest versions for all
the dependencies.

This works now and it will work fine until the next update for some dependency (this time was GNURadio). But I am working on a way to trigger Docker builds (on Dockerhub) every time something happens (it could be a push to the GNURadio repository, Sigrok repository, or it might even be a cron job which builds a new Docker image once a week/month). This way we'll always have an up-to-date Docker image to build our Scopy flatpak on, such that we don't exceed the Appveyor time limit.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>