### PR TITLE
Preferences: initialize sig_gen_nr_of_periods to 1

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -38,7 +38,7 @@ using namespace adiscope;
 Preferences::Preferences(QWidget *parent) :
 	QWidget(parent),
 	ui(new Ui::Preferences),
-	sig_gen_periods_nr(2),
+	sig_gen_periods_nr(1),
 	save_session_on_exit(true),
 	double_click_to_detach(false),
 	pref_api(new Preferences_API(this)),


### PR DESCRIPTION
I missed this initialization when implementing https://github.com/analogdevicesinc/scopy/pull/833
Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>