### PR TITLE
Logic fixes

### DIFF
--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -653,12 +653,17 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 
 	currentChannelMenuLayout->insertItem(-1, new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
+	tabWidget->addTab(channelEnumerator, "General");
+	const int channelMenuTabId = tabWidget->addTab(currentChannelMenuScrollArea, "Channel");
+
 	connect(m_oscPlot, &CapturePlot::channelSelected, [=](int chIdx, bool selected){
 		chIdx -= m_oscAnalogChannels;
 		if (m_oscChannelSelected != chIdx && selected) {
 			m_oscChannelSelected = chIdx;
 			nameLineEdit->setEnabled(true);
 			nameLineEdit->setText(m_oscPlotCurves[chIdx]->getName());
+
+			tabWidget->setCurrentIndex(channelMenuTabId);
 
 			if (m_oscChannelSelected < m_nbChannels) {
 				if (m_oscDecoderMenu) {

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -584,7 +584,7 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 		});
 
 		const int itemsInLayout = decoderEnumerator->count();
-		decoderEnumerator->addWidget(decoderMenuItem, itemsInLayout / 2, itemsInLayout / 2);
+		decoderEnumerator->addWidget(decoderMenuItem, itemsInLayout / 2, itemsInLayout % 2);
 
 		decoderComboBox->setCurrentIndex(0);
 

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -427,6 +427,7 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 	QVBoxLayout *decoderSettingsLayout = new QVBoxLayout();
 
 	QComboBox *stackDecoderComboBox = new QComboBox();
+	stackDecoderComboBox->setVisible(false);
 	auto updateButtonStackedDecoder = [=](){
 		if (m_oscChannelSelected < m_nbChannels) {
 			stackDecoderComboBox->setVisible(false);
@@ -595,9 +596,9 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 			m_oscPlot->replot();
 		});
 
-		int chId = m_oscPlotCurves.size() - 1 + m_oscAnalogChannels;
+		int chId = m_oscPlotCurves.size() - 1;
 
-		connect(curve, &AnnotationCurve::decoderMenuChanged, [&](){
+		connect(curve, &AnnotationCurve::decoderMenuChanged, [=](){
 			if (m_oscChannelSelected != chId) {
 				return;
 			}
@@ -726,6 +727,8 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 
 		m_oscDecoderMenu = curve->getCurrentDecoderStackMenu();
 		decoderSettingsLayout->addWidget(m_oscDecoderMenu);
+
+		updateButtonStackedDecoder();
 	});
 
 	currentChannelMenuScrollArea->setWidget(currentChannelMenu);

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -521,6 +521,10 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 			curve->dataAvailable(from, to);
 		}, Qt::DirectConnection);
 
+		connect(curve, &QObject::destroyed, [=](){
+			disconnect(connectionHandle);
+		});
+
 		g_slist_free(decoderList);
 
 		QSpacerItem *spacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -971,7 +971,7 @@ void LogicAnalyzer::on_btnGroupChannels_toggled(bool checked)
 		m_plot.beginGroupSelection();
 	} else {
 		if (m_plot.endGroupSelection()) {
-			channelSelectedChanged(m_selectedChannel, false);
+//			channelSelectedChanged(m_selectedChannel, false);
 		}
 	}
 }

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1983,6 +1983,14 @@ void Oscilloscope::create_add_channel_panel()
 	layout_logic->setContentsMargins(0,0,0,0);
 	layout_logic->insertWidget(1, labelWarningMixedSignal);
 
+	QLabel *infoLabel = new QLabel(tr("* When the Mixed Signal View is enabled the LogicAnalyzer tool will be disabled!\n"
+					  "** The trigger can be disabled or set only on the Digital channels or Analog channels, not on both at the same time!"));
+	infoLabel->setStyleSheet(QString::fromUtf8("color: white;"));
+	infoLabel->setWordWrap(true);
+	infoLabel->setVisible(true);
+
+	layout_logic->insertWidget(2, infoLabel);
+
 	QPushButton *btn = math_ui.btnAddChannel;
 
 	Math *math = new Math(nullptr, nb_channels);

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1322,6 +1322,8 @@ void Oscilloscope::enableMixedSignalView()
 		setDigitalPlotCurvesParams();
 		iio->unlock();
 	}
+
+	trigger_settings.enableMixedSignalView();
 }
 
 void Oscilloscope::disableMixedSignalView()
@@ -1360,6 +1362,8 @@ void Oscilloscope::disableMixedSignalView()
 
 	mixed_sink = nullptr;
 	mixed_source = nullptr;
+
+	trigger_settings.disaleMixedSignalView();
 }
 
 void Oscilloscope::setDigitalPlotCurvesParams()

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -1363,7 +1363,7 @@ void Oscilloscope::disableMixedSignalView()
 	mixed_sink = nullptr;
 	mixed_source = nullptr;
 
-	trigger_settings.disaleMixedSignalView();
+	trigger_settings.disableMixedSignalView();
 }
 
 void Oscilloscope::setDigitalPlotCurvesParams()

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -1734,6 +1734,9 @@ bool CapturePlot::endGroupSelection(bool moveAnnotationCurvesLast)
 		}
 	}
 
+	group.first()->setSelected(true);
+	group.first()->selected(true);
+
 	for (QwtPlotZoneItem *groupMarker : d_groupMarkers) {
 		groupMarker->detach();
 		delete groupMarker;

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -356,7 +356,7 @@ void PatternGenerator::on_btnGroupChannels_toggled(bool checked)
 		m_plot.beginGroupSelection();
 	} else {
 		if (m_plot.endGroupSelection(true)) {
-			channelSelectedChanged(m_selectedChannel, false);
+//			channelSelectedChanged(m_selectedChannel, false);
 			updateGroupsAndPatterns();
 		}
 	}

--- a/src/trigger_settings.cpp
+++ b/src/trigger_settings.cpp
@@ -168,6 +168,7 @@ TriggerSettings::TriggerSettings(M2kAnalogIn* libm2k_adc,
 	MouseWheelWidgetGuard *wheelEventGuard = new MouseWheelWidgetGuard(this);
 	wheelEventGuard->installEventRecursively(this);
 
+	ui->mixedSignalLbl->setVisible(false);
 }
 
 TriggerSettings::~TriggerSettings()
@@ -245,6 +246,20 @@ void TriggerSettings::setChannelAttenuation(double value)
 	m_displayScale = value;
 	trigger_hysteresis->setDisplayScale(value);
 	trigger_level->setDisplayScale(value);
+}
+
+void TriggerSettings::enableMixedSignalView()
+{
+	ui->extern_en->setDisabled(true);
+	ui->extern_to_en->setDisabled(true);
+	ui->mixedSignalLbl->setVisible(true);
+}
+
+void TriggerSettings::disaleMixedSignalView()
+{
+	ui->extern_en->setEnabled(true);
+	ui->extern_to_en->setEnabled(true);
+	ui->mixedSignalLbl->setVisible(false);
 }
 
 void TriggerSettings::setDcLevelCoupled(double value)

--- a/src/trigger_settings.cpp
+++ b/src/trigger_settings.cpp
@@ -255,7 +255,7 @@ void TriggerSettings::enableMixedSignalView()
 	ui->mixedSignalLbl->setVisible(true);
 }
 
-void TriggerSettings::disaleMixedSignalView()
+void TriggerSettings::disableMixedSignalView()
 {
 	ui->extern_en->setEnabled(true);
 	ui->extern_to_en->setEnabled(true);

--- a/src/trigger_settings.hpp
+++ b/src/trigger_settings.hpp
@@ -77,7 +77,7 @@ namespace adiscope {
 		void setChannelAttenuation(double value);
 
 		void enableMixedSignalView();
-		void disaleMixedSignalView();
+		void disableMixedSignalView();
 
 	Q_SIGNALS:
 		void sourceChanged(int);

--- a/src/trigger_settings.hpp
+++ b/src/trigger_settings.hpp
@@ -76,6 +76,9 @@ namespace adiscope {
 
 		void setChannelAttenuation(double value);
 
+		void enableMixedSignalView();
+		void disaleMixedSignalView();
+
 	Q_SIGNALS:
 		void sourceChanged(int);
 		void levelChanged(double);

--- a/ui/trigger_settings.ui
+++ b/ui/trigger_settings.ui
@@ -115,7 +115,7 @@
         <x>0</x>
         <y>0</y>
         <width>266</width>
-        <height>823</height>
+        <height>887</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -481,6 +481,19 @@ color: rgba(255,255,255,51);
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="mixedSignalLbl">
+         <property name="styleSheet">
+          <string notr="true">color: white;</string>
+         </property>
+         <property name="text">
+          <string>This feature is not supported while the Mixed Signal View is enabled!</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -924,6 +937,7 @@ color: rgba(255,255,255,51);
       <zorder>verticalSpacer_3</zorder>
       <zorder></zorder>
       <zorder>trigger_logic_controls</zorder>
+      <zorder>mixedSignalLbl</zorder>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
1. fixes regarding crashes when disabling the mixed signal view
2. when a new group is created select the first channel in it
3. fix the position on decoders in the mixed signal view menu
4. add information about how mixed signal view affects scopy when enabled
5. disable some trigger settings that won't work with the mixed signal view
6. make sure the stacked decoder button is correctly shown and set