### PR TITLE
Spectrum and Network analyzer: fixes and enhancements

### DIFF
--- a/src/FftDisplayPlot.cc
+++ b/src/FftDisplayPlot.cc
@@ -320,6 +320,25 @@ void FftDisplayPlot::setWindowCoefficientSum(unsigned int ch, float sum, float s
 	d_win_coefficient_sum_sqr[ch] = sqr_sum;
 }
 
+void FftDisplayPlot::useLogScaleY(bool log_scale)
+{
+	if (log_scale) {
+		QwtLogScaleEngine *scaleEngine = new QwtLogScaleEngine();
+		setAxisScaleEngine(QwtPlot::yLeft,  (QwtScaleEngine *)scaleEngine);
+		OscScaleDraw *yScaleDraw = new OscScaleDraw(&dBFormatter, "V/√Hz");
+		yScaleDraw->enableComponent(QwtAbstractScaleDraw::Ticks, true);
+		yScaleDraw->setFloatPrecision(2);
+		setAxisScaleDraw(QwtPlot::yLeft, yScaleDraw);
+	} else {
+		OscScaleEngine *scaleEngine = new OscScaleEngine();
+		this->setAxisScaleEngine(QwtPlot::yLeft, (QwtScaleEngine *)scaleEngine);
+		OscScaleDraw *yScaleDraw = new OscScaleDraw(&dBFormatter, "");
+		yScaleDraw->setFloatPrecision(2);
+		setAxisScaleDraw(QwtPlot::yLeft, yScaleDraw);
+	}
+	replot();
+}
+
 void FftDisplayPlot::useLogFreq(bool use_log_freq)
 {
 	if (use_log_freq) {

--- a/src/FftDisplayPlot.h
+++ b/src/FftDisplayPlot.h
@@ -227,6 +227,7 @@ namespace adiscope {
 
 		void setWindowCoefficientSum(unsigned int ch, float sum, float sqr_sum);
 		void setNbOverlappingAverages(unsigned int nb_avg);
+		void useLogScaleY(bool log_scale);
 	Q_SIGNALS:
 		void newData();
 		void sampleRateUpdated(double);

--- a/src/FftDisplayPlot.h
+++ b/src/FftDisplayPlot.h
@@ -126,11 +126,11 @@ namespace adiscope {
 		std::vector<double *> d_refXdata;
 		std::vector<double *> d_refYdata;
 
-		double d_win_coefficient_sum;
-		double d_win_coefficient_sum_sqr;
-		unsigned int d_spectral_density_avg_idx;
-		double d_overlapping;
-		std::vector<double *> d_overlapping_data;
+		std::vector<double> d_win_coefficient_sum;
+		std::vector<double> d_win_coefficient_sum_sqr;
+		unsigned int d_buffer_idx;
+		unsigned int d_nb_overlapping_avg;
+		std::vector<std::vector<double>> d_ps_avg;
 
 
 		void plotData(const std::vector<double *> &pts,
@@ -225,8 +225,8 @@ namespace adiscope {
 		void registerReferenceWaveform(QString name, QVector<double> xData, QVector<double> yData);
 		void unregisterReferenceWaveform(QString name);
 
-		void setWindowCoefficientSum(float sum, float sqr_sum);
-
+		void setWindowCoefficientSum(unsigned int ch, float sum, float sqr_sum);
+		void setNbOverlappingAverages(unsigned int nb_avg);
 	Q_SIGNALS:
 		void newData();
 		void sampleRateUpdated(double);

--- a/src/FftDisplayPlot.h
+++ b/src/FftDisplayPlot.h
@@ -71,6 +71,7 @@ namespace adiscope {
 			DBU = 2,
 			VPEAK = 3,
 			VRMS = 4,
+			VROOTHZ = 5
 		};
 
 		enum MarkerType {
@@ -106,6 +107,7 @@ namespace adiscope {
 
 		std::vector<enum AverageType> d_ch_average_type;
 		std::vector<average_sptr> d_ch_avg_obj;
+		std::vector<unsigned int> d_current_avg_index;
 
 		enum MagnitudeType d_presetMagType;
 		enum MagnitudeType d_magType;
@@ -124,6 +126,13 @@ namespace adiscope {
 		std::vector<double *> d_refXdata;
 		std::vector<double *> d_refYdata;
 
+		double d_win_coefficient_sum;
+		double d_win_coefficient_sum_sqr;
+		unsigned int d_spectral_density_avg_idx;
+		double d_overlapping;
+		std::vector<double *> d_overlapping_data;
+
+
 		void plotData(const std::vector<double *> &pts,
 				uint64_t num_points);
 		void _resetXAxisPoints();
@@ -133,7 +142,7 @@ namespace adiscope {
 			in_data, std::vector<double *> out_data,
 			uint64_t nb_points);
 		average_sptr getNewAvgObject(enum AverageType avg_type,
-			uint data_width, uint history);
+			uint data_width, uint history, bool history_en);
 
 		void add_marker(int chn);
 		void remove_marker(int chn, int which);
@@ -171,7 +180,7 @@ namespace adiscope {
 		enum AverageType averageType(uint chIdx) const;
 		uint averageHistory(uint chIdx) const;
 		void setAverage(uint chIdx, enum AverageType avg_type,
-			uint history);
+			uint history, bool history_en = true);
 		void resetAverageHistory();
 		void setStartStop(double start, double stop);
 		void setVisiblePeakSearch(bool enabled);
@@ -216,12 +225,15 @@ namespace adiscope {
 		void registerReferenceWaveform(QString name, QVector<double> xData, QVector<double> yData);
 		void unregisterReferenceWaveform(QString name);
 
+		void setWindowCoefficientSum(float sum, float sqr_sum);
+
 	Q_SIGNALS:
 		void newData();
 		void sampleRateUpdated(double);
 		void sampleCountUpdated(uint);
 		void newMarkerData();
 		void markerSelected(uint chIdx, uint mkIdx);
+		void currentAverageIndex(unsigned int chnIdx, unsigned int avgIdx);
 
 	public Q_SLOTS:
 		void setSampleRate(double sr, double units,

--- a/src/average.cpp
+++ b/src/average.cpp
@@ -471,7 +471,7 @@ void LinearRMS::getAverage(double *out_data, unsigned int num_samples) const
 	unsigned int num = std::min(m_data_width, num_samples);
 
 	for (unsigned int i = 0; i < num; i++)
-		out_data[i] = m_sqr_sums[i] / m_inserted_count;
+		out_data[i] = sqrt(m_sqr_sums[i] / m_inserted_count);
 }
 
 void LinearRMS::reset()

--- a/src/average.h
+++ b/src/average.h
@@ -21,6 +21,8 @@
 #ifndef AVERAGE_H
 #define AVERAGE_H
 
+#include <boost/thread/mutex.hpp>
+
 namespace adiscope {
 
 
@@ -34,6 +36,7 @@ public:
 	virtual void reset() = 0;
 	unsigned int dataWidth() const;
 	unsigned int history() const;
+	virtual void setHistory(unsigned int);
 
 protected:
 	unsigned int m_data_width;
@@ -63,10 +66,12 @@ protected:
 	double **m_history;
 	unsigned int m_insert_index;
 	unsigned int m_inserted_count;
+	boost::mutex m_history_mutex;
 
 private:
 	void alloc_history(unsigned int data_width, unsigned int history_size);
 	void free_history();
+	void setHistory(unsigned int) override;
 };
 
 class PeakHoldContinuous: public AverageHistoryOne

--- a/src/average.h
+++ b/src/average.h
@@ -28,7 +28,7 @@ namespace adiscope {
 
 class SpectrumAverage {
 public:
-	SpectrumAverage(unsigned int data_width, unsigned int history);
+	SpectrumAverage(unsigned int data_width, unsigned int history, bool history_en);
 	virtual ~SpectrumAverage();
 	virtual void pushNewData(double *data) = 0;
 	virtual void getAverage(double *out_data,
@@ -37,10 +37,12 @@ public:
 	unsigned int dataWidth() const;
 	unsigned int history() const;
 	virtual void setHistory(unsigned int);
+	bool historyEnabled() const;
 
 protected:
 	unsigned int m_data_width;
 	unsigned int m_history_size;
+	bool m_history_enabled;
 	double *m_average;
 };
 
@@ -100,6 +102,30 @@ class ExponentialAverage: public AverageHistoryOne
 public:
 	ExponentialAverage(unsigned int data_width, unsigned int history);
 	virtual void pushNewData(double *data);
+};
+
+class LinearRMSOne: public AverageHistoryOne
+{
+public:
+	LinearRMSOne(unsigned int data_width, unsigned int history);
+	~LinearRMSOne();
+	virtual void pushNewData(double *data);
+
+private:
+	double *m_sqr_sums;
+	unsigned int m_inserted_count;
+};
+
+class LinearAverageOne: public AverageHistoryOne
+{
+public:
+	LinearAverageOne(unsigned int data_width, unsigned int history);
+	~LinearAverageOne();
+	virtual void pushNewData(double *data);
+
+private:
+	double *m_sums;
+	unsigned int m_inserted_count;
 };
 
 class PeakHold: public AverageHistoryN

--- a/src/fft_block.hpp
+++ b/src/fft_block.hpp
@@ -32,10 +32,12 @@ namespace adiscope {
 		~fft_block();
 
 		void set_window(const std::vector<float>& window);
+		void set_overlap_factor(double overlap_factor);
 
 	private:
 		bool d_complex;
 		gr::basic_block_sptr d_fft;
+		gr::basic_block_sptr d_s2v_overlap;
 	};
 }
 

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -180,7 +180,8 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	iterationsThreadCanceled(false), iterationsThreadReady(false),
 	iterationsThread(nullptr), autoAdjustGain(true),
 	filterDc(false), m_initFlowgraph(true), m_hasReference(false),
-	m_importDataLoaded(false)
+	m_importDataLoaded(false),
+	m_nb_periods(2)
 {
 	if (ctx) {
 		iio = iio_manager::get_instance(ctx,
@@ -550,6 +551,7 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	connect(ui->btnCursors, &CustomPushButton::toggled, [=](bool checked) {
 		triggerRightMenuToggle(ui->btnCursors, checked);
 	});
+	connect(ui->btnApplyPeriod, SIGNAL(clicked()), this, SLOT(validateSpinboxPeriods()));
 
 	ui->btnSettings->setProperty("id",QVariant(-1));
 	ui->btnGeneralSettings->setProperty("id",QVariant(-2));
@@ -1332,7 +1334,7 @@ void NetworkAnalyzer::_saveChannelBuffers(double frequency, double sample_rate, 
 void NetworkAnalyzer::computeCaptureParams(double frequency,
 		size_t& buffer_size, size_t& adc_rate)
 {
-	size_t nrOfPeriods = 2;
+	size_t nrOfPeriods = m_nb_periods;
 
 	for (const auto& rate : sampleRates) {
 
@@ -1593,6 +1595,8 @@ void NetworkAnalyzer::startStop(bool pressed)
 	ui->responseGainCmb->setEnabled(!pressed);
 	pushDelay->setEnabled(!pressed);
 	captureDelay->setEnabled(!pressed);
+	ui->btnApplyPeriod->setEnabled(!pressed);
+	ui->spinBox_periods->setEnabled(!pressed);
 
 	if (pressed) {
 		if (shouldClear) {
@@ -1726,4 +1730,13 @@ void NetworkAnalyzer::readPreferences()
 void NetworkAnalyzer::onGraphIndexChanged(int index)
 {
 	ui->stackedWidget->setCurrentIndex(index);
+}
+void NetworkAnalyzer::on_spinBox_periods_valueChanged(int n)
+{
+	m_nb_periods = n;
+}
+
+void NetworkAnalyzer::validateSpinboxPeriods()
+{
+	on_spinBox_periods_valueChanged(ui->spinBox_periods->value());
 }

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -230,6 +230,7 @@ private:
 	bool m_hasReference;
 	bool m_importDataLoaded;
 	QVector<QVector<double>> m_importData;
+	unsigned int m_nb_periods;
 
 	void goertzel();
 	void setFilterParameters();
@@ -279,6 +280,8 @@ private Q_SLOTS:
 	void onFrequencyBarMoved(int pos);
 	void toggleBufferPreview(bool toggle = false);
 
+	void on_spinBox_periods_valueChanged(int n);
+	void validateSpinboxPeriods();
 public Q_SLOTS:
 
 	void showEvent(QShowEvent *event);

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -52,6 +52,7 @@
 #include <gnuradio/blocks/vector_source.h>
 #include "frequency_compensation_filter.h"
 
+#include <QStackedWidget>
 #include "oscilloscope.hpp"
 
 #include "TimeDomainDisplayPlot.h"
@@ -202,6 +203,9 @@ private:
 	bool d_cursorsEnabled;
 
 	ScaleSpinButton *samplesCount;
+	ScaleSpinButton *samplesPerDecadeCount;
+	ScaleSpinButton *samplesStepSize;
+	QStackedWidget *sampleStackedWidget;
 	ScaleSpinButton *amplitude;
 	PositionSpinButton *offset;
 	PositionSpinButton *magMax;
@@ -259,6 +263,8 @@ private:
 private Q_SLOTS:
 	void startStop(bool start);
 	void updateNumSamples(bool force = false);
+	void updateNumSamplesPerDecade(bool force = false);
+	void updateSampleStepSize(bool force = false);
 	void plot(double frequency, double mag, double mag2, double phase, float dcVoltage);
 	void _saveChannelBuffers(double frequency, double sample_rate, std::vector<float> data1, std::vector<float> data2);
 

--- a/src/network_analyzer.hpp
+++ b/src/network_analyzer.hpp
@@ -230,6 +230,7 @@ private:
 	bool m_hasReference;
 	bool m_importDataLoaded;
 	QVector<QVector<double>> m_importData;
+	unsigned int m_nb_averaging;
 	unsigned int m_nb_periods;
 
 	void goertzel();
@@ -280,6 +281,8 @@ private Q_SLOTS:
 	void onFrequencyBarMoved(int pos);
 	void toggleBufferPreview(bool toggle = false);
 
+	void validateSpinboxAveraging();
+	void on_spinBox_averaging_valueChanged(int n);
 	void on_spinBox_periods_valueChanged(int n);
 	void validateSpinboxPeriods();
 public Q_SLOTS:

--- a/src/network_analyzer_api.cpp
+++ b/src/network_analyzer_api.cpp
@@ -241,6 +241,27 @@ void NetworkAnalyzer_API::setPlotType(int val)
 {
 	 net->ui->cmb_graphs->setCurrentIndex(val);
 }
+
+int NetworkAnalyzer_API::getAveraging() const
+{
+	return net->ui->spinBox_averaging->value();
+}
+
+void NetworkAnalyzer_API::setAveraging(int val)
+{
+	net->ui->spinBox_averaging->setValue(val);
+}
+
+int NetworkAnalyzer_API::getPeriods() const
+{
+	return net->ui->spinBox_periods->value();
+}
+
+void NetworkAnalyzer_API::setPeriods(int val)
+{
+	net->ui->spinBox_periods->setValue(val);
+}
+
 int NetworkAnalyzer_API::getLineThickness() const
 {
 	return net->ui->cbLineThickness->currentIndex();

--- a/src/network_analyzer_api.hpp
+++ b/src/network_analyzer_api.hpp
@@ -59,6 +59,8 @@ class NetworkAnalyzer_API : public ApiObject
 	Q_PROPERTY(QList<double> data READ data STORED false)
 	Q_PROPERTY(QList<double> phase READ phase STORED false)
 	Q_PROPERTY(QList<double> freq READ freq STORED false)
+	Q_PROPERTY(int averaging READ getAveraging WRITE setAveraging)
+	Q_PROPERTY(int periods READ getPeriods WRITE setPeriods)
 public:
 	explicit NetworkAnalyzer_API(NetworkAnalyzer *net) :
 		ApiObject(), net(net) {}
@@ -108,6 +110,12 @@ public:
 
 	int getPlotType() const;
 	void setPlotType(int val);
+
+	int getAveraging() const;
+	void setAveraging(int val);
+
+	int getPeriods() const;
+	void setPeriods(int val);
 
 	Q_INVOKABLE void show();
 

--- a/src/spectrum_analyzer.hpp
+++ b/src/spectrum_analyzer.hpp
@@ -38,6 +38,7 @@
 
 #include <QWidget>
 #include <QQueue>
+#include <QTimer>
 
 /* libm2k includes */
 #include <libm2k/analog/genericanalogin.hpp>
@@ -148,6 +149,7 @@ private Q_SLOTS:
 	void on_btnBrowseFile_clicked();
 	void on_btnImport_clicked();
 	void onReferenceChannelDeleted();
+	void refreshCurrentSampleLabel();
 
 private:
 	void initInstrumentStrings();
@@ -203,6 +205,8 @@ private:
 	StartStopRangeWidget *startStopRange;
 
 	QList<channel_sptr> channels;
+	QTimer *sample_timer;
+	std::chrono::time_point<std::chrono::system_clock>  m_time_start;
 
 	adiscope::scope_sink_f::sptr fft_sink;
 	iio_manager::port_id *fft_ids;
@@ -238,6 +242,7 @@ private:
 	ChannelWidget *getChannelWidgetAt(unsigned int id);
 	void updateMarkerMenu(unsigned int id);
 	bool isIioManagerStarted() const;
+	void setCurrentSampleLabel(double);
 };
 
 class SpectrumChannel: public QObject

--- a/src/spectrum_analyzer.hpp
+++ b/src/spectrum_analyzer.hpp
@@ -103,6 +103,7 @@ public:
 
 	void setNativeDialogs(bool nativeDialogs) override;
 
+	void setCurrentAverageIndexLabel(uint chnIdx);
 public Q_SLOTS:
 	void readPreferences();	
 	void run() override;
@@ -113,6 +114,8 @@ Q_SIGNALS:
 	void showTool();
 
 private Q_SLOTS:
+	void on_btnHistory_toggled(bool checked);
+	void onCurrentAverageIndexChanged(uint chnIdx, uint avgIdx);
 	void on_btnToolSettings_toggled(bool checked);
 	void on_btnSettings_clicked(bool checked);
 	void on_btnSweep_toggled(bool checked);
@@ -141,7 +144,8 @@ private Q_SLOTS:
 	void singleCaptureDone();
 	void on_btnMarkerTable_toggled(bool checked);
 	void onTopValueChanged(double);
-	void onRangeValueChanged(double);
+	void onUnitPerDivValueChanged(double);
+	void onBottomValueChanged(double);
 	void rightMenuFinished(bool opened);	
 	void btnExportClicked();
 	void updateRunButton(bool);
@@ -150,6 +154,7 @@ private Q_SLOTS:
 	void on_btnImport_clicked();
 	void onReferenceChannelDeleted();
 	void refreshCurrentSampleLabel();
+	void validateSpinboxAveraging();
 
 private:
 	void initInstrumentStrings();
@@ -198,8 +203,12 @@ private:
 	QButtonGroup *channels_group;
 	FftDisplayPlot *fft_plot;
 
-	PositionSpinButton *range;
+	ScaleSpinButton *unit_per_div_scale;
+	ScaleSpinButton *top_scale;
+	ScaleSpinButton *bottom_scale;
+	PositionSpinButton *unit_per_div;
 	PositionSpinButton *top;
+	PositionSpinButton *bottom;
 	PositionSpinButton *marker_freq_pos;
 
 	StartStopRangeWidget *startStopRange;
@@ -243,6 +252,8 @@ private:
 	void updateMarkerMenu(unsigned int id);
 	bool isIioManagerStarted() const;
 	void setCurrentSampleLabel(double);
+
+	bool canSwitchAverageHistory(FftDisplayPlot::AverageType avg_type);
 };
 
 class SpectrumChannel: public QObject
@@ -281,18 +292,26 @@ public:
 	uint averaging() const;
 	void setAveraging(uint);
 
+	uint averageIdx() const;
+	void setAverageIdx(uint);
+
 	FftDisplayPlot::AverageType averageType() const;
 	void setAverageType(FftDisplayPlot::AverageType);
 
 	SpectrumAnalyzer::FftWinType fftWindow() const;
 	void setFftWindow(SpectrumAnalyzer::FftWinType win, int taps);
 
+	bool isAverageHistoryEnabled() const;
+	void setAverageHistoryEnabled(bool enabled);
+	bool canStoreAverageHistory() const;
 private:
 	int m_id;
 	QString m_name;
 	float m_line_width;
 	QColor m_color;
 	uint m_averaging;
+	uint m_average_current_index;
+	bool m_average_history;
 	FftDisplayPlot::AverageType m_avg_type;
 	SpectrumAnalyzer::FftWinType m_fft_win;
 	FftDisplayPlot *m_plot;

--- a/src/spectrum_analyzer.hpp
+++ b/src/spectrum_analyzer.hpp
@@ -203,7 +203,6 @@ private:
 	QButtonGroup *channels_group;
 	FftDisplayPlot *fft_plot;
 
-	ScaleSpinButton *unit_per_div_scale;
 	ScaleSpinButton *top_scale;
 	ScaleSpinButton *bottom_scale;
 	PositionSpinButton *unit_per_div;

--- a/src/spectrum_analyzer.hpp
+++ b/src/spectrum_analyzer.hpp
@@ -38,7 +38,6 @@
 
 #include <QWidget>
 #include <QQueue>
-#include <QTimer>
 
 /* libm2k includes */
 #include <libm2k/analog/genericanalogin.hpp>
@@ -144,7 +143,7 @@ private Q_SLOTS:
 	void singleCaptureDone();
 	void on_btnMarkerTable_toggled(bool checked);
 	void onTopValueChanged(double);
-	void onUnitPerDivValueChanged(double);
+	void onScalePerDivValueChanged(double);
 	void onBottomValueChanged(double);
 	void rightMenuFinished(bool opened);	
 	void btnExportClicked();
@@ -198,6 +197,7 @@ private:
 	libm2k::analog::GenericAnalogIn* m_generic_analogin;
 	Ui::SpectrumAnalyzer *ui;
 	adiscope::DbClickButtons *marker_selector;
+	unsigned int m_nb_overlapping_avg;
 
 	QButtonGroup *settings_group;
 	QButtonGroup *channels_group;
@@ -304,6 +304,10 @@ public:
 	bool isAverageHistoryEnabled() const;
 	void setAverageHistoryEnabled(bool enabled);
 	bool canStoreAverageHistory() const;
+
+	void setGainMode(int index);
+	libm2k::analog::M2K_RANGE getGainMode();
+	static double win_overlap_factor(SpectrumAnalyzer::FftWinType type);
 private:
 	int m_id;
 	QString m_name;
@@ -311,6 +315,7 @@ private:
 	QColor m_color;
 	uint m_averaging;
 	uint m_average_current_index;
+	libm2k::analog::M2K_RANGE m_gain_mode;
 	bool m_average_history;
 	FftDisplayPlot::AverageType m_avg_type;
 	SpectrumAnalyzer::FftWinType m_fft_win;

--- a/src/spectrum_analyzer_api.cpp
+++ b/src/spectrum_analyzer_api.cpp
@@ -334,16 +334,13 @@ double SpectrumAnalyzer_API::unitPerDiv()
 {
 	if (sp->ui->topWidget->currentIndex() == 0) {
 		return sp->unit_per_div->value();
-	} else {
-		return sp->unit_per_div_scale->value();
 	}
+	return 0;
 }
 void SpectrumAnalyzer_API::setunitPerDiv(double val)
 {
 	if (sp->ui->topWidget->currentIndex() == 0) {
 		sp->unit_per_div->setValue(val);
-	} else {
-		sp->unit_per_div_scale->setValue(val);
 	}
 }
 

--- a/src/spectrum_analyzer_api.cpp
+++ b/src/spectrum_analyzer_api.cpp
@@ -298,20 +298,53 @@ void SpectrumAnalyzer_API::setUnits(QString s)
 
 double SpectrumAnalyzer_API::topScale()
 {
-	return sp->top->value();
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		return sp->top->value();
+	} else {
+		return sp->top_scale->value();
+	}
 }
 void SpectrumAnalyzer_API::setTopScale(double val)
 {
-	sp->top->setValue(val);
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		sp->top->setValue(val);
+	} else {
+		sp->top_scale->setValue(val);
+	}
 }
 
-double SpectrumAnalyzer_API::range()
+double SpectrumAnalyzer_API::bottomScale()
 {
-	return sp->range->value();
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		return sp->bottom->value();
+	} else {
+		return sp->bottom_scale->value();
+	}
 }
-void SpectrumAnalyzer_API::setRange(double val)
+void SpectrumAnalyzer_API::setBottomScale(double val)
 {
-	sp->range->setValue(val);
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		sp->bottom->setValue(val);
+	} else {
+		sp->bottom_scale->setValue(val);
+	}
+}
+
+double SpectrumAnalyzer_API::unitPerDiv()
+{
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		return sp->unit_per_div->value();
+	} else {
+		return sp->unit_per_div_scale->value();
+	}
+}
+void SpectrumAnalyzer_API::setunitPerDiv(double val)
+{
+	if (sp->ui->topWidget->currentIndex() == 0) {
+		sp->unit_per_div->setValue(val);
+	} else {
+		sp->unit_per_div_scale->setValue(val);
+	}
 }
 
 bool SpectrumAnalyzer_API::markerTableVisible()

--- a/src/spectrum_analyzer_api.hpp
+++ b/src/spectrum_analyzer_api.hpp
@@ -34,7 +34,8 @@ class SpectrumAnalyzer_API : public ApiObject
 	Q_PROPERTY(QString units READ units WRITE setUnits);
 	Q_PROPERTY(QString resBW READ resBW WRITE setResBW);
 	Q_PROPERTY(double topScale READ topScale WRITE setTopScale);
-	Q_PROPERTY(double range READ range WRITE setRange);
+	Q_PROPERTY(double bottomScale READ bottomScale WRITE setBottomScale);
+	Q_PROPERTY(double unitPerDiv READ unitPerDiv WRITE setunitPerDiv);
 	Q_PROPERTY(QVariantList channels READ getChannels);
 	Q_PROPERTY(int currentChannel READ currentChannel WRITE setCurrentChannel);
 	Q_PROPERTY(bool markerTableVisible READ markerTableVisible WRITE
@@ -76,8 +77,11 @@ private:
 	double topScale();
 	void setTopScale(double);
 
-	double range();
-	void setRange(double);
+	double bottomScale();
+	void setBottomScale(double);
+
+	double unitPerDiv();
+	void setunitPerDiv(double);
 
 	bool markerTableVisible();
 	void setMarkerTableVisible(bool);

--- a/src/spinbox_a.cpp
+++ b/src/spinbox_a.cpp
@@ -691,7 +691,7 @@ void ScaleSpinButton::stepUp()
 	double current_scale = m_units[ui->SBA_Combobox->currentIndex()].second;
 	double newVal;
 
-	double epsilon = 1E-15;
+	double epsilon = 1E-12;
 
 	if (isInFineMode()) {
 		newVal = (current_val + m_fine_increment) * current_scale;
@@ -724,7 +724,7 @@ void ScaleSpinButton::stepDown()
 	double current_scale = m_units[ui->SBA_Combobox->currentIndex()].second;
 	double newVal;
 
-	double epsilon = 1E-15;
+	double epsilon = 1E-12;
 
 	if (isInFineMode()) {
 		newVal = (current_val - m_fine_increment) * current_scale;

--- a/src/stream_to_vector_overlap.h
+++ b/src/stream_to_vector_overlap.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2014 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file LICENSE.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+/*
+ * Copyright (c) 2019 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef M2K_STREAM_TO_VECTOR_OVERLAP_H
+#define M2K_STREAM_TO_VECTOR_OVERLAP_H
+
+#include <gnuradio/sync_decimator.h>
+
+namespace adiscope {
+
+class stream_to_vector_overlap : virtual public gr::sync_decimator
+{
+public:
+	typedef boost::shared_ptr<stream_to_vector_overlap> sptr;
+	static sptr make(size_t itemsize, size_t nitems_per_block, double overlap_factor);
+	virtual void set_overlap_factor(double) = 0;
+};
+} /* namespace adiscope */
+
+#endif /* M2K_STREAM_TO_VECTOR_OVERLAP_H */

--- a/src/stream_to_vector_overlap_impl.cc
+++ b/src/stream_to_vector_overlap_impl.cc
@@ -1,0 +1,99 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2014 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file LICENSE.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+/*
+ * Copyright (c) 2019 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stream_to_vector_overlap_impl.h"
+#include <gnuradio/sync_decimator.h>
+
+using namespace gr;
+namespace adiscope {
+
+stream_to_vector_overlap::sptr
+stream_to_vector_overlap::make(size_t itemsize,
+			       size_t nitems_per_block,
+			       double overlap_factor)
+{
+	return gnuradio::get_initial_sptr(new stream_to_vector_overlap_impl(
+						  itemsize,
+						  nitems_per_block,
+						  overlap_factor));
+}
+
+stream_to_vector_overlap_impl::stream_to_vector_overlap_impl(size_t itemsize,
+							     size_t nitems_per_block,
+							     double overlap_factor)
+	: gr::sync_decimator("stream_to_vector_overlap",
+			 io_signature::make(1, 1, itemsize),
+			 io_signature::make(1, 1, itemsize * nitems_per_block),
+			 nitems_per_block),
+	  m_overlap_factor(overlap_factor),
+	  m_nitems_per_block(nitems_per_block),
+	  m_itemsize(itemsize)
+{
+	m_nb_overlapped_items = nitems_per_block * m_overlap_factor;
+}
+
+int stream_to_vector_overlap_impl::work(int noutput_items,
+					gr_vector_const_void_star& input_items,
+					gr_vector_void_star& output_items)
+{
+	size_t block_size = output_signature()->sizeof_stream_item(0);
+	size_t nb_input_items = noutput_items * block_size;
+	size_t nb_total_copied_items = 0;
+	size_t overlap_size = m_nb_overlapped_items * m_itemsize;
+	const char* in = (const char*)input_items[0];
+	char* out = (char*)output_items[0];
+
+	unsigned int src_index = 0;
+	while (src_index + block_size < nb_input_items) {
+		memcpy(out + nb_total_copied_items, in + src_index, block_size);
+		nb_total_copied_items += block_size;
+		src_index = src_index + block_size - overlap_size;
+	}
+	return nb_total_copied_items / block_size;
+}
+
+void stream_to_vector_overlap_impl::set_overlap_factor(double factor)
+{
+	m_overlap_factor = factor;
+	m_nb_overlapped_items = m_nitems_per_block * m_overlap_factor;
+}
+
+}

--- a/src/stream_to_vector_overlap_impl.h
+++ b/src/stream_to_vector_overlap_impl.h
@@ -1,0 +1,69 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2014 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file LICENSE.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+/*
+ * Copyright (c) 2019 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef M2K_STREAM_TO_VECTOR_OVERLAP_IMPL_H
+#define M2K_STREAM_TO_VECTOR_OVERLAP_IMPL_H
+
+#include "stream_to_vector_overlap.h"
+
+namespace adiscope {
+
+class stream_to_vector_overlap_impl : public stream_to_vector_overlap
+{
+public:
+	explicit stream_to_vector_overlap_impl(size_t itemsize,
+					       size_t nitems_per_block,
+					       double overlap_factor);
+
+	int work(int noutput_items,
+		 gr_vector_const_void_star& input_items,
+		 gr_vector_void_star& output_items);
+	void set_overlap_factor(double);
+
+private:
+	double m_overlap_factor;
+	unsigned int m_nb_overlapped_items;
+	size_t m_itemsize;
+	size_t m_nitems_per_block;
+};
+} /* namespace adiscope */
+
+#endif /* M2K_STREAM_TO_VECTOR_OVERLAP_IMPL_H */

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -1496,6 +1496,100 @@ color: rgba(255,255,255,51);
                          </layout>
                         </widget>
                        </item>
+                       <item row="3" column="0" colspan="2">
+                        <layout class="QGridLayout" name="sweepPeriodLayout">
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="horizontalSpacing">
+                          <number>3</number>
+                         </property>
+                         <property name="verticalSpacing">
+                          <number>0</number>
+                         </property>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="lblPeriods">
+                           <property name="text">
+                            <string>Periods</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="0">
+                          <widget class="QSpinBox" name="spinBox_periods">
+                           <property name="styleSheet">
+                            <string notr="true">font-size: 14px;
+height:24px;
+color: white;
+border: 0px;
+border-bottom: 1px solid rgba(255,255,255,100);
+
+
+QSpinBox[invalid=true] {
+border-color: red;
+}
+QSpinBox[valid=true] {
+border-color: green;
+}</string>
+                           </property>
+                           <property name="buttonSymbols">
+                            <enum>QAbstractSpinBox::NoButtons</enum>
+                           </property>
+                           <property name="minimum">
+                            <number>2</number>
+                           </property>
+                           <property name="maximum">
+                            <number>100</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QPushButton" name="btnApplyPeriod">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>64</width>
+                             <height>25</height>
+                            </size>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QPushButton {
+color: white;
+background-color: #4a64ff;
+font-family:  14pt;
+border-width: 0px;
+border-radius: 3px;
+min-width: 64px;
+}
+QPushButton:disabled {
+background-color: grey;
+}
+QPushButton:pressed {
+background-color: #F45000;
+}
+
+QPushButton:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[valid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[invalid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton:pressed {
+background-color: #4a64ff;
+}
+QPushButton:hover
+{
+	 background-color: #4a34ff;
+}</string>
+                           </property>
+                           <property name="text">
+                            <string>Apply</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
                       </layout>
                      </item>
                      <item>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -470,6 +470,22 @@ color:  red;</string>
                         </property>
                        </spacer>
                       </item>
+                      <item row="0" column="3">
+                       <widget class="QLabel" name="currentAverageLabel">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="styleSheet">
+                         <string notr="true">color:white;</string>
+                        </property>
+                        <property name="text">
+                         <string>Average: </string>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                    </layout>
@@ -1495,6 +1511,103 @@ color: rgba(255,255,255,51);
                           </property>
                          </layout>
                         </widget>
+                       </item>
+                       <item row="4" column="0" colspan="2">
+                        <layout class="QGridLayout" name="sweepAverageLayout">
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="horizontalSpacing">
+                          <number>3</number>
+                         </property>
+                         <property name="verticalSpacing">
+                          <number>0</number>
+                         </property>
+                         <item row="1" column="0">
+                          <widget class="QSpinBox" name="spinBox_averaging">
+                           <property name="styleSheet">
+                            <string notr="true">font-size: 14px;
+height:24px;
+color: white;
+border: 0px;
+border-bottom: 1px solid rgba(255,255,255,100);
+
+
+QSpinBox[invalid=true] {
+border-color: red;
+}
+QSpinBox[valid=true] {
+border-color: green;
+}</string>
+                           </property>
+                           <property name="buttonSymbols">
+                            <enum>QAbstractSpinBox::NoButtons</enum>
+                           </property>
+                           <property name="minimum">
+                            <number>1</number>
+                           </property>
+                           <property name="maximum">
+                            <number>1000000</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="lblAveraging">
+                           <property name="text">
+                            <string>Average</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QPushButton" name="btnApplyAverage">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>64</width>
+                             <height>25</height>
+                            </size>
+                           </property>
+                           <property name="styleSheet">
+                            <string notr="true">QPushButton {
+color: white;
+background-color: #4a64ff;
+font-family:  14pt;
+border-width: 0px;
+border-radius: 3px;
+min-width: 64px;
+}
+QPushButton:disabled {
+background-color: grey;
+}
+QPushButton:pressed {
+background-color: #F45000;
+}
+
+QPushButton:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[valid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[invalid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton:pressed {
+background-color: #4a64ff;
+}
+QPushButton:hover
+{
+	 background-color: #4a34ff;
+}</string>
+                           </property>
+                           <property name="text">
+                            <string>Apply</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
                        </item>
                        <item row="3" column="0" colspan="2">
                         <layout class="QGridLayout" name="sweepPeriodLayout">

--- a/ui/spectrum_analyzer.ui
+++ b/ui/spectrum_analyzer.ui
@@ -560,7 +560,7 @@ QWidget {
               </sizepolicy>
              </property>
              <property name="currentIndex">
-              <number>0</number>
+              <number>2</number>
              </property>
              <widget class="QWidget" name="channelSettings">
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -813,6 +813,40 @@ QPushButton:hover
                    <property name="text">
                     <string/>
                    </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <property name="spacing">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="label_7">
+                   <property name="text">
+                    <string>Gain mode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="cmbGainMode">
+                   <property name="currentText">
+                    <string>Low</string>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>Low</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>High</string>
+                    </property>
+                   </item>
                   </widget>
                  </item>
                 </layout>

--- a/ui/spectrum_analyzer.ui
+++ b/ui/spectrum_analyzer.ui
@@ -436,6 +436,39 @@ QPushButton:checked:hover {
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="lbl_crtSampleNb">
+               <property name="minimumSize">
+                <size>
+                 <width>200</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>200</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Sample:</string>
+               </property>
+              </widget>
+             </item>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
                <property name="sizeHint" stdset="0">
                 <size>
                  <width>0</width>

--- a/ui/spectrum_analyzer.ui
+++ b/ui/spectrum_analyzer.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>857</width>
+    <width>969</width>
     <height>661</height>
    </rect>
   </property>
@@ -466,6 +466,31 @@ QPushButton:checked:hover {
                </property>
               </widget>
              </item>
+             <item>
+              <spacer name="horizontalSpacer_14">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="lbl_crtAvgSample">
+               <property name="text">
+                <string>Average Sample: </string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_13">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -663,14 +688,17 @@ QWidget {
                 </layout>
                </item>
                <item>
-                <layout class="QVBoxLayout" name="verticalLayout_12">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
+                <layout class="QGridLayout" name="gridLayout_6">
                  <property name="topMargin">
                   <number>0</number>
                  </property>
-                 <item>
+                 <property name="horizontalSpacing">
+                  <number>3</number>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
                   <widget class="QLabel" name="label_averaging">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -686,23 +714,104 @@ QWidget {
                    </property>
                   </widget>
                  </item>
-                 <item>
+                 <item row="1" column="0">
                   <widget class="QSpinBox" name="spinBox_averaging">
                    <property name="styleSheet">
                     <string notr="true">font-size: 14px;
 height:24px;
 color: white;
 border: 0px;
-border-bottom: 1px solid rgba(255,255,255,100);</string>
+border-bottom: 1px solid rgba(255,255,255,100);
+
+
+QSpinBox[invalid=true] {
+border-color: red;
+}
+QSpinBox[valid=true] {
+border-color: green;
+}</string>
                    </property>
                    <property name="buttonSymbols">
                     <enum>QAbstractSpinBox::NoButtons</enum>
+                   </property>
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
                    </property>
                    <property name="minimum">
                     <number>1</number>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>10000</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QPushButton" name="btnApply">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>64</width>
+                     <height>25</height>
+                    </size>
+                   </property>
+                   <property name="styleSheet">
+                    <string notr="true">QPushButton {
+color: white;
+background-color: #4a64ff;
+font-family:  14pt;
+border-width: 0px;
+border-radius: 3px;
+min-width: 64px;
+}
+QPushButton:disabled {
+background-color: grey;
+}
+QPushButton:pressed {
+background-color: #F45000;
+}
+
+QPushButton:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[valid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton[invalid=true]:enabled:!pressed { background-color: #4a64ff; }
+QPushButton:pressed {
+background-color: #4a64ff;
+}
+QPushButton:hover
+{
+	 background-color: #4a34ff;
+}</string>
+                   </property>
+                   <property name="text">
+                    <string>Apply</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_15">
+                 <property name="spacing">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="lbl_history">
+                   <property name="text">
+                    <string>History</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="adiscope::CustomSwitch" name="btnHistory">
+                   <property name="text">
+                    <string/>
                    </property>
                   </widget>
                  </item>
@@ -1221,11 +1330,20 @@ color: rgba(255,255,255,51);
                     <number>2</number>
                    </property>
                    <item>
-                    <layout class="QHBoxLayout" name="rangeLayout">
-                     <property name="spacing">
-                      <number>0</number>
+                    <widget class="QStackedWidget" name="bottomWidget"/>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_11">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
                      </property>
-                    </layout>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
                    </item>
                    <item>
                     <widget class="QLabel" name="lbl_rbw">
@@ -1248,7 +1366,10 @@ color: rgba(255,255,255,51);
                     <number>2</number>
                    </property>
                    <item>
-                    <layout class="QHBoxLayout" name="topLayout"/>
+                    <widget class="QStackedWidget" name="topWidget"/>
+                   </item>
+                   <item>
+                    <widget class="QStackedWidget" name="divisionWidget"/>
                    </item>
                    <item>
                     <widget class="QLabel" name="lbl_units">


### PR DESCRIPTION
Network Analyzer:
-  Add averaging.
-  Add a control for the min number of periods per capture.
-  Increase the number of captured samples.

Spectrum Analyzer:
-  Increase the max number of averages and display the current average buffer.
-  Add a Gain control for each channel.
-  Increase the possible bin size.
-  Add a new unit (Volts per square root hertz) for noise spectral density.
