### PR TITLE
Fix issues related to exception handling while unplugging the board.

### DIFF
--- a/src/calibration.cpp
+++ b/src/calibration.cpp
@@ -20,6 +20,7 @@
 
 #include "logging_categories.h"
 #include "calibration.hpp"
+#include <libm2k/m2kexceptions.hpp>
 
 #include <errno.h>
 #include <QDebug>
@@ -94,10 +95,21 @@ bool Calibration::calibrateAll()
 	}
 
 	bool ok = false;
-	ok = m_m2k->calibrateADC();
+	try {
+		ok = m_m2k->calibrateADC();
+	} catch (libm2k::m2k_exception &e) {
+		qDebug(CAT_CALIBRATION) << e.what();
+		ok = false;
+	}
 	if(!ok || m_cancel)
 		goto calibration_fail;
-	ok = m_m2k->calibrateDAC();
+
+	try {
+		ok = m_m2k->calibrateDAC();
+	} catch (libm2k::m2k_exception &e) {
+		qDebug(CAT_CALIBRATION) << e.what();
+		ok = false;
+	}
 	if(!ok || m_cancel)
 		goto calibration_fail;
 

--- a/src/iio_manager.hpp
+++ b/src/iio_manager.hpp
@@ -56,6 +56,12 @@ namespace adiscope {
 		const unsigned id;
 
 		/* Get a shared pointer to the instance of iio_manager that
+		 * manages the requested device if there is one.
+		 * Return a NULL pointer if there is no instance yet.
+		 */
+		static boost::shared_ptr<iio_manager> has_instance(const std::string &_dev);
+
+		/* Get a shared pointer to the instance of iio_manager that
 		 * manages the requested device */
 		static boost::shared_ptr<iio_manager> get_instance(
 				struct iio_context *ctx,

--- a/src/power_controller.cpp
+++ b/src/power_controller.cpp
@@ -52,6 +52,8 @@ PowerController::PowerController(struct iio_context *ctx,
 	ui->setupUi(this);
 
 	try {
+		m_m2k_powersupply->enableChannel(0, false);
+		m_m2k_powersupply->enableChannel(1, false);
 		m_m2k_powersupply->pushChannel(0, 0.0);
 		m_m2k_powersupply->pushChannel(1, 0.0);
 	} catch (libm2k::m2k_exception &e) {

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -1217,6 +1217,9 @@ void SpectrumAnalyzer::on_comboBox_type_currentIndexChanged(const QString& s)
 	}
 
 	const bool visible = ((*it).second != FftDisplayPlot::AverageType::SAMPLE);
+	if (!visible) {
+		ui->spinBox_averaging->setValue(1);
+	}
 	ui->spinBox_averaging->setVisible(visible);
 	ui->label_averaging->setVisible(visible);
 

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1036,8 +1036,10 @@ void adiscope::ToolLauncher::disconnect()
 			calib->cancelCalibration();
 			calibration_thread.waitForFinished();
 		}
-		auto iio=iio_manager::get_instance(ctx,filter->device_name(TOOL_DMM));
-		iio->stop_all();
+		auto iio = iio_manager::has_instance(filter->device_name(TOOL_DMM));
+		if (iio) {
+			iio->stop_all();
+		}
 		alive_timer->stop();
 
 		ui->saveBtn->parentWidget()->setEnabled(false);

--- a/src/tool_launcher.hpp
+++ b/src/tool_launcher.hpp
@@ -260,6 +260,8 @@ private:
 
 	bool m_useNativeDialogs;
 
+	bool m_dac_tools_failed, m_adc_tools_failed;
+
 	void _setupToolMenu();
 	void saveRunningToolsBeforeCalibration();
 	void stopToolsBeforeCalibration();

--- a/src/toolmenuitem.cpp
+++ b/src/toolmenuitem.cpp
@@ -121,6 +121,15 @@ bool ToolMenuItem::eventFilter(QObject *watched, QEvent *event)
 	return QObject::event(event);
 }
 
+void ToolMenuItem::setCalibrating(bool calibrating)
+{
+	if (calibrating) {
+		d_toolBtn->setText(tr("Calibrating..."));
+	} else {
+		d_toolBtn->setText(d_name);
+	}
+}
+
 void ToolMenuItem::setDisabled(bool disabled)
 {
 	BaseMenuItem::setDisabled(disabled);

--- a/src/toolmenuitem.h
+++ b/src/toolmenuitem.h
@@ -44,6 +44,8 @@ public:
 
 	bool eventFilter(QObject *watched, QEvent *event);
 
+	void setCalibrating(bool calibrating);
+
 Q_SIGNALS:
 	void detach();
 	void toggleButtonGroup(bool);


### PR DESCRIPTION
- Unplugging the board during the calibration should not crash the app, even if the calibration is throwing exceptions. We handle those and disconnect without errors.
- Unplugging the board during the tool construction should not crash the app, even if the constructors are throwing exceptions. We handle those in the Tool Launcher and disconnect without errors.
- We should not suppose that the calibration and connection were done well and all the tools are available from that point on.

- Make sure the Power Supplies are not ON when first connecting to a board.
- Don't use averaging in the "Sample" Type for Spectrum Analyzer.