### PR TITLE
Oscilloscope: change unit from Hz to sps for sample rate in osc plot

### DIFF
--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -2358,10 +2358,9 @@ void CapturePlot::moveCursorReadouts(CustomPlotPositionButton::ReadoutsPosition 
 
 void CapturePlot::updateBufferSizeSampleRateLabel(int nsamples, double sr)
 {
-	QString txtSampleRate = d_cursorMetricFormatter.format(sr, "Hz", 0);
+	QString txtSampleRate = d_cursorMetricFormatter.format(sr, "sps", 0);
 	QString txtSamplingPeriod = d_cursorTimeFormatter.format(1 / sr, "", 0);
-	QString text = QString("%1 Samples at ").arg(nsamples) + txtSampleRate +
-		"/" + txtSamplingPeriod;
+	QString text = QString("%1 Samples at ").arg(nsamples) + txtSampleRate;
 	d_sampleRateLabel->setText(text);
 }
 


### PR DESCRIPTION
Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>