### PR TITLE
NetworkAnalyzer: use full namespace for analog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ find_package(gnuradio-scopy REQUIRED PATH_SUFFIXES scopy)
 find_package(gnuradio-m2k REQUIRED PATH_SUFFIXES m2k)
 
 add_definitions(-DBOOST_ALL_DYN_LINK)
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(Boost COMPONENTS system filesystem thread chrono REQUIRED)
 
 set(VC_PATH "$ENV{VS120COMNTOOLS}/../../VC")
 find_library(IIO_LIBRARIES NAMES iio libiio PATHS ${VC_PATH}/lib ${VC_PATH}/lib/amd64)

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -73,7 +73,7 @@ void NetworkAnalyzer::_configureDacFlowgraph()
 {
 	// Create the blocks that are used to generate sine waves
 	top_block = make_top_block("Signal Generator");
-	source_block = analog::sig_source_f::make(1, analog::GR_SIN_WAVE,
+	source_block = gr::analog::sig_source_f::make(1, gr::analog::GR_SIN_WAVE,
 			1, 1, 1);
 	head_block = blocks::head::make(sizeof(float), 1);
 	vector_block = blocks::vector_sink_f::make();


### PR DESCRIPTION
Because of ambigous reference to gr::analog or libm2k::analog. Fixes
compilation error

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>