### PR TITLE
General: Integrate m2k exception.

### DIFF
--- a/src/adc_sample_conv.cpp
+++ b/src/adc_sample_conv.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "adc_sample_conv.hpp"
+#include <libm2k/m2kexceptions.hpp>
 #include <libm2k/analog/m2kanalogin.hpp>
 
 using namespace gr;
@@ -49,7 +50,7 @@ double adc_sample_conv::conversionWrapper(unsigned int chn_idx, double sample, b
 		} else {
 			return m2k_adc->convertVoltsToRaw(chn_idx, sample);
 		}
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		return 0;
 	}
 }

--- a/src/dmm.cpp
+++ b/src/dmm.cpp
@@ -47,6 +47,7 @@
 
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 
 #include "dmm_api.hpp"
 
@@ -626,7 +627,7 @@ void DMM::writeAllSettingsToHardware()
 					trigger->setAnalogMode(i, libm2k::ALWAYS);
 				}
 			}
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_VOLTMETER) << "Can't write to hardware: " << e.what();
 		}
 	}

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -43,6 +43,8 @@
 
 #include "filter.hpp"
 
+#include <libm2k/m2kexceptions.hpp>
+
 #include "osc_export_settings.h"
 #include "filemanager.h"
 #include "config.h"
@@ -1069,7 +1071,7 @@ void LogicAnalyzer::startStop(bool start)
 					Q_EMIT dataAvailable(0, bufferSize);
 					updateBufferPreviewer(0, m_lastCapturedSample);
 
-				} catch (std::invalid_argument &e) {
+				} catch (libm2k::m2k_exception &e) {
 					qDebug() << e.what();
 				}
 			} else {
@@ -1095,7 +1097,7 @@ void LogicAnalyzer::startStop(bool start)
 							m_plot.setTriggerState(CapturePlot::Triggered);
 						}, Qt::QueuedConnection);
 
-					} catch (std::invalid_argument &e) {
+					} catch (libm2k::m2k_exception &e) {
 						qDebug() << e.what();
 						break;
 					}

--- a/src/manualcalibration.cpp
+++ b/src/manualcalibration.cpp
@@ -34,6 +34,7 @@
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
 #include <libm2k/m2k.hpp>
+#include <libm2k/m2kexceptions.hpp>
 #include <libm2k/analog/m2kpowersupply.hpp>
 #include <libm2k/analog/dmm.hpp>
 
@@ -241,7 +242,7 @@ void ManualCalibration::positivePowerSupplyParam(const int step)
 		/*adc offset calibration*/
 		try {
 			value = m_m2k_powersupply->readChannel(0);
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_CALIBRATION_MANUAL) << "Can't read value: " << e.what();
 		}
 
@@ -274,7 +275,7 @@ void ManualCalibration::positivePowerSupplyParam(const int step)
 			/*adc gain calibration*/
 			try {
 				value = m_m2k_powersupply->readChannel(0);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_CALIBRATION_MANUAL) << "Can't read value: " << e.what();
 			}
 			stParameters.gain_pos_adc = offset_Value / (value +
@@ -306,7 +307,7 @@ void ManualCalibration::setEnablePositiveSuppply(bool enabled)
 {
 	try {
 		m_m2k_powersupply->enableChannel(0, enabled);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_CALIBRATION_MANUAL) << "Can't enable channel: " << e.what();
 	}
 }
@@ -315,7 +316,7 @@ void ManualCalibration::setPositiveValue(double value)
 {
 	try {
 		m_m2k_powersupply->pushChannel(0, value);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_CALIBRATION_MANUAL) << "Can't write value: " << e.what();
 	}
 }
@@ -358,7 +359,7 @@ void ManualCalibration::negativePowerSupplyParam(const int step)
 		/*adc offset calibration*/
 		try {
 			value = m_m2k_powersupply->readChannel(1);
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_CALIBRATION_MANUAL) << "Can't read value: " << e.what();
 		}
 		stParameters.offset_neg_adc = offset_Value - value;
@@ -390,7 +391,7 @@ void ManualCalibration::negativePowerSupplyParam(const int step)
 			/*adc gain calibration*/
 			try {
 				value = m_m2k_powersupply->readChannel(1);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_CALIBRATION_MANUAL) << "Can't read value: " << e.what();
 			}
 			stParameters.gain_neg_adc =  offset_Value / (value +
@@ -421,7 +422,7 @@ void ManualCalibration::setEnableNegativeSuppply(bool enabled)
 {
 	try {
 		m_m2k_powersupply->enableChannel(1, enabled);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_CALIBRATION_MANUAL) << "Can't enable channel: " << e.what();
 	}
 }
@@ -430,7 +431,7 @@ void ManualCalibration::setNegativeValue(double value)
 {
 	try {
 		m_m2k_powersupply->pushChannel(1, value);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_CALIBRATION_MANUAL) << "Can't write value: " << e.what();
 	}
 }

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -61,6 +61,7 @@
 
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 
 using namespace adiscope;
 using namespace gr;
@@ -1139,7 +1140,7 @@ void NetworkAnalyzer::setFilterParameters()
 			f12->set_high_gain(range0);
 			f21->set_high_gain(range1);
 			f22->set_high_gain(range1);
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_NETWORK_ANALYZER) << e.what();
 		}
 	}
@@ -1199,7 +1200,7 @@ void NetworkAnalyzer::goertzel()
 				// Sleep before DACs start
 				QThread::msleep(pushDelay->value());
 				m_m2k_analogout->push(buffers);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				return;
 			}
 		}
@@ -1231,7 +1232,7 @@ void NetworkAnalyzer::goertzel()
 			try {
 				m_m2k_analogin->setOversamplingRatio(1);
 				m_m2k_analogin->setSampleRate(adc_rate);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_NETWORK_ANALYZER) << e.what();
 			}
 		}
@@ -1247,7 +1248,7 @@ void NetworkAnalyzer::goertzel()
 			if (m_m2k_analogin) {
 				try {
 					buffer_p = m_m2k_analogin->getSamplesRawInterleaved(buffer_size);
-				} catch (std::exception &e) {
+				} catch (libm2k::m2k_exception &e) {
 					qDebug(CAT_NETWORK_ANALYZER) << e.what();
 					return;
 				}
@@ -1492,7 +1493,7 @@ bool NetworkAnalyzer::_checkMagForOverrange(double magnitude)
 
 	try {
 		vlsb = m_m2k_analogin->getScalingFactor(static_cast<ANALOG_IN_CHANNEL>(responseChannel));
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_NETWORK_ANALYZER) << e.what();
 		return false;
 	}
@@ -1650,7 +1651,7 @@ void NetworkAnalyzer::startStop(bool pressed)
 			thd.waitForFinished();
 			m_m2k_analogin->stopAcquisition();
 			m_m2k_analogout->stop();
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_NETWORK_ANALYZER) << e.what();
 		}
 		m_dBgraph.sweepDone();
@@ -1672,7 +1673,7 @@ std::vector<double> NetworkAnalyzer::generateSinWave(
 			if (!m_m2k_analogout->isChannelEnabled(chn_idx)) {
 				return {};
 			}
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_NETWORK_ANALYZER) << e.what();
 		}
 	}
@@ -1715,7 +1716,7 @@ void NetworkAnalyzer::configHwForNetworkAnalyzing()
 				trigger->setAnalogDelay(0);
 			}
 
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_NETWORK_ANALYZER) << e.what();
 		}
 	}

--- a/src/osc_adc.cpp
+++ b/src/osc_adc.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 
 #include "hardware_trigger.hpp"
+#include <libm2k/m2kexceptions.hpp>
 using namespace adiscope;
 
 /*
@@ -236,7 +237,7 @@ M2kAdc::M2kAdc(struct iio_context *ctx, struct iio_device *adc_dev):
 		"m2k-adc-trigger");
 	try {
 		m_trigger = std::make_shared<HardwareTrigger>(m2k_trigger);
-	} catch (std::exception& e){
+	} catch (libm2k::m2k_exception& e){
 		qDebug() << "Disabling hardware trigger support." << e.what();
 	}
 

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -42,6 +42,7 @@
 
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 
 /* Local includes */
 #include "logging_categories.h"
@@ -4463,7 +4464,7 @@ void Oscilloscope::resetStreamingFlag(bool enable)
 
 	try {
 		m_m2k_analogin->getTrigger()->setAnalogStreamingFlag(false);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_OSCILLOSCOPE) << e.what();
 	}
 	cleanBuffersAllSinks();
@@ -4475,7 +4476,7 @@ void Oscilloscope::resetStreamingFlag(bool enable)
 		if (enable && !d_displayOneBuffer) {
 			m_m2k_analogin->getTrigger()->setAnalogStreamingFlag(true);
 		}
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_OSCILLOSCOPE) << e.what();
 	}
 
@@ -4666,7 +4667,7 @@ void Oscilloscope::setGainMode(uint chnIdx, libm2k::analog::M2K_RANGE gain_mode)
 		try {
 			libm2k::analog::ANALOG_IN_CHANNEL chn = static_cast<libm2k::analog::ANALOG_IN_CHANNEL>(chnIdx);
 			m_m2k_analogin->setRange(chn, gain_mode);
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_OSCILLOSCOPE) << e.what();
 		}
 	}
@@ -4686,7 +4687,7 @@ void Oscilloscope::setChannelHwOffset(uint chnIdx, double offset)
 		try {
 			libm2k::analog::ANALOG_IN_CHANNEL chn = static_cast<libm2k::analog::ANALOG_IN_CHANNEL>(chnIdx);
 			m_m2k_analogin->setVerticalOffset(chn, offset);
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_OSCILLOSCOPE) << e.what();
 		}
 	}
@@ -4725,7 +4726,7 @@ void Oscilloscope::writeAllSettingsToHardware()
 				libm2k::analog::ANALOG_IN_CHANNEL chn = static_cast<libm2k::analog::ANALOG_IN_CHANNEL>(i);
 				m_m2k_analogin->setRange(chn, mode);
 				m_m2k_analogin->setVerticalOffset(chn, channel_offset[i]);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_OSCILLOSCOPE) << e.what();
 			}
 		}
@@ -4830,7 +4831,7 @@ void Oscilloscope::setSampleRate(double sample_rate)
 			m_m2k_analogin->setSampleRate(sample_rate);
 			m_m2k_analogin->setOversamplingRatio(1);
 		}
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_OSCILLOSCOPE) << e.what();
 	}
 }
@@ -4848,7 +4849,7 @@ double Oscilloscope::getSampleRate()
 			sr = (double)(sr / osr);
 		}
 		return sr;
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_OSCILLOSCOPE) << e.what();
 		return 0;
 	}

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -34,6 +34,8 @@
 #include "../logicanalyzer/annotationdecoder.h"
 #include "pattern_generator_api.h"
 
+#include <libm2k/m2kexceptions.hpp>
+
 using namespace adiscope;
 using namespace adiscope::logic;
 
@@ -713,13 +715,13 @@ void PatternGenerator::startStop(bool start)
 								m_m2kDigital->enableChannel(i, false);
 							}
 						}
-					} catch (std::exception &e) {
+					} catch (libm2k::m2k_exception &e) {
 						qDebug() << e.what();
 					}
 				});
 			}
 
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug() << e.what();
 		}
 
@@ -735,7 +737,7 @@ void PatternGenerator::startStop(bool start)
 					m_m2kDigital->enableChannel(i, false);
 				}
 			}
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug() << e.what();
 		}
 	}

--- a/src/power_controller.cpp
+++ b/src/power_controller.cpp
@@ -31,6 +31,7 @@
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
 #include <libm2k/m2k.hpp>
+#include <libm2k/m2kexceptions.hpp>
 #include <libm2k/analog/m2kpowersupply.hpp>
 
 #define TIMER_TIMEOUT_MS	200
@@ -52,7 +53,7 @@ PowerController::PowerController(struct iio_context *ctx,
 	try {
 		m_m2k_powersupply->pushChannel(0, 0.0);
 		m_m2k_powersupply->pushChannel(1, 0.0);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't write push value: " << e.what();
 	}
 
@@ -113,7 +114,7 @@ PowerController::~PowerController()
 
 	try {
 		m_m2k_powersupply->powerDownDacs(true);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << e.what();
 	}
 
@@ -150,7 +151,7 @@ void PowerController::dac1_set_value(double value)
 {
 	try {
 		m_m2k_powersupply->pushChannel(0, value);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't write push value: " << e.what();
 	}
 	averageVoltageCh1.clear();
@@ -167,7 +168,7 @@ void PowerController::dac2_set_value(double value)
 {
 	try {
 		m_m2k_powersupply->pushChannel(1, value);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't write push value: " << e.what();
 	}
 	averageVoltageCh2.clear();
@@ -177,7 +178,7 @@ void PowerController::dac1_set_enabled(bool enabled)
 {
 	try {
 		m_m2k_powersupply->enableChannel(0, enabled);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't enable channel: " << e.what();
 	}
 	averageVoltageCh1.clear();
@@ -192,7 +193,7 @@ void PowerController::dac2_set_enabled(bool enabled)
 {
 	try {
 		m_m2k_powersupply->enableChannel(1, enabled);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't enable channel: " << e.what();
 	}
 	averageVoltageCh2.clear();
@@ -226,7 +227,7 @@ void PowerController::update_lcd()
 	try {
 		value1 = m_m2k_powersupply->readChannel(0);
 		value2 = m_m2k_powersupply->readChannel(1);
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_POWER_CONTROLLER) << "Can't read value: " << e.what();
 	}
 

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -72,6 +72,7 @@
 
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 
 #define NB_POINTS	32768
 #define DAC_BIT_COUNT   12
@@ -1452,7 +1453,7 @@ void SignalGenerator::stop()
 		buffers.clear();
 		m_running = false;
 		m_m2k_analogout->stop();
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_SIGNAL_GENERATOR) << e.what();
 	}
 }

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -57,6 +57,7 @@
 
 /* libm2k includes */
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 
 #define TIMER_TIMEOUT_MS 100
 
@@ -342,7 +343,7 @@ SpectrumAnalyzer::SpectrumAnalyzer(struct iio_context *ctx, Filter *filt,
 			if (canConvRawToVolts) {
 				fft_plot->setScaleFactor(crt_channel, m_m2k_analogin->getScalingFactor(chn));
 			}
-		} catch (std::exception &e) {
+		} catch (libm2k::m2k_exception &e) {
 			qDebug(CAT_SPECTRUM_ANALYZER) << e.what();
 		}
 
@@ -1556,7 +1557,7 @@ void SpectrumAnalyzer::writeAllSettingsToHardware()
 				m_generic_analogin->setSampleRate(i, m_generic_analogin->getMaximumSamplerate(i));
 			}
 		}
-	} catch (std::exception &e) {
+	} catch (libm2k::m2k_exception &e) {
 		qDebug(CAT_SPECTRUM_ANALYZER) << "Can't write settings to hardware: " << e.what();
 	}
 }
@@ -1647,7 +1648,7 @@ void SpectrumAnalyzer::setSampleRate(double sr)
 		if (m_m2k_analogin) {
 			try {
 				m_m2k_analogin->setOversamplingRatio(sample_rate_divider);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_SPECTRUM_ANALYZER) << "Can't write oversampling ratio: " << e.what();
 			}
 		} else {
@@ -1655,7 +1656,7 @@ void SpectrumAnalyzer::setSampleRate(double sr)
 				for (unsigned int i = 0; i < m_adc_nb_channels; i++) {
 					m_generic_analogin->setSampleRate(i, sr);
 				}
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug(CAT_SPECTRUM_ANALYZER) << "Can't write sampling frequency: " << e.what();
 			}
 		}

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -65,6 +65,7 @@
 
 #include <libm2k/m2k.hpp>
 #include <libm2k/contextbuilder.hpp>
+#include <libm2k/m2kexceptions.hpp>
 #include <libm2k/digital/m2kdigital.hpp>
 
 #define TIMER_TIMEOUT_MS 5000
@@ -1176,7 +1177,7 @@ void adiscope::ToolLauncher::destroyContext()
 		if (m_m2k) {
 			try {
 				libm2k::context::contextClose(m_m2k);
-			} catch (std::exception &e) {
+			} catch (libm2k::m2k_exception &e) {
 				qDebug() << e.what();
 			}
 			m_m2k = nullptr;

--- a/src/trigger_settings.cpp
+++ b/src/trigger_settings.cpp
@@ -20,6 +20,7 @@
 
 #include <libm2k/context.hpp>
 #include <libm2k/m2k.hpp>
+#include <libm2k/m2kexceptions.hpp>
 #include <libm2k/analog/m2kanalogin.hpp>
 #include <libm2k/m2khardwaretrigger.hpp>
 #include <libm2k/contextbuilder.hpp>
@@ -370,7 +371,7 @@ void TriggerSettings::enableExternalTriggerOut(bool enabled)
 		} else {
 			m_trigger->setAnalogExternalOutSelect(libm2k::SELECT_NONE);
 		}
-	} catch (std::exception& e) {
+	} catch (libm2k::m2k_exception& e) {
 		qDebug() << e.what();
 	}
 }
@@ -401,7 +402,7 @@ void TriggerSettings::on_cmb_analog_extern_currentIndexChanged(int index)
 		mode = static_cast<libm2k::M2K_TRIGGER_MODE>(start_idx + index);
 		try {
 			m_trigger->setAnalogMode(currentChannel(), mode);
-		} catch (std::exception& e){
+		} catch (libm2k::m2k_exception& e){
 			qDebug() << e.what();
 		}
 	}
@@ -455,7 +456,7 @@ void TriggerSettings::updateHwVoltLevels(int chnIdx)
 		m_trigger->setAnalogLevel(chnIdx, level);
 		m_trigger->setAnalogHysteresis(chnIdx, trigg_configs[chnIdx].hyst_val);
 	}
-	catch (std::exception& e)
+	catch (libm2k::m2k_exception& e)
 	{
 		qDebug() << e.what();
 	}
@@ -549,7 +550,7 @@ void TriggerSettings::writeHwDelay(long long raw_delay)
 		try {
 			m_trigger->setAnalogDelay(raw_delay);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}
@@ -565,7 +566,7 @@ void TriggerSettings::writeHwLevel(double level)
 		try {
 			m_trigger->setAnalogLevel(currentChannel(), level);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}
@@ -577,7 +578,7 @@ void TriggerSettings::writeHwHysteresis(double level)
 		try {
 			m_trigger->setAnalogHysteresis(currentChannel(), level);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}
@@ -592,7 +593,7 @@ void TriggerSettings::writeHwAnalogCondition(int cond)
 		try {
 			m_trigger->setAnalogCondition(currentChannel(), t_cond);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}
@@ -607,7 +608,7 @@ void TriggerSettings::writeHwDigitalCondition(int cond)
 		try {
 			m_trigger->setAnalogExternalCondition(currentChannel(), t_cond);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}
@@ -620,7 +621,7 @@ void TriggerSettings::writeHwMode(int mode)
 			m_trigger->setAnalogMode(currentChannel(),
 				static_cast<libm2k::M2K_TRIGGER_MODE>(mode));
 		}
-		catch (std::exception& e)
+		catch (libm2k::m2k_exception& e)
 		{
 			qDebug() << e.what();
 		}
@@ -664,7 +665,7 @@ void TriggerSettings::writeHwSource(int source_chn)
 			}
 			m_trigger->setAnalogSource(source);
 		}
-		catch (std::exception& e) {
+		catch (libm2k::m2k_exception& e) {
 			qDebug() << e.what();
 		}
 	}


### PR DESCRIPTION
Instead of catching the standard C++ exception on libm2k API calls, catch the libm2k exception.