### PR TITLE
Appveyor MacOS: Update Qt to 5.15.1 for MacOS builds.

### DIFF
--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -16,16 +16,13 @@ BOOST_VERSION_FILE=1_65_1
 BOOST_VERSION=1.65.1
 
 PYTHON="python3"
-PACKAGES="pkg-config cmake fftw bison gettext autoconf automake libtool libzip glib libusb $PYTHON"
+PACKAGES=" qt pkg-config cmake fftw bison gettext autoconf automake libtool libzip glib libusb $PYTHON"
 PACKAGES="$PACKAGES glibmm doxygen wget gnu-sed libmatio dylibbundler libxml2"
 
 set -e
 cd ~
 WORKDIR=${PWD}
 NUM_JOBS=4
-
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8846805afc0cb8e5d114d5e222af1de3b35289df/Formula/qt.rb
-export PATH="/usr/local/opt/qt/bin:$PATH"
 
 brew_install_or_upgrade() {
 	brew install $1 || \


### PR DESCRIPTION
We locked the builds to Qt 5.14.2 because Qt introduced a bug in Qt 5.15.0,
related to QPushButtons. Installing an older Brew formula using the github
Formula file was deprecated in the last couple of days and stopped working
for our build. Building the desired 5.14.2 version from source would take
too much time and would fail on our Appveyor builds.
Fortunately, Brew added today the 5.15.1 Formula on the official
repositories, so we can now use this updated version (this version
introduces the QPushButton fix that we needed.)

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>