### PR TITLE
SignalGenerator: initialize stairphase

### DIFF
--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -1492,7 +1492,7 @@ basic_block_sptr SignalGenerator::getSignalSource(gr::top_block_sptr top,
 	float offset;
 	int rising_steps=1;
 	int falling_steps=1;
-	int stairphase;
+	int stairphase=0;
 
 	amplitude = data.amplitude / 2.0;
 	offset = data.offset;


### PR DESCRIPTION
This prevents warning/error regarding stairphase being used before init

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>