### PR TITLE
Oscilloscope: fix crash when receiving a constant signal

### DIFF
--- a/src/HistogramDisplayPlot.cc
+++ b/src/HistogramDisplayPlot.cc
@@ -51,7 +51,7 @@
 #include <gnuradio/math.h>
 #include <boost/math/special_functions/round.hpp>
 #include <QLocale>
-
+#include <QDebug>
 #include "HistogramDisplayPlot.h"
 
 #ifdef _MSC_VER
@@ -607,12 +607,23 @@ HistogramDisplayPlot::setXaxis(double min, double max)
 void
 HistogramDisplayPlot::_resetXAxisPoints(double left, double right)
 {
-  // Something's wrong with the data (NaN, Inf, or something else)
-  if((left == right) || (left > right))
-    throw std::runtime_error("HistogramDisplayPlot::_resetXAxisPoints left and/or right values are invalid");
+	// Something's wrong with the data (NaN, Inf, or something else)
+	if((left == 0 && right == 0) || (left > right))
+	{
+		// assume some default values
+		d_left = -0.01;
+		d_right = 0.01;
+		qDebug() << "Using default values for histogram";
+		// throw std::runtime_error("HistogramDisplayPlot::_resetXAxisPoints left and/or right values are invalid");
+	}
+	else
+	{
+		d_left  = left *(1 - copysign(0.1, left));
+		d_right = right*(1 + copysign(0.1, right));
+	}
 
-  d_left  = left *(1 - copysign(0.1, left));
-  d_right = right*(1 + copysign(0.1, right));
+	// when both left & right are 0
+
   d_width = (d_right - d_left)/(d_bins);
   for(long loc = 0; loc < d_bins; loc++){
     d_xdata[loc] = d_left + loc*d_width;


### PR DESCRIPTION
This bug sporadically occurs when a buffer is constant - has the same
value through the buffer. This was tested by creating a synthetic signal
using a gnuradio::analog::sig_source block to feed in a constant waveform.
When this waveform is fed into the flow, the application crashes because
it computes min and max for the signal and eventually computes a difference
which is 0 in this case. In order to prevent this, I provided some default
values for the histogram computation.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>