### PR TITLE
appveyor.yml: update pacman before updating rest of deps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ install:
     - sh: docker version
 
 build_script:
+    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy pacman"
     - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     - cmd: set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 5"
     - cmd: "%BUILD_DEPS_CMD%"


### PR DESCRIPTION
MSYS2 introduced a bug  https://github.com/msys2/MSYS2-packages/issues/1960
The current workaround is to update pacman before updating rest of deps

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>