### PR TITLE
Fix MacOS builds on Appveyor and update the code to be compatible with Qt 5.15 and latest Qwt.

### DIFF
--- a/CI/appveyor/before_install_lib.sh
+++ b/CI/appveyor/before_install_lib.sh
@@ -223,8 +223,7 @@ EOF
 }
 
 patch_qwtpolar() {
-	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qt_5.15_qwtpolar.patch
-	wget https://raw.githubusercontent.com/analogdevicesinc/scopy-flatpak/master/qwtpolar-qwt-6.1-compat.patch -O - | patch -p1
+	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qwtpolar-qwt-qt-compat.patch
 
 	patch -p1 <<-EOF
 --- a/qwtpolarconfig.pri

--- a/CI/appveyor/before_install_lib.sh
+++ b/CI/appveyor/before_install_lib.sh
@@ -158,6 +158,21 @@ qmake_build_git() {
 	__build_common "$dir" "__qmake" "git_clone_update"
 }
 
+qmake_build_local() {
+	local dir="$1"
+	local qtarget="$2"
+	local patchfunc="$3"
+
+	[ ! -d "$WORKDIR/$dir" ] || {
+		[ -z "$patchfunc" ] || {
+			pushd $WORKDIR/$dir
+			$patchfunc
+			popd
+		}
+	}
+	__build_common "$dir" "__qmake"
+}
+
 patch_qwt() {
 	patch -p1 <<-EOF
 --- a/qwtconfig.pri
@@ -177,7 +192,7 @@ patch_qwt() {
  
 -    QWT_CONFIG += QwtFramework
 +    #QWT_CONFIG += QwtFramework
- }  
+ }
  
  ######################################################################
 --- a/src/src.pro
@@ -203,11 +218,12 @@ patch_qwt() {
 +        macx: QWT_SONAME=\$\${QWT_INSTALL_LIBS}/libqwtmathml.dylib
          QMAKE_LFLAGS *= \$\${QMAKE_LFLAGS_SONAME}\$\${QWT_SONAME}
          QMAKE_LFLAGS_SONAME=
-     }   
+     }
 EOF
 }
 
 patch_qwtpolar() {
+	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qt_5.15_qwtpolar.patch
 	wget https://raw.githubusercontent.com/analogdevicesinc/scopy-flatpak/master/qwtpolar-qwt-6.1-compat.patch -O - | patch -p1
 
 	patch -p1 <<-EOF

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -213,29 +213,14 @@ build_grscopy() {
 	sudo make $JOBS install
 }
 
-build_libsigrok() {
-	echo "### Building libsigrok - branch $LIBSIGROK_BRANCH"
-
-	git clone --depth 1 https://github.com/sigrokproject/libsigrok.git -b $LIBSIGROK_BRANCH ${WORKDIR}/libsigrok
-
-	mkdir ${WORKDIR}/libsigrok/build-${ARCH}
-	cd ${WORKDIR}/libsigrok
-
-	./autogen.sh
-	./configure --disable-all-drivers --enable-bindings --enable-cxx
-
-	sudo make $JOBS install
-}
-
 build_libsigrokdecode() {
 	echo "### Building libsigrokdecode - branch $LIBSIGROKDECODE_BRANCH"
 
+	git clone --depth 1 https://github.com/sigrokproject/libsigrokdecode.git -b $LIBSIGROKDECODE_BRANCH ${WORKDIR}/libsigrokdecode
 	mkdir -p ${WORKDIR}/libsigrokdecode/build-${ARCH}
 	cd ${WORKDIR}/libsigrokdecode
 
-	wget http://sigrok.org/download/source/libsigrokdecode/libsigrokdecode-0.4.1.tar.gz -O- \
-		| tar xz --strip-components=1 -C ${WORKDIR}/libsigrokdecode
-
+	./autogen.sh
 	./configure
 	sudo make $JOBS install
 }
@@ -282,7 +267,6 @@ build_grscopy
 build_grm2k
 build_qwt
 build_qwtpolar
-build_libsigrok
 build_libsigrokdecode
 
 

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -16,13 +16,16 @@ BOOST_VERSION_FILE=1_65_1
 BOOST_VERSION=1.65.1
 
 PYTHON="python3"
-PACKAGES="pkg-config qt cmake fftw bison gettext autoconf automake libtool libzip glib libusb $PYTHON"
+PACKAGES="pkg-config cmake fftw bison gettext autoconf automake libtool libzip glib libusb $PYTHON"
 PACKAGES="$PACKAGES glibmm doxygen wget gnu-sed libmatio dylibbundler libxml2"
 
 set -e
 cd ~
 WORKDIR=${PWD}
 NUM_JOBS=4
+
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8846805afc0cb8e5d114d5e222af1de3b35289df/Formula/qt.rb
+export PATH="/usr/local/opt/qt/bin:$PATH"
 
 brew_install_or_upgrade() {
 	brew install $1 || \
@@ -39,7 +42,7 @@ for pak in $PACKAGES ; do
 	brew_install $pak
 done
 
-for pkg in qt gcc bison gettext cmake python; do
+for pkg in gcc bison gettext cmake python; do
 	brew link --overwrite --force $pkg
 done
 

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -251,7 +251,7 @@ EOF
 
 build_qwt() {
 	echo "### Building qwt - branch qwt-6.1-multiaxes"
-	svn checkout https://svn.code.sf.net/p/qwt/code/branches/qwt-6.1-multiaxes ${WORKDIR}/qwt
+	svn checkout https://svn.code.sf.net/p/qwt/code/branches/$QWT_BRANCH ${WORKDIR}/qwt
 	qmake_build_local "qwt" "qwt.pro" "patch_qwt"
 }
 

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -261,7 +261,9 @@ EOF
 }
 
 build_qwt() {
-	qmake_build_git "qwt" "https://github.com/osakared/qwt.git" "qwt-6.1-multiaxes" "qwt.pro" "patch_qwt"
+	echo "### Building qwt - branch qwt-6.1-multiaxes"
+	svn checkout https://svn.code.sf.net/p/qwt/code/branches/qwt-6.1-multiaxes ${WORKDIR}/qwt
+	qmake_build_local "qwt" "qwt.pro" "patch_qwt"
 }
 
 build_qwtpolar() {

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -137,6 +137,7 @@ build_boost() {
 	wget https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_FILE.tar.gz
 	tar -xzf boost_$BOOST_VERSION_FILE.tar.gz
 	cd boost_$BOOST_VERSION_FILE
+	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/boost-darwin.patch
 	./bootstrap.sh --with-libraries=atomic,date_time,filesystem,program_options,system,chrono,thread,regex,test
 	./b2
 	./b2 install

--- a/CI/appveyor/install_ubuntu_deps.sh
+++ b/CI/appveyor/install_ubuntu_deps.sh
@@ -199,9 +199,7 @@ build_qwtpolar() {
 		| tar xj --strip-components=1 -C ${WORKDIR}/qwtpolar
 
 	cd ~/qwtpolar
-	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qt_5.15_qwtpolar.patch
-	curl -o qwtpolar-qwt-6.1-compat.patch https://raw.githubusercontent.com/analogdevicesinc/scopy-flatpak/master/qwtpolar-qwt-6.1-compat.patch
-	patch -p1 < qwtpolar-qwt-6.1-compat.patch
+	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qwtpolar-qwt-qt-compat.patch
 	sed -i 's/\/usr\/local\/qwtpolar-$$QWT_POLAR_VERSION/\/usr\/local/g' qwtpolarconfig.pri
 	sed -i 's/QWT_POLAR_CONFIG     += QwtPolarExamples/ /g' qwtpolarconfig.pri
 	sed -i 's/QWT_POLAR_CONFIG     += QwtPolarDesigner/ /g' qwtpolarconfig.pri

--- a/CI/appveyor/install_ubuntu_deps.sh
+++ b/CI/appveyor/install_ubuntu_deps.sh
@@ -174,7 +174,7 @@ build_libsigrokdecode() {
 build_qwt() {
 	echo "### Building qwt - branch $QWT_BRANCH"
 
-	git clone --depth 1 https://github.com/osakared/qwt.git -b $QWT_BRANCH ${WORKDIR}/qwt
+	svn checkout https://svn.code.sf.net/p/qwt/code/branches/$QWT_BRANCH ${WORKDIR}/qwt
 	cd ${WORKDIR}/qwt
 
 	# Disable components that we won't build
@@ -199,6 +199,7 @@ build_qwtpolar() {
 		| tar xj --strip-components=1 -C ${WORKDIR}/qwtpolar
 
 	cd ~/qwtpolar
+	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/qt_5.15_qwtpolar.patch
 	curl -o qwtpolar-qwt-6.1-compat.patch https://raw.githubusercontent.com/analogdevicesinc/scopy-flatpak/master/qwtpolar-qwt-6.1-compat.patch
 	patch -p1 < qwtpolar-qwt-6.1-compat.patch
 	sed -i 's/\/usr\/local\/qwtpolar-$$QWT_POLAR_VERSION/\/usr\/local/g' qwtpolarconfig.pri

--- a/CI/appveyor/patches/boost-darwin.patch
+++ b/CI/appveyor/patches/boost-darwin.patch
@@ -1,0 +1,18 @@
+diff --git a/darwin.jam b/darwin.jam
+--- a/tools/build/src/tools/darwin.jam
++++ b/tools/build/src/tools/darwin.jam
+@@ -138,10 +138,10 @@
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
+-    {
+-        flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+-    }
++#    if $(real-version) < "4.0.0"
++#    {
++#        flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
++#    }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+     if $(real-version) < "4.2.0"
+     {

--- a/CI/appveyor/patches/qt_5.15_qwtpolar.patch
+++ b/CI/appveyor/patches/qt_5.15_qwtpolar.patch
@@ -1,0 +1,76 @@
+diff --git a/qwt_polar_curve.cpp b/qwt_polar_curve.cpp
+--- a/src/qwt_polar_curve.cpp
++++ b/src/qwt_polar_curve.cpp
+@@ -16,6 +16,7 @@
+ #include <qwt_curve_fitter.h>
+ #include <qwt_clipper.h>
+ #include <qpainter.h>
++#include <QPolygonF>
+
+ static inline bool qwtInsidePole( const QwtScaleMap &map, double radius )
+ {
+@@ -435,7 +435,12 @@
+     {
+         double off = qCeil( qMax( qreal( 1.0 ), painter->pen().widthF() ) );
+         clipRect = clipRect.toRect().adjusted( -off, -off, off, off );
+-        polyline = QwtClipper::clipPolygonF( clipRect, polyline );
++
++#if QWT_VERSION < 0x060400
++	polyline = QwtClipper::clipPolygonF( clipRect, polyline );
++#else /* QWT_VERSION < 0x060400 */
++	polyline = QwtClipper::clippedPolygonF( clipRect, polyline );
++#endif /* QWT_VERSION < 0x060400 */
+     }
+
+     QwtPainter::drawPolyline( painter, polyline );
+
+diff --git a/qwt_polar_fitter.cpp b/qwt_polar_fitter.cpp
+--- a/src/qwt_polar_fitter.cpp
++++ b/src/qwt_polar_fitter.cpp
+@@ -7,6 +7,7 @@
+  *****************************************************************************/
+
+ #include "qwt_polar_fitter.h"
++#include <QPolygonF>
+
+ class QwtPolarFitter::PrivateData
+ {
+
+diff --git a/qwt_polar_fitter.h b/qwt_polar_fitter.h
+--- a/src/qwt_polar_fitter.h
++++ b/src/qwt_polar_fitter.h
+@@ -12,6 +12,7 @@
+ #include "qwt_polar_global.h"
+ #include <qwt_curve_fitter.h>
+
++class QPolygonF;
+ /*!
+   \brief A simple curve fitter for polar points
+
+diff --git a/qwt_polar_grid.cpp b/qwt_polar_grid.cpp
+--- a/src/qwt_polar_grid.cpp
++++ b/src/qwt_polar_grid.cpp
+@@ -18,6 +18,7 @@
+ #include <qpainter.h>
+ #include <qpen.h>
+ #include <float.h>
++#include <QPolygonF>
+
+ static inline bool isClose( double value1, double value2 )
+ {
+@@ -726,8 +727,13 @@
+             polygon[0] = pole.toPoint();
+             polygon[1] = pos.toPoint();
+
+-            if ( testDisplayFlag( ClipGridLines ) )
+-                polygon = QwtClipper::clipPolygonF( canvasRect, polygon );
++#if QWT_VERSION < 0x060400
++	    if ( testDisplayFlag( ClipGridLines ) )
++		    polygon = QwtClipper::clipPolygonF( canvasRect, polygon );
++#else /* QWT_VERSION < 0x060400 */
++	    if ( testDisplayFlag( ClipGridLines ) )
++		    polygon = QwtClipper::clippedPolygonF( canvasRect, polygon );
++#endif /* QWT_VERSION < 0x060400 */
+
+             QwtPainter::drawPolyline( painter, polygon );
+         }

--- a/CI/appveyor/patches/qwtpolar-qwt-qt-compat.patch
+++ b/CI/appveyor/patches/qwtpolar-qwt-qt-compat.patch
@@ -35,6 +35,15 @@ diff --git a/qwt_polar_fitter.cpp b/qwt_polar_fitter.cpp
 
  class QwtPolarFitter::PrivateData
  {
+@@ -25,7 +25,7 @@ public:
+    \param stepCount Number of points, that will be inserted between 2 points
+    \sa setStepCount()
+ */
+-QwtPolarFitter::QwtPolarFitter( int stepCount )
++QwtPolarFitter::QwtPolarFitter( int stepCount ) : QwtCurveFitter(QwtCurveFitter::Polygon)
+ {
+     d_data = new PrivateData;
+     d_data->stepCount = stepCount;
 
 diff --git a/qwt_polar_fitter.h b/qwt_polar_fitter.h
 --- a/src/qwt_polar_fitter.h
@@ -74,3 +83,30 @@ diff --git a/qwt_polar_grid.cpp b/qwt_polar_grid.cpp
 
              QwtPainter::drawPolyline( painter, polygon );
          }
+
+diff --git a/qwt_polar_spectrogram.cpp b/qwt_polar_spectrogram.cpp
+--- a/src/qwt_polar_spectrogram.cpp
++++ b/src/qwt_polar_spectrogram.cpp
+@@ -305,12 +305,8 @@ QImage QwtPolarSpectrogram::renderImage(
+     QImage image( rect.size(), d_data->colorMap->format() == QwtColorMap::RGB
+                   ? QImage::Format_ARGB32 : QImage::Format_Indexed8 );
+
+-    const QwtInterval intensityRange = d_data->data->interval( Qt::ZAxis );
+-    if ( !intensityRange.isValid() )
+-        return image;
+-
+     if ( d_data->colorMap->format() == QwtColorMap::Indexed )
+-        image.setColorTable( d_data->colorMap->colorTable( intensityRange ) );
++        image.setColorTable( d_data->colorMap->colorTable256());
+
+     /*
+      For the moment we only announce the composition of the image by
+@@ -471,7 +467,7 @@ void QwtPolarSpectrogram::renderTile(
+                 const double radius = radialMap.invTransform( r );
+
+                 const double value = d_data->data->value( azimuth, radius );
+-                *line++ = d_data->colorMap->colorIndex( intensityRange, value );
++                *line++ = d_data->colorMap->colorIndex(256, intensityRange, value );
+             }
+         }
+     }

--- a/src/ConstellationDisplayPlot.cc
+++ b/src/ConstellationDisplayPlot.cc
@@ -78,7 +78,7 @@ protected:
   using QwtPlotZoomer::trackerText;
   virtual QwtText trackerText( const QPoint& p ) const
   {
-    QwtDoublePoint dp = QwtPlotZoomer::invTransform(p);
+    QPointF dp = QwtPlotZoomer::invTransform(p);
     QwtText t(QString("(%1, %2)").arg(dp.x(), 0, 'f', 4).
 	      arg(dp.y(), 0, 'f', 4));
     return t;

--- a/src/DisplayPlot.cc
+++ b/src/DisplayPlot.cc
@@ -47,7 +47,10 @@
 #include <qwt_plot_zoomer.h>
 #include <qwt_legend.h>
 #include <qwt_plot_layout.h>
+#include <qwt_math.h>
 
+#include <QStack>
+#include <QPainter>
 #include <QColor>
 #include <cmath>
 #include <iostream>
@@ -558,8 +561,8 @@ DisplayPlot::DisplayPlot(int nplots, QWidget* parent,
   d_picker = new QwtDblClickPlotPicker(canvas());
 
 #if QWT_VERSION < 0x060000
-  connect(d_picker, SIGNAL(selected(const QwtDoublePoint &)),
-      this, SLOT(onPickerPointSelected(const QwtDoublePoint &)));
+  connect(d_picker, SIGNAL(selected(const QPointF &)),
+      this, SLOT(onPickerPointSelected(const QPointF &)));
 #else
   d_picker->setStateMachine(new QwtPickerDblClickPointMachine());
   connect(d_picker, SIGNAL(selected(const QPointF &)),
@@ -1022,7 +1025,7 @@ void DisplayPlot::legendEntryChecked(const QVariant &plotItem, bool on, int inde
 }
 
 void
-DisplayPlot::onPickerPointSelected(const QwtDoublePoint & p)
+DisplayPlot::onPickerPointSelected(const QPointF & p)
 {
   QPointF point = p;
   //fprintf(stderr,"onPickerPointSelected %f %f\n", point.x(), point.y());

--- a/src/DisplayPlot.h
+++ b/src/DisplayPlot.h
@@ -44,6 +44,7 @@
 
 #include <stdint.h>
 #include <cstdio>
+#include <cmath>
 #include <vector>
 #include <qwt_plot.h>
 #include <qwt_painter.h>
@@ -64,10 +65,6 @@
 #include "plot_utils.hpp"
 #include "extendingplotzoomer.h"
 #include "printableplot.h"
-
-#if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
-#endif
 
 typedef QList<QColor> QColorList;
 Q_DECLARE_METATYPE ( QColorList )
@@ -494,7 +491,7 @@ public Q_SLOTS:
   // Because of the preprocessing of slots in QT, these are not
   // easily separated by the version check. Make one for each
   // version until it's worked out.
-  void onPickerPointSelected(const QwtDoublePoint & p);
+  void onPickerPointSelected(const QPointF & p);
   void onPickerPointSelected6(const QPointF & p);
 
   unsigned int xAxisNumDiv() const;

--- a/src/FftDisplayPlot.cc
+++ b/src/FftDisplayPlot.cc
@@ -27,6 +27,7 @@
 #include "limitedplotzoomer.h"
 #include "osc_scale_engine.h"
 
+#include <QDebug>
 #include <qwt_symbol.h>
 #include <boost/make_shared.hpp>
 
@@ -57,7 +58,7 @@ protected:
   using QwtPlotZoomer::trackerText;
   virtual QwtText trackerText( const QPoint& p ) const
   {
-    QwtDoublePoint dp = QwtPlotZoomer::invTransform(p);
+    QPointF dp = QwtPlotZoomer::invTransform(p);
     QwtText t(QString("(%1, %2)").arg(dp.x(), 0, 'f', 4).
               arg(dp.y(), 0, 'f', 4));
     return t;

--- a/src/HistogramDisplayPlot.cc
+++ b/src/HistogramDisplayPlot.cc
@@ -50,6 +50,7 @@
 #include <volk/volk.h>
 #include <gnuradio/math.h>
 #include <boost/math/special_functions/round.hpp>
+#include <QLocale>
 
 #include "HistogramDisplayPlot.h"
 
@@ -132,7 +133,7 @@ protected:
   virtual QwtText trackerText(const QPoint& p) const
   {
     QwtText t;
-    QwtDoublePoint dp = QwtPlotZoomer::invTransform(p);
+    QPointF dp = QwtPlotZoomer::invTransform(p);
     if((dp.y() > 0.0001) && (dp.y() < 10000)) {
       t.setText(QString("%1 V, %2 pts").
 		arg(dp.x(), 0, 'f', 2).
@@ -625,7 +626,7 @@ HistogramDisplayPlot::_resetXAxisPoints(double left, double right)
 
   // Set up zoomer base for maximum unzoom x-axis
   // and reset to maximum unzoom level
-  QwtDoubleRect zbase = d_zoomer[0]->zoomBase();
+  QRectF zbase = d_zoomer[0]->zoomBase();
 
   if(d_semilogx) {
     setAxisScale(QwtPlot::xBottom, 1e-1, d_right);

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -84,7 +84,7 @@ protected:
   virtual QwtText trackerText( const QPoint& p ) const
   {
     QwtText t;
-    QwtDoublePoint dp = QwtPlotZoomer::invTransform(p);
+    QPointF dp = QwtPlotZoomer::invTransform(p);
     const TimeDomainDisplayPlot* plt = (const TimeDomainDisplayPlot *)plot();
     t.setText(plt->timeScaleValueFormat(dp.x(), 3) + "," +
 	      plt->yAxisScaleValueFormat(dp.y(), 3));
@@ -541,7 +541,7 @@ TimeDomainDisplayPlot::_resetXAxisPoints(double*& xAxis, unsigned long long numP
 
   // Set up zoomer base for maximum unzoom x-axis
   // and reset to maximum unzoom level
-//  QwtDoubleRect zbase = d_zoomer->zoomBase();
+//  QRectF zbase = d_zoomer->zoomBase();
 
 //  if(d_semilogx) {
 //    setAxisScale(QwtPlot::xBottom, 1e-1, d_numPoints*delt);

--- a/src/cursor_readouts.cpp
+++ b/src/cursor_readouts.cpp
@@ -26,6 +26,7 @@
 #include <QGridLayout>
 #include <qwt_plot.h>
 #include <qwt_scale_div.h>
+#include <qwt_scale_map.h>
 
 using namespace adiscope;
 

--- a/src/extendingplotzoomer.cpp
+++ b/src/extendingplotzoomer.cpp
@@ -19,6 +19,7 @@
  */
 #include "extendingplotzoomer.h"
 #include "oscilloscope_plot.hpp"
+#include <QPainterPath>
 
 using namespace adiscope;
 

--- a/src/logicanalyzer/annotationcurve.cpp
+++ b/src/logicanalyzer/annotationcurve.cpp
@@ -32,11 +32,15 @@
 #include <qwt_painter.h>
 #include <qwt_series_data.h>
 #include <qwt_text.h>
+#include <qwt_scale_map.h>
 #include <QStaticText>
 #include <QFormLayout>
 #include <QComboBox>
 #include <QLabel>
 #include <QSpacerItem>
+#include <QPainter>
+#include <QDebug>
+#include <map>
 
 #include <QElapsedTimer>
 
@@ -49,7 +53,7 @@ AnnotationCurve::AnnotationCurve(logic::LogicTool *logic, std::shared_ptr<logic:
 	: GenericLogicPlotCurve(initialDecoder->decoder()->name, initialDecoder->decoder()->id, LogicPlotCurveType::Annotations)
 	, m_visibleRows(0)
 {
-    setSamples({0.0}, {0.0});
+    setSamples(QVector<double>({0.0}), QVector<double>({0.0})),
     setRenderHint(RenderAntialiased, true);
     setBrush(QBrush(Qt::red));
     setBaseline(0.0);
@@ -136,12 +140,12 @@ void AnnotationCurve::dataAvailable(uint64_t from, uint64_t to)
     m_annotationDecoder->dataAvailable(from, to);
 }
 
-void AnnotationCurve::setClassRows(const map<std::pair<const srd_decoder *, int>, Row> &classRows)
+void AnnotationCurve::setClassRows(const std::map<std::pair<const srd_decoder *, int>, Row> &classRows)
 {
     m_classRows = classRows;
 }
 
-void AnnotationCurve::setAnnotationRows(const map<const Row, RowData> &annotationRows)
+void AnnotationCurve::setAnnotationRows(const std::map<Row, RowData> &annotationRows)
 {
     m_annotationRows = annotationRows;
 }

--- a/src/logicanalyzer/annotationcurve.h
+++ b/src/logicanalyzer/annotationcurve.h
@@ -24,8 +24,6 @@
 
 #include <qwt_point_mapper.h>
 
-#include <map>
-
 #include <libsigrokdecode/libsigrokdecode.h>
 
 #include <memory>
@@ -72,7 +70,7 @@ public:
     virtual void dataAvailable(uint64_t from, uint64_t to) override;
 
     void setClassRows(const std::map<std::pair<const srd_decoder*, int>, Row> &classRows);
-    void setAnnotationRows(const std::map<const Row, RowData> &annotationRows);
+    void setAnnotationRows(const std::map<Row, RowData> &annotationRows);
 
     void sort_rows();
 
@@ -129,7 +127,7 @@ private:
     mutable std::mutex m_mutex;
 
     std::map<std::pair<const srd_decoder*, int>, Row> m_classRows;
-    std::map<const Row, RowData> m_annotationRows;
+    std::map<Row, RowData> m_annotationRows;
 
 	std::vector<std::shared_ptr<adiscope::bind::Decoder>> m_bindings;
 

--- a/src/logicanalyzer/annotationdecoder.cpp
+++ b/src/logicanalyzer/annotationdecoder.cpp
@@ -20,9 +20,9 @@
 
 
 #include "annotationdecoder.h"
-
+#include <libsigrokdecode/libsigrokdecode.h>
 #include "logic_analyzer.h"
-
+#include <QDebug>
 #include <algorithm>
 
 using namespace adiscope;

--- a/src/logicanalyzer/annotationdecoder.h
+++ b/src/logicanalyzer/annotationdecoder.h
@@ -78,7 +78,7 @@ private:
     struct srd_session *m_srdSession;
     std::vector<std::shared_ptr<logic::Decoder>> m_stack;
     std::map<std::pair<const srd_decoder*, int>, Row> m_class_rows;
-    std::map<const Row, RowData> m_annotation_rows;
+    std::map<Row, RowData> m_annotation_rows;
     std::vector<DecodeChannel> m_channels;
 
     std::thread *m_decodeThread;

--- a/src/logicanalyzer/logicanalyzer_api.cpp
+++ b/src/logicanalyzer/logicanalyzer_api.cpp
@@ -29,6 +29,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QDebug>
 #include <glib.h>
 
 #include "binding/decoder.hpp"

--- a/src/logicanalyzer/logicdatacurve.cpp
+++ b/src/logicanalyzer/logicdatacurve.cpp
@@ -28,6 +28,9 @@
 #include <qwt_point_mapper.h>
 #include <qwt_painter.h>
 #include <qwt_series_data.h>
+#include <qwt_scale_map.h>
+
+#include <QPainter>
 
 static const QColor EdgeColor(0x80, 0x80, 0x80);
 static const QColor HighColor(0x00, 0xC0, 0x00);
@@ -48,7 +51,7 @@ LogicDataCurve::LogicDataCurve(uint16_t *data, uint8_t bit, adiscope::logic::Log
 
     // TODO: maybe custom plot with reimplemented replot() ?
 
-    setSamples({0.0}, {0.0});
+    setSamples(QVector<double>({0.0}), QVector<double>({0.0}));
     setBrush(QBrush(Qt::black));
 }
 

--- a/src/marker_controller.cpp
+++ b/src/marker_controller.cpp
@@ -23,6 +23,7 @@
 #include <qwt_plot_picker.h>
 #include <qwt_picker_machine.h>
 #include <qwt_scale_div.h>
+#include <qwt_interval.h>
 
 using namespace adiscope;
 

--- a/src/osc_scale_engine.cpp
+++ b/src/osc_scale_engine.cpp
@@ -20,6 +20,8 @@
 
 #include "osc_scale_engine.h"
 #include "qwt_math.h"
+#include <qwt_interval.h>
+#include <QDebug>
 #include <limits>
 
 static inline long double qwtIntervalWidthL( const QwtInterval &interval )

--- a/src/osc_scale_zoomer.cpp
+++ b/src/osc_scale_zoomer.cpp
@@ -52,7 +52,7 @@ QwtText OscScaleZoomer::trackerText(const QPoint& pos) const
 	                                     plot()->axisScaleDraw(QwtPlot::xTop));
 	const OscScaleDraw *draw_y = static_cast<const OscScaleDraw *>(
 	                                     plot()->axisScaleDraw(QwtPlot::yLeft));
-	QwtDoublePoint dp = QwtPlotZoomer::invTransform(pos);
+	QPointF dp = QwtPlotZoomer::invTransform(pos);
 	QString text;
 
 	text += draw_x->label(dp.x()).text();

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -29,6 +29,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QThread>
+#include <QDebug>
 
 #include <algorithm>
 

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -21,6 +21,7 @@
 
 #include "pattern_generator.h"
 
+#include <QDebug>
 #include "ui_pattern_generator.h"
 #include "digitalchannel_manager.hpp"
 #include "dynamicWidget.hpp"

--- a/src/sismograph.cpp
+++ b/src/sismograph.cpp
@@ -20,6 +20,7 @@
 
 #include "sismograph.hpp"
 
+#include <QPen>
 #include <qwt_plot_layout.h>
 #include <qwt_scale_engine.h>
 

--- a/src/smoothcurvefitter.cpp
+++ b/src/smoothcurvefitter.cpp
@@ -20,6 +20,8 @@
 
 #include "smoothcurvefitter.h"
 
+#include <QPolygonF>
+#include <QPainterPath>
 #include <qwt_spline_cubic.h>
 #include <qwt_spline_parametrization.h>
 

--- a/src/spectrum_marker.cpp
+++ b/src/spectrum_marker.cpp
@@ -22,6 +22,7 @@
 
 #include <qwt_plot.h>
 #include <qwt_symbol.h>
+#include <qwt_scale_map.h>
 
 using namespace adiscope;
 

--- a/src/spectrum_marker.hpp
+++ b/src/spectrum_marker.hpp
@@ -22,6 +22,7 @@
 #define SPECTRUM_MARKER_H
 
 #include <qwt_plot_marker.h>
+#include <QColor>
 
 namespace adiscope {
 

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -21,6 +21,10 @@
 #include "symbol.h"
 
 #include <qwt_scale_div.h>
+#include <qwt_scale_map.h>
+#include <qwt_interval.h>
+#include <QPainter>
+#include <QPainterPath>
 
 /*
  * Abstract Class Symbol

--- a/src/x_axis_scale_zoomer.cpp
+++ b/src/x_axis_scale_zoomer.cpp
@@ -19,6 +19,7 @@
  */
 #include "x_axis_scale_zoomer.h"
 #include "qwt_scale_draw.h"
+#include <qwt_text.h>
 
 #include <dbgraph.hpp>
 


### PR DESCRIPTION
- Boost needs a compatibility patch to handle the the "-fcoalesce-templates" argument on MacOS.
- Qwt was updated to the latest version (still multiaxes) from the official repo. We were using an old version from a github repository. We switched to the official Qwt repository where the "multiaxes" branch is maintained and contains bug fixes from the last couple of years.
- Updating Qwt breaks QwtPolar (which, unlike the first one, was not updated for bug fixes on the official repo). We added a patch to handle the new fixes and merged that patch with the existing one ( which ensured compat with "multiaxes" in the first place).
- The last step was to downgrade Qt from 5.15.0 to 5.14 (keeping all the fixes listed above), because it contains a bug related to QPushButton signals and slots.

The Qwt updates + QwtPolar patches should also be applied in the scopy-flatpak repository (for the Flatpak package) and the scopy-mingw-build-deps repo (for the Windows builds). 

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>