### PR TITLE
MacOS Appveyor fixes

### DIFF
--- a/CI/appveyor/before_install_lib.sh
+++ b/CI/appveyor/before_install_lib.sh
@@ -177,7 +177,7 @@ patch_qwt() {
 	patch -p1 <<-EOF
 --- a/qwtconfig.pri
 +++ b/qwtconfig.pri
-@@ -19,7 +19,7 @@ QWT_VERSION      = \$\${QWT_VER_MAJ}.\$\${QWT_VER_MIN}.\$\${QWT_VER_PAT}
+@@ -19,7 +19,7 @@
  QWT_INSTALL_PREFIX = \$\$[QT_INSTALL_PREFIX]
  
  unix {
@@ -186,12 +186,30 @@ patch_qwt() {
      # QWT_INSTALL_PREFIX = /usr/local/qwt-\$\$QWT_VERSION-svn-qt-\$\$QT_VERSION
  }
  
-@@ -161,7 +161,7 @@ QWT_CONFIG     += QwtPlayground
+@@ -107,7 +107,7 @@
+ # Otherwise you have to build it from the designer directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtDesigner
++#QWT_CONFIG     += QwtDesigner
+ 
+ ######################################################################
+ # Compile all Qwt classes into the designer plugin instead
+@@ -148,7 +148,7 @@
+ # Otherwise you have to build them from the tests directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtTests
++#QWT_CONFIG     += QwtTests
+ 
+ ######################################################################
+ # When Qt has been built as framework qmake wants
+@@ -157,7 +157,7 @@
  
  macx:!static:CONFIG(qt_framework, qt_framework|qt_no_framework) {
  
 -    QWT_CONFIG += QwtFramework
-+    #QWT_CONFIG += QwtFramework
++#    QWT_CONFIG += QwtFramework
  }
  
  ######################################################################
@@ -204,18 +222,6 @@ patch_qwt() {
 -        QWT_SONAME=libqwt.so.\$\${VER_MAJ}.\$\${VER_MIN}
 +        !macx: QWT_SONAME=libqwt.so.\$\${VER_MAJ}.\$\${VER_MIN}
 +        macx: QWT_SONAME=\$\${QWT_INSTALL_LIBS}/libqwt.dylib
-         QMAKE_LFLAGS *= \$\${QMAKE_LFLAGS_SONAME}\$\${QWT_SONAME}
-         QMAKE_LFLAGS_SONAME=
-     }
---- a/textengines/mathml/mathml.pro
-+++ b/textengines/mathml/mathml.pro
-@@ -57,7 +57,8 @@ contains(QWT_CONFIG, QwtDll) {
- 
-         # we increase the SONAME for every minor number
- 
--        QWT_SONAME=libqwtmathml.so.\$\${VER_MAJ}.\$\${VER_MIN}
-+        !macx: QWT_SONAME=libqwtmathml.so.\$\${VER_MAJ}.\$\${VER_MIN}
-+        macx: QWT_SONAME=\$\${QWT_INSTALL_LIBS}/libqwtmathml.dylib
          QMAKE_LFLAGS *= \$\${QMAKE_LFLAGS_SONAME}\$\${QWT_SONAME}
          QMAKE_LFLAGS_SONAME=
      }

--- a/CI/appveyor/install_ubuntu_deps.sh
+++ b/CI/appveyor/install_ubuntu_deps.sh
@@ -189,7 +189,7 @@ build_qwt() {
 	cd ${WORKDIR}/qwt
 
 	# Disable components that we won't build
-	sed -i "s/^QWT_CONFIG\\s*+=\\s*QwtMathML$/#/g" qwtconfig.pri
+	sed -i "s/^QWT_CONFIG\\s*+=\\s*QwtTests$/#/g" qwtconfig.pri
 	sed -i "s/^QWT_CONFIG\\s*+=\\s*QwtDesigner$/#/g" qwtconfig.pri
 	sed -i "s/^QWT_CONFIG\\s*+=\\s*QwtExamples$/#/g" qwtconfig.pri
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
 pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 pkg_check_modules(LIBSIGROK_DECODE REQUIRED libsigrokdecode)
+pkg_get_variable(LIBSIGROK_DECODERS_DIR libsigrokdecode decodersdir)
 message(CMAKE_PATH ${CMAKE_PREFIX_PATH})
 include_directories(
 	${Boost_INCLUDE_DIRS}
@@ -251,11 +252,11 @@ if (ENABLE_APPLICATION_BUNDLE)
 		set(BUNDLED_QT_PLUGINS ${BUNDLED_QT_PLUGINS} ${CMAKE_BINARY_DIR}/Scopy.app/Contents/plugins/${_dir}/${_name})
 	endforeach()
 
-	file(GLOB_RECURSE DECODERS ${CMAKE_SOURCE_DIR}/resources/decoders/*.py)
+	file(GLOB_RECURSE DECODERS ${LIBSIGROK_DECODERS_DIR}/*.py)
 	foreach(_decoder ${DECODERS})
-		file(RELATIVE_PATH _file ${CMAKE_SOURCE_DIR}/resources ${_decoder})
+		file(RELATIVE_PATH _file ${LIBSIGROK_DECODERS_DIR} ${_decoder})
 		get_filename_component(_path ${_file} DIRECTORY)
-		set_source_files_properties(${_decoder} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/${_path})
+		set_source_files_properties(${_decoder} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/decoders/${_path})
 	endforeach()
 
 	install(CODE "


### PR DESCRIPTION
This PR handles 2 issues that were found on MacOS.
1) The Qwt official repo removed the MathML module, so we need to update the Scopy Qwt Patch to drop the module as well.
2) The decoders were not copied in the MacOS bundle file, so the App would always start with a pop-up informing the user that the digital decoders will not work.