### PR TITLE
OscTriggerSettings: Move trigger channel selection widget

### DIFF
--- a/ui/trigger_settings.ui
+++ b/ui/trigger_settings.ui
@@ -115,7 +115,7 @@
         <x>0</x>
         <y>0</y>
         <width>266</width>
-        <height>828</height>
+        <height>823</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -261,45 +261,6 @@ color: rgba(255,255,255,51);
            </item>
           </layout>
          </item>
-         <item>
-          <layout class="QGridLayout" name="gridLayout">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="horizontalSpacing">
-            <number>3</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="lbl_source">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-size: 13px;</string>
-             </property>
-             <property name="text">
-              <string>Source</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QComboBox" name="cmb_source">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="currentIndex">
-              <number>-1</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
        </item>
        <item>
@@ -403,6 +364,45 @@ color: rgba(255,255,255,51);
               <property name="topMargin">
                <number>0</number>
               </property>
+              <item>
+               <layout class="QGridLayout" name="gridLayout">
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing">
+                 <number>3</number>
+                </property>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lbl_source">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">font-size: 13px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Source</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QComboBox" name="cmb_source">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="currentIndex">
+                   <number>-1</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
               <item>
                <widget class="QLabel" name="lbl_condition">
                 <property name="sizePolicy">


### PR DESCRIPTION
from general trigger settings to internal only settings

By doing so, when the internal trigger is grayed out, the channel is
grayed out as well. This is due to only using TI as trigger-in pin and
TO as trigger-out pin. This is implemented in libm2k but was not correctly
showed in the UI.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>

Moved channel from below <auto/manual> to the location in the screenshot.
![image](https://user-images.githubusercontent.com/8676912/90036749-0b585980-dccc-11ea-95af-0de0be09d028.png)
Disabling internal trigger will disable channel selection