### PR TITLE
appveyor: Use the old deps archive provided by scopy-mingw-build-deps

### DIFF
--- a/CI/appveyor/extract_msys_deps.sh
+++ b/CI/appveyor/extract_msys_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash.exe
+
+SCOPY_MINGW_BUILD_DEPS_FORK=analogdevicesinc
+SCOPY_MINGW_BUILD_DEPS_BRANCH=test-mirrors	#TODO: change before merging to master;
+
+echo "Download pre-downloaded MSYS2 libraries with required versions... "
+wget "https://ci.appveyor.com/api/projects/$SCOPY_MINGW_BUILD_DEPS_FORK/scopy-mingw-build-deps/artifacts/old-msys-build-deps-$MINGW_VERSION.tar.xz?branch=$SCOPY_MINGW_BUILD_DEPS_BRANCH&job=Environment: MINGW_VERSION=$MINGW_VERSION, ARCH=$ARCH" -O /tmp/old-msys-build-deps-$MINGW_VERSION.tar.xz
+cd /c
+tar xvf /tmp/old-msys-build-deps-$MINGW_VERSION.tar.xz

--- a/CI/appveyor/install_msys_deps.sh
+++ b/CI/appveyor/install_msys_deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash.exe
 
 SCOPY_MINGW_BUILD_DEPS_FORK=analogdevicesinc
-SCOPY_MINGW_BUILD_DEPS_BRANCH=master
+SCOPY_MINGW_BUILD_DEPS_BRANCH=test-mirrors #TODO: change before merging to master;
 
 echo "Download and install pre-compiled libraries ... "
 wget "https://ci.appveyor.com/api/projects/$SCOPY_MINGW_BUILD_DEPS_FORK/scopy-mingw-build-deps/artifacts/scopy-$MINGW_VERSION-build-deps-pacman.txt?branch=$SCOPY_MINGW_BUILD_DEPS_BRANCH&job=Environment: MINGW_VERSION=$MINGW_VERSION, ARCH=$ARCH" -O /tmp/scopy-$MINGW_VERSION-build-deps-pacman.txt
@@ -16,10 +16,10 @@ PACMAN_SYNC_DEPS="
 "
 
 PACMAN_REPO_DEPS="
-	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-breakpad-git-r1680.70914b2d-1-any.pkg.tar.xz \
-	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
-	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
-	http://repo.msys2.org/mingw/$ARCH/mingw-w64-$ARCH-qt5-5.14.2-3-any.pkg.tar.zst \
+	/c/old_msys_deps_$MINGW_VERSION/mingw-w64-$ARCH-breakpad-git-r1680.70914b2d-1-any.pkg.tar.xz \
+	/c/old_msys_deps_$MINGW_VERSION/mingw-w64-$ARCH-libusb-1.0.21-2-any.pkg.tar.xz \
+	/c/old_msys_deps_$MINGW_VERSION/mingw-w64-$ARCH-boost-1.72.0-3-any.pkg.tar.zst \
+	/c/old_msys_deps_$MINGW_VERSION/mingw-w64-$ARCH-qt5-5.14.2-3-any.pkg.tar.zst \
 "
 
 PATH=/c/msys64/$MINGW_VERSION/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,21 +58,18 @@ environment:
 #          PACKAGE_CMD: ""
 #          DEPLOY_FILE: "/home/appveyor/projects/scopy/Scopy.flatpak"
 
-
-matrix:
-    fast_finish: true
-
 install:
     # Install Inno Setup
     - cmd: choco install InnoSetup
 
 build_script:
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz"
-    - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-    - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
+    - cmd: C:\msys64\usr\bin\bash -lc "/c/projects/scopy/CI/appveyor/extract_msys_deps.sh"
+    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U /c/old_msys_deps_$MINGW_VERSION/pacman-5.2.2-1-x86_64.pkg.tar.xz"
+ #   - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+ #   - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+    - cmd: C:\msys64\usr\bin\bash -lc "cd /c/old_msys_deps_$MINGW_VERSION; pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
     - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --populate"
-    - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+    - cmd: C:\msys64\usr\bin\bash -lc "cd /c/old_msys_deps_$MINGW_VERSION; pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
     - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     - cmd: set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 5"
     - cmd: "%BUILD_DEPS_CMD%"


### PR DESCRIPTION
Use the old deps archive provided by scopy-mingw-build-deps instead of trying to get packages from repo.msys2.org.

Some older packages might be removed from the official repo. Using this
change, we don't depend on that official repo to build our application.

Also, remove the fast_finish flag, we want to use the MacOS builds whether
the Mingw build fails or not.

- [x] Wait for the scopy-mingw-build-deps build to be done, in order to test Scopy. ( https://ci.appveyor.com/project/analogdevicesinc/scopy-mingw-build-deps/builds/35695184 )