### PR TITLE
ci: use older version of boost as 1.73 currently breaks build

### DIFF
--- a/CI/appveyor/build_appveyor_mingw.sh
+++ b/CI/appveyor/build_appveyor_mingw.sh
@@ -25,7 +25,8 @@ SCOPY_CMAKE_OPTS="
 	-DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe \
 	-DPYTHON_EXECUTABLE=/$MINGW_VERSION/bin/python3.exe \
 	"
-DLL_DEPS="libmatio-*.dll libhdf5-*.dll libszip*.dll libpcre*.dll libdouble-conversion*.dll libwinpthread-*.dll libgcc_*.dll libstdc++-*.dll libboost_*.dll libglib-*.dll libintl-*.dll libiconv-*.dll libglibmm-2.*.dll libgmodule-2.*.dll libgobject-2.*.dll libffi-*.dll libsigc-2.*.dll libfftw3f-*.dll libicu*.dll zlib*.dll libharfbuzz-*.dll libfreetype-*.dll libbz2-*.dll libpng16-*.dll libgraphite2.dll libjpeg-*.dll libsqlite3-*.dll libwebp-*.dll libxml2-*.dll liblzma-*.dll libxslt-*.dll libzip*.dll libpython3.*.dll libgnutls*.dll libnettle*.dll libhogweed*.dll libgmp*.dll libidn*.dll libp11*.dll libtasn*.dll libunistring*.dll libusb-*.dll libzstd*.dll libgnuradio-*.dll /$MINGW_VERSION/lib/python3.* libiio*.dll libvolk*.dll liblog4cpp*.dll libad9361*.dll liborc*.dll libsigrok*.dll qwt*.dll libm2k*.dll"
+
+DLL_DEPS="libmatio-*.dll libhdf5-*.dll libszip*.dll libpcre*.dll libdouble-conversion*.dll libwinpthread-*.dll libgcc_*.dll libstdc++-*.dll libboost_*.dll libglib-*.dll libintl-*.dll libiconv-*.dll libglibmm-2.*.dll libgmodule-2.*.dll libgobject-2.*.dll libffi-*.dll libsigc-2.*.dll libfftw3f-*.dll libicu*.dll zlib*.dll libharfbuzz-*.dll libfreetype-*.dll libbz2-*.dll libpng16-*.dll libgraphite2.dll libjpeg-*.dll libsqlite3-*.dll libwebp-*.dll libxml2-*.dll liblzma-*.dll libxslt-*.dll libzip*.dll libpython3.*.dll libgnutls*.dll libnettle*.dll libhogweed*.dll libgmp*.dll libidn*.dll libp11*.dll libtasn*.dll libunistring*.dll libusb-*.dll libzstd*.dll libgnuradio-*.dll /$MINGW_VERSION/lib/python3.* libiio*.dll libvolk*.dll liblog4cpp*.dll libad9361*.dll liborc*.dll libsigrok*.dll qwt*.dll libm2k*.dll libbrotli*.dll"
 
 OLD_PATH=$PATH
 DEST_FOLDER=scopy_$ARCH_BIT

--- a/CI/appveyor/install_msys_deps.sh
+++ b/CI/appveyor/install_msys_deps.sh
@@ -18,6 +18,7 @@ PACMAN_SYNC_DEPS="
 PACMAN_REPO_DEPS="
 	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-breakpad-git-r1680.70914b2d-1-any.pkg.tar.xz \
 	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
+	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
 "
 
 PATH=/c/msys64/$MINGW_VERSION/bin:$PATH

--- a/CI/appveyor/install_msys_deps.sh
+++ b/CI/appveyor/install_msys_deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash.exe
 
-SCOPY_MINGW_BUILD_DEPS_FORK=adisuciu
-SCOPY_MINGW_BUILD_DEPS_BRANCH=qt5.12.4
+SCOPY_MINGW_BUILD_DEPS_FORK=analogdevicesinc
+SCOPY_MINGW_BUILD_DEPS_BRANCH=master
 
 echo "Download and install pre-compiled libraries ... "
 wget "https://ci.appveyor.com/api/projects/$SCOPY_MINGW_BUILD_DEPS_FORK/scopy-mingw-build-deps/artifacts/scopy-$MINGW_VERSION-build-deps-pacman.txt?branch=$SCOPY_MINGW_BUILD_DEPS_BRANCH&job=Environment: MINGW_VERSION=$MINGW_VERSION, ARCH=$ARCH" -O /tmp/scopy-$MINGW_VERSION-build-deps-pacman.txt
@@ -19,6 +19,7 @@ PACMAN_REPO_DEPS="
 	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-breakpad-git-r1680.70914b2d-1-any.pkg.tar.xz \
 	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
 	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
+	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-qt5-5.14.2-3-any.pkg.tar.zst \
 "
 
 PATH=/c/msys64/$MINGW_VERSION/bin:$PATH


### PR DESCRIPTION
Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>