### PR TITLE
Fixes and improvements regarding the mixed signal view

### DIFF
--- a/src/iio_manager.hpp
+++ b/src/iio_manager.hpp
@@ -35,7 +35,11 @@
 #include <libm2k/analog/m2kanalogin.hpp>
 #include <libm2k/digital/m2kdigital.hpp>
 
+#include <m2k/mixed_signal_source.h>
+
 #include <mutex>
+
+#include "timeout_block.hpp"
 
 /* 1k samples by default */
 #define IIO_BUFFER_SIZE 0x400
@@ -122,6 +126,12 @@ namespace adiscope {
 		/* Set the timeout for the source device */
 		void set_device_timeout(unsigned int mseconds);
 
+		/* Replace the iio_block source with the mixed source */
+		void enableMixedSignal(gr::m2k::mixed_signal_source::sptr mixed_source);
+
+		/* Bring back the data from the iio_block source */
+		void disableMixedSignal(gr::m2k::mixed_signal_source::sptr mixed_source);
+
 		adiscope::frequency_compensation_filter::sptr freq_comp_filt[2][2];
 
 	private:
@@ -140,6 +150,9 @@ namespace adiscope {
 
 		gr::m2k::analog_in_source::sptr iio_block;
 		unsigned int nb_channels;
+
+		boost::shared_ptr<timeout_block> timeout_b;
+		gr::m2k::mixed_signal_source::sptr m_mixed_source;
 
 		struct connection {
 			gr::basic_block_sptr src;

--- a/src/logic_analyzer_sink_impl.cpp
+++ b/src/logic_analyzer_sink_impl.cpp
@@ -72,7 +72,6 @@ int logic_analyzer_sink_impl::work(int noutput_items,
 
 	d_index += nitems;
 
-
 	if (d_triggered && (d_index == d_end) && d_end != 0) {
 		if (gr::high_res_timer_now() - d_last_time > d_update_time) {
 			d_last_time = gr::high_res_timer_now();

--- a/src/mixed_signal_sink.h
+++ b/src/mixed_signal_sink.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIXED_SIGNAL_SINK_H
+#define MIXED_SIGNAL_SINK_H
+
+#include <gnuradio/sync_block.h>
+
+#include "logicanalyzer/logic_analyzer.h"
+#include "TimeDomainDisplayPlot.h"
+
+class mixed_signal_sink : virtual public gr::sync_block
+{
+public:
+	typedef boost::shared_ptr<mixed_signal_sink> sptr;
+
+	static sptr make(adiscope::logic::LogicAnalyzer *logicAnalyzer,
+	                 adiscope::TimeDomainDisplayPlot *oscPlot,
+	                 int bufferSize);
+
+	virtual void clean_buffers() = 0;
+	virtual void set_nsamps(int newsize) = 0;
+};
+
+#endif // MIXED_SIGNAL_SINK_H

--- a/src/mixed_signal_sink_impl.cpp
+++ b/src/mixed_signal_sink_impl.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mixed_signal_sink_impl.h"
+
+#include <volk/volk.h>
+#include <qapplication.h>
+
+using namespace gr;
+
+
+mixed_signal_sink::sptr mixed_signal_sink::make(adiscope::logic::LogicAnalyzer *logicAnalyzer,
+						adiscope::TimeDomainDisplayPlot *oscPlot,
+						int bufferSize)
+{
+	return gnuradio::get_initial_sptr(
+				new mixed_signal_sink_impl(logicAnalyzer, oscPlot, bufferSize));
+}
+
+mixed_signal_sink_impl::mixed_signal_sink_impl(adiscope::logic::LogicAnalyzer *logicAnalyzer,
+					       adiscope::TimeDomainDisplayPlot *oscPlot,
+					       int bufferSize)
+	: sync_block("mixed_signal_sink",
+		     io_signature::make3(3, 3, sizeof(float), sizeof(float), sizeof(unsigned short)),
+		     io_signature::make(0, 0, 0))
+	, d_logic_analyzer(logicAnalyzer)
+	, d_osc_plot(oscPlot)
+	, d_size(bufferSize)
+	, d_buffer_size(2 * bufferSize)
+	, d_index(0)
+	, d_end(d_size)
+	, d_tags(std::vector< std::vector<gr::tag_t> >(3))
+	, d_trigger_tag_key(pmt::intern("buffer_start"))
+	, d_triggered(false)
+	, d_update_time(0.1 * gr::high_res_timer_tps())
+	, d_last_time(0)
+{
+	d_digital_buffer = static_cast<uint16_t*>(volk_malloc(d_buffer_size * sizeof(uint16_t), volk_get_alignment()));
+	memset(d_digital_buffer, 0, d_buffer_size * sizeof(uint16_t));
+
+	for (int i = 0; i < 2; ++i) {
+		d_analog_buffer.push_back(
+					static_cast<float*>(volk_malloc(d_buffer_size * sizeof(float), volk_get_alignment())));
+		memset(d_analog_buffer[i], 0, d_buffer_size * sizeof(float));
+
+		d_analog_plot_buffers.push_back(
+					static_cast<double*>(volk_malloc(d_buffer_size * sizeof(double), volk_get_alignment())));
+		memset(d_analog_plot_buffers[i], 0, d_buffer_size * sizeof(double));
+	}
+}
+
+int mixed_signal_sink_impl::work(int noutput_items,
+				 gr_vector_const_void_star &input_items,
+				 gr_vector_void_star &output_items)
+{
+	gr::thread::scoped_lock lock(d_setlock);
+
+	// space left in buffer
+	const int nfill = d_end - d_index;
+	// num items we can put in the buffer
+	const int nitems = std::min(noutput_items, nfill);
+
+	// look for trigger tag
+	_test_trigger_tags(nitems);
+
+	for (int i = 0; i < 2; ++i) {
+		const float *in = static_cast<const float*>(input_items[i]);
+		memcpy(&d_analog_buffer[i][d_index], in, sizeof(float) * nitems);
+	}
+
+	const uint16_t *in = static_cast<const uint16_t *>(input_items[2]);
+	memcpy(d_digital_buffer + d_index, in, sizeof(uint16_t) * nitems);
+
+	d_index += nitems;
+
+	if (d_triggered && (d_index == d_end) && d_end != 0) {
+		if (gr::high_res_timer_now() - d_last_time > d_update_time) {
+			d_last_time = gr::high_res_timer_now();
+
+			for (int i = 0; i < 2; ++i) {
+				volk_32f_convert_64f(d_analog_plot_buffers[i], &d_analog_buffer[i][d_start], d_size);
+			}
+
+			d_logic_analyzer->setData(d_digital_buffer + d_start, d_size);
+			qApp->postEvent(d_osc_plot,
+					new IdentifiableTimeUpdateEvent(d_analog_plot_buffers,
+									d_size,
+									d_tags,
+									"Osc Time"));
+		}
+
+		_reset();
+	}
+
+
+	if (d_index == d_end) {
+		_reset();
+	}
+
+	return nitems;
+}
+
+void mixed_signal_sink_impl::clean_buffers()
+{
+	gr::thread::scoped_lock lock(d_setlock);
+
+	memset(d_digital_buffer, 0, d_buffer_size * sizeof(uint16_t));
+
+	for (int i = 0; i < 2; ++i) {
+		memset(d_analog_buffer[i], 0, d_buffer_size * sizeof(float));
+		memset(d_analog_plot_buffers[i], 0, d_buffer_size * sizeof(double));
+	}
+
+	_reset();
+}
+
+void mixed_signal_sink_impl::set_nsamps(int newsize)
+{
+	if (newsize != d_size) {
+		gr::thread::scoped_lock lock(d_setlock);
+
+		// set new size
+		d_size = newsize;
+		d_buffer_size = 2 * d_size;
+
+		// free old buffers
+		volk_free(d_digital_buffer);
+		for (int i = 0; i < 2; ++i) {
+			volk_free(d_analog_buffer[i]);
+			volk_free(d_analog_plot_buffers[i]);
+
+		}
+		d_analog_buffer.clear();
+		d_analog_plot_buffers.clear();
+
+		// create new buffers
+		d_digital_buffer = static_cast<uint16_t*>(volk_malloc(d_buffer_size * sizeof(uint16_t), volk_get_alignment()));
+		memset(d_digital_buffer, 0, d_buffer_size * sizeof(uint16_t));
+
+		for (int i = 0; i < 2; ++i) {
+			d_analog_buffer.push_back(
+						static_cast<float*>(volk_malloc(d_buffer_size * sizeof(float), volk_get_alignment())));
+			memset(d_analog_buffer[i], 0, d_buffer_size * sizeof(float));
+			d_analog_plot_buffers.push_back(
+						static_cast<double*>(volk_malloc(d_buffer_size * sizeof(double), volk_get_alignment())));
+			memset(d_analog_plot_buffers[i], 0, d_buffer_size * sizeof(double));
+		}
+
+		_reset();
+	}
+}
+
+void mixed_signal_sink_impl::_adjust_tags(int adj)
+{
+	for (size_t n = 0; n < d_tags.size(); ++n) {
+		for (size_t t = 0; t < d_tags[n].size(); ++t) {
+			d_tags[n][t].offset += adj;
+		}
+	}
+}
+
+void mixed_signal_sink_impl::_test_trigger_tags(int nitems)
+{
+	int trigger_index;
+
+	uint64_t nr = nitems_read(0);
+	std::vector<gr::tag_t> tags;
+	get_tags_in_range(tags, 0, nr, nr + nitems + 1, d_trigger_tag_key);
+	if (tags.size() > 0) {
+		d_triggered = true;
+		trigger_index = tags[0].offset - nr;
+		d_start = d_index + trigger_index;
+		d_end = d_start + d_size;
+		_adjust_tags(-d_start);
+	}
+}
+
+void mixed_signal_sink_impl::_reset()
+{
+	for (int i = 0; i < d_tags.size(); ++i) {
+		d_tags[i].clear();
+	}
+
+	d_start = 0;
+	d_index = 0;
+	d_end = d_size;
+
+	d_triggered = false;
+}

--- a/src/mixed_signal_sink_impl.h
+++ b/src/mixed_signal_sink_impl.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIXED_SIGNAL_SINK_IMPL_H
+#define MIXED_SIGNAL_SINK_IMPL_H
+
+#include "mixed_signal_sink.h"
+
+class mixed_signal_sink_impl : public mixed_signal_sink
+{
+public:
+	mixed_signal_sink_impl(adiscope::logic::LogicAnalyzer *logicAnalyzer,
+			       adiscope::TimeDomainDisplayPlot *oscPlot,
+			       int bufferSize);
+	int work(int noutput_items,
+		 gr_vector_const_void_star &input_items,
+		 gr_vector_void_star &output_items) override;
+	void clean_buffers() override;
+	void set_nsamps(int newsize) override;
+
+private:
+	void _adjust_tags(int adj);
+	void _test_trigger_tags(int nitems);
+	void _reset();
+
+private:
+	adiscope::logic::LogicAnalyzer *d_logic_analyzer;
+	adiscope::TimeDomainDisplayPlot *d_osc_plot;
+
+	std::vector<float*> d_analog_buffer;
+	std::vector<double*> d_analog_plot_buffers;
+	uint16_t *d_digital_buffer;
+
+	int d_size;
+	int d_buffer_size;
+	int d_index;
+	int d_end;
+	int d_start;
+
+	std::vector< std::vector<gr::tag_t> > d_tags;
+	pmt::pmt_t d_trigger_tag_key;
+	bool d_triggered;
+
+	gr::high_res_timer_type d_update_time;
+	gr::high_res_timer_type d_last_time;
+};
+
+#endif // MIXED_SIGNAL_SINK_IMPL_H

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -63,6 +63,7 @@
 #include "filemanager.h"
 #include "scopyExceptionHandler.h"
 #include "oscilloscope_api.hpp"
+#include "mixed_signal_sink.h"
 
 #include "runsinglewidget.h"
 
@@ -78,6 +79,8 @@
 #include "ui_trigger_settings.h"
 
 #include <functional>
+
+#include <m2k/mixed_signal_source.h>
 
 #define MAX_MATH_CHANNELS 4
 #define MAX_MATH_RANGE SHRT_MAX
@@ -1284,52 +1287,41 @@ void Oscilloscope::setFilteringEnabled(bool set)
 
 void Oscilloscope::enableMixedSignalView()
 {
+	const bool iioStarted = isIioManagerStarted();
+	if (iioStarted) {
+		iio->lock();
+	}
+
 	m_mixedSignalViewEnabled = true;
 
-	m_mixedSignalViewMenu = m_logicAnalyzer->enableMixedSignalView(&plot,
-										    nb_channels + nb_math_channels + nb_ref_channels);
+	m_mixedSignalViewMenu = m_logicAnalyzer->enableMixedSignalView(&plot, nb_channels +
+								       nb_math_channels + nb_ref_channels);
 
-//	ui->logicSettingsWidget->addTab(m_mixedSignalViewMenu[0], "General");
-//	ui->logicSettingsWidget->addTab(m_mixedSignalViewMenu[1], "Channel");
 	ui->logicSettingsLayout->addWidget(m_mixedSignalViewMenu[0]);
 
+	mixed_sink = mixed_signal_sink::make(m_logicAnalyzer, &this->plot, active_sample_count);
+
+	mixed_source = gr::m2k::mixed_signal_source::make_from(m_m2k_context, active_sample_count);
+
+	if (iioStarted) {
+		// enable the mixed_source in the iio_manager
+		iio->enableMixedSignal(mixed_source);
+
+		boost::shared_ptr<adc_sample_conv> block = dynamic_pointer_cast<adc_sample_conv>(adc_samp_conv_block);
+
+		// connect analog
+		for (int i = 0; i < nb_channels; ++i) {
+			iio->disconnect(block, i, qt_time_block, i);
+			iio->connect(block, i, mixed_sink, i);
+		}
+
+		// connect digital
+		iio->connect(mixed_source, 2, mixed_sink, 2);
 
 
-	// configure flowgraph for logic acquisition
-	// soure block does not close context on ~destructor()
-	logic_top_block = gr::make_top_block("LA_MIXED");
-
-	logic_source = gr::m2k::digital_in_source::make_from(m_m2k_context,
-								 active_sample_count,
-								 0 /*not used*/,
-								 active_sample_rate,
-								 64,
-								 false,
-								 false);
-
-
-//	logic_source->set_sync_with_analog(true);
-
-	logic_sink = logic_analyzer_sink::make(m_logicAnalyzer, active_sample_count);
-//	logic_top_block->connect(logic_source, 0, logic_sink, 0);
-	iio->connect(logic_source, 0, logic_sink, 0);
-
-	boost::shared_ptr<adc_sample_conv> block =
-	dynamic_pointer_cast<adc_sample_conv>(
-					adc_samp_conv_block);
-
-	s2f = gr::blocks::short_to_float::make();
-	add = gr::blocks::add_ff::make();
-	nullSink = gr::blocks::null_sink::make(sizeof(float));
-
-	// hack #################
-	iio->connect(logic_source, 0, s2f, 0);
-	iio->connect(s2f, 0, add, 0);
-	iio->connect(block, 0, add, 1);
-	iio->connect(add, 0, nullSink, 0);
-	// hack #################
-
-//	m_m2k_context->startMixedSignalAcquisition(active_sample_count);
+		setDigitalPlotCurvesParams();
+		iio->unlock();
+	}
 }
 
 void Oscilloscope::disableMixedSignalView()
@@ -1348,35 +1340,26 @@ void Oscilloscope::disableMixedSignalView()
 
 	m_mixedSignalViewMenu[0]->deleteLater();
 
-	// clear gnuradio logic flowgraph
-	iio->disconnect(logic_source, 0, logic_sink, 0);
-
-	boost::shared_ptr<adc_sample_conv> block =
-	dynamic_pointer_cast<adc_sample_conv>(
-					adc_samp_conv_block);
-
-	// hack ###################################
-	iio->disconnect(logic_source, 0, s2f, 0);
-	iio->disconnect(s2f, 0, add, 0);
-	iio->disconnect(block, 0, add, 1);
-	iio->disconnect(add, 0, nullSink, 0);
-	// hack ###################################
-
-	logic_top_block->disconnect_all();
-	logic_top_block = nullptr;
-	logic_sink = nullptr;
-	logic_source = nullptr;
-
-	// remove widgets
-//	while (ui->logicSettingsLayout->count()) {
-//		auto item = ui->logicSettingsLayout->takeAt(0);
-//		if (item && item->widget()) {
-//			ui->logicSettingsLayout->removeWidget(item->widget());
-//		}
-//	}
 	if (iioStarted) {
+		// disable the mixed_source in the iio_manager
+		iio->disableMixedSignal(mixed_source);
+
+		boost::shared_ptr<adc_sample_conv> block = dynamic_pointer_cast<adc_sample_conv>(adc_samp_conv_block);
+
+		// disconnect analog
+		for (int i = 0; i < nb_channels; ++i) {
+			iio->disconnect(block, i, mixed_sink, i);
+			iio->connect(block, i, qt_time_block, i);
+		}
+
+		// disconnect digital
+		iio->disconnect(mixed_source, 2, mixed_sink, 2);
+
 		iio->unlock();
 	}
+
+	mixed_sink = nullptr;
+	mixed_source = nullptr;
 }
 
 void Oscilloscope::setDigitalPlotCurvesParams()
@@ -1390,7 +1373,7 @@ void Oscilloscope::setDigitalPlotCurvesParams()
 	for (int i = 0; i < plot.getNrDigitalPlotCurves(); ++i) {
 		QwtPlotCurve *curve = plot.getDigitalPlotCurve(i);
 		GenericLogicPlotCurve *logic_curve = dynamic_cast<GenericLogicPlotCurve *>(curve);
-		logic_curve->reset();
+//		logic_curve->reset();
 
 		logic_curve->setSampleRate(active_sample_rate);
 		logic_curve->setBufferSize(active_sample_count);
@@ -1581,8 +1564,8 @@ void Oscilloscope::activateAcCoupling(int i)
 		iio->set_buffer_size(ids[ch], active_sample_count);
 		dc_cancel.at(ch)->set_buffer_size(active_sample_count);
 	}
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 	if(started) {
@@ -1678,8 +1661,8 @@ void Oscilloscope::deactivateAcCoupling(int i)
 		iio->set_buffer_size(ids[ch], active_sample_count);
 		dc_cancel.at(ch)->set_buffer_size(active_sample_count);
 	}
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 
@@ -2630,31 +2613,26 @@ void Oscilloscope::toggle_blockchain_flow(bool en)
 {
 	if (en) {
 
-		if (logic_source) {
+		if (m_mixedSignalViewEnabled) {
+			// enable the mixed_source in the iio_manager
+			iio->enableMixedSignal(mixed_source);
+
+			boost::shared_ptr<adc_sample_conv> block = dynamic_pointer_cast<adc_sample_conv>(adc_samp_conv_block);
+
+			// connect analog
+			for (int i = 0; i < nb_channels; ++i) {
+				iio->disconnect(block, i, qt_time_block, i);
+				iio->connect(block, i, mixed_sink, i);
+			}
+
+			// connect digital
+			iio->connect(mixed_source, 2, mixed_sink, 2);
+
 			// set digital params; analog should be already set when this method is called
 			setDigitalPlotCurvesParams();
 
-			// clear data in sink blocks (analog + digital)
-			qt_time_block->clean_buffers();
-			qt_time_block->set_nsamps(active_sample_count);
-
-			logic_sink->clean_buffers();
-			logic_sink->set_nsamps(active_sample_count);
-
-			// flush device buffers
-//			m_m2k_digital->reset();
-//			m_m2k_analogin->reset();
-//			m_m2k_context->
-
-			// set kernel buffers
-			m_m2k_digital->setKernelBuffersCountIn(64);
-			m_m2k_analogin->setKernelBuffersCount(64);
-
-			// start mixed signal acquisition
-//			m_m2k_analogin->cancelAcquisition();
-//			m_m2k_analogin->stopAcquisition();
-//			m_m2k_context->stopMixedSignalAcquisition();
-			m_m2k_context->startMixedSignalAcquisition(active_sample_count);
+			mixed_sink->clean_buffers();
+			mixed_sink->set_nsamps(active_sample_count);
 		}
 
 		if (autosetRequested) {
@@ -2675,8 +2653,19 @@ void Oscilloscope::toggle_blockchain_flow(bool en)
 			iio->stop(autoset_id[0]);			
 		}
 
-		if (logic_source) {
-			m_m2k_context->stopMixedSignalAcquisition();
+		if (m_mixedSignalViewEnabled) {
+			iio->disableMixedSignal(mixed_source);
+
+			boost::shared_ptr<adc_sample_conv> block = dynamic_pointer_cast<adc_sample_conv>(adc_samp_conv_block);
+
+			// disconnect analog
+			for (int i = 0; i < nb_channels; ++i) {
+				iio->disconnect(block, i, mixed_sink, i);
+				iio->connect(block, i, qt_time_block, i);
+			}
+
+			// disconnect digital
+			iio->disconnect(mixed_source, 2, mixed_sink, 2);
 		}
 	}
 }
@@ -3351,8 +3340,8 @@ void Oscilloscope::onCmbMemoryDepthChanged(QString value)
 		iio->set_buffer_size(ids[i], active_sample_count);
 		dc_cancel.at(i)->set_buffer_size(active_sample_count);
 	}
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 
@@ -3475,8 +3464,8 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 		dc_cancel.at(i)->set_buffer_size(active_sample_count);
 	}
 
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 
@@ -3615,6 +3604,10 @@ void adiscope::Oscilloscope::onTimePositionChanged(double value)
 	if (started) {
 		trigger_settings.setTriggerDelay(active_trig_sample_count);
 		last_set_time_pos = active_time_pos;
+
+		if (mixed_source) {
+			setDigitalPlotCurvesParams();
+		}
 	}
 	updateBufferPreviewer();
 	if (reset_horiz_offset) {
@@ -3657,8 +3650,8 @@ void adiscope::Oscilloscope::onTimePositionChanged(double value)
 		iio->set_buffer_size(ids[i], active_sample_count);
 		dc_cancel.at(i)->set_buffer_size(active_sample_count);
 	}
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 
@@ -4543,8 +4536,8 @@ void Oscilloscope::setupAutosetFreqSweep()
 		iio->set_buffer_size(ids[i], autoset_fft_size);
 		dc_cancel.at(i)->set_buffer_size(active_sample_count);
 	}
-	if (logic_source) {
-		logic_source->set_buffer_size(active_sample_count);
+	if (mixed_source) {
+		mixed_source->set_buffer_size(active_sample_count);
 		setDigitalPlotCurvesParams();
 	}
 	if (keep_one) {
@@ -4624,7 +4617,7 @@ void Oscilloscope::requestAutoset()
 void Oscilloscope::periodicFlowRestart(bool force)
 {
 	static uint64_t restartFlowCounter = 0;
-	const uint64_t NO_FLOW_BUFFERS = 64;
+	const uint64_t NO_FLOW_BUFFERS = 1024;
 	if(force) {
 		restartFlowCounter = NO_FLOW_BUFFERS;
 	}
@@ -4634,8 +4627,8 @@ void Oscilloscope::periodicFlowRestart(bool force)
 		QElapsedTimer t;
 		t.start();
 		iio->lock();
-		m_m2k_context->stopMixedSignalAcquisition();
-		m_m2k_context->startMixedSignalAcquisition(active_sample_count);
+//		m_m2k_context->stopMixedSignalAcquisition();
+//		m_m2k_context->startMixedSignalAcquisition(active_sample_count);
 		iio->unlock();
 		qDebug(CAT_OSCILLOSCOPE)<<"Restarted flow @ " << QTime::currentTime().toString("hh:mm:ss") <<"restart took " << t.elapsed() << "ms";
 	}
@@ -4990,8 +4983,8 @@ void Oscilloscope::setAllSinksSampleCount(unsigned long sample_count)
 	this->qt_xy_block->set_nsamps(sample_count);
 	this->qt_hist_block->set_nsamps(sample_count);
 
-	if (logic_sink) {
-		logic_sink->set_nsamps(sample_count);
+	if (mixed_sink) {
+		mixed_sink->set_nsamps(sample_count);
 	}
 
 	auto it = math_sinks.constBegin();

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -77,6 +77,7 @@
 /* gr-m2k includes */
 #include <m2k/digital_in_source.h>
 #include "logic_analyzer_sink.h"
+#include "mixed_signal_sink.h"
 
 /*Generated UI */
 #include "ui_math_panel.h"
@@ -487,6 +488,9 @@ namespace adiscope {
 		gr::blocks::add_ff::sptr add;
 		gr::blocks::null_sink::sptr nullSink;
 		std::vector<QWidget *> m_mixedSignalViewMenu;
+
+		gr::m2k::mixed_signal_source::sptr mixed_source;
+		mixed_signal_sink::sptr mixed_sink;
 	};
 }
 #endif /* M2K_OSCILLOSCOPE_H */


### PR DESCRIPTION
- Fix the mixed acquisition (there should no longer be any desync)
- Add a mixed signal sink
- The iio_manager will be configured with the mixed sink when started from the oscilloscope with mixed signal enabled
- Stacked decoders are now available in the mixed signal view
- Crashes that occured in the mixed signal view were fixed, the tool should now be more stable


Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>