### PR TITLE
Oscilloscope: Fix vertical display scale.

### DIFF
--- a/src/spinbox_a.cpp
+++ b/src/spinbox_a.cpp
@@ -306,7 +306,7 @@ void SpinBoxA::setValue(double value)
 
 	// Update line edit
 	int index;
-	double scale = findUnitOfValue(m_value, &index);
+	double scale = findUnitOfValue(m_value * m_displayScale, &index);
 	double number = m_value / scale;
 	double abs_number = qAbs(number);
 	int significant_digits = m_decimal_count;


### PR DESCRIPTION
Probe attenuation modifies the display scale of Volts/Div and vertical position. When the value exceeded the unit boundaries the display scale should be modified according to the new temporary computed value.

Fixes #814 