### PR TITLE
WindowsInstaller: Use "Tasks" to create checkbox that deletes Scopy.ini.

### DIFF
--- a/CI/appveyor/build_appveyor_mingw.sh
+++ b/CI/appveyor/build_appveyor_mingw.sh
@@ -80,8 +80,6 @@ mv /c/$DEST_FOLDER/Scopy.exe.sym /c/$DEBUG_FOLDER
 mv /c/$DEST_FOLDER/.debug /c/$DEBUG_FOLDER
 
 echo "### Creating archives ... "
-# Create empty ini file for overwrite in setup
-touch /c/$DEST_FOLDER/Scopy.ini
 7z a "/c/scopy-${ARCH_BIT}bit.zip" /c/$DEST_FOLDER
 # appveyor PushArtifact /c/scopy-${ARCH_BIT}bit.zip
 7z a "/c/debug-${ARCH_BIT}bit.zip" /c/$DEBUG_FOLDER

--- a/scopy-32.iss.cmakein
+++ b/scopy-32.iss.cmakein
@@ -55,38 +55,15 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+Name: "deleteini"; Description: Delete previous settings (Scopy.ini)
 
 [Files]
 Source: "c:\scopy_32\*"; DestDir: "{app}"; Check: not Is64BitInstallMode; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\scopy_32\Scopy.ini"; DestDir: "{userappdata}\ADI"; Check: DeleteIniFile;
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
-[Code]
-var
-  DeleteIniCheckBox: TNewCheckBox;
-
-procedure InitializeWizard;
-var
-  MainPage: TWizardPage;
-begin
-  MainPage := PageFromId(wpSelectDir)//CreateCustomPage(wpWelcome, '', '');
-  DeleteIniCheckBox := TNewCheckBox.Create(MainPage);
-  DeleteIniCheckBox.Checked := True;
-  DeleteIniCheckBox.Parent := MainPage.Surface;
-  DeleteIniCheckBox.Top := 195
-  DeleteIniCheckBox.Left := 0
-  DeleteIniCheckBox.Width := 200
-  DeleteIniCheckBox.Caption := 'Delete previous settings (Scopy.ini)';
-end;
-
-function DeleteIniFile: Boolean;
-begin
-  { here is the Check function used above; if you return True to this }
-  { function, the file will be installed, when False, the file won't }
-  { be installed }
-  Result := DeleteIniCheckBox.Checked;
-end;
+[InstallDelete]
+Type: files; Name: "{userappdata}\ADI\Scopy.ini"; Tasks: deleteini

--- a/scopy-64.iss.cmakein
+++ b/scopy-64.iss.cmakein
@@ -55,38 +55,15 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+Name: "deleteini"; Description: Delete previous settings (Scopy.ini)
 
 [Files]
 Source: "c:\scopy_64\*"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\scopy_64\Scopy.ini"; DestDir: "{userappdata}\ADI"; Check: DeleteIniFile;
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
-[Code]
-var
-  DeleteIniCheckBox: TNewCheckBox;
-
-procedure InitializeWizard;
-var
-  MainPage: TWizardPage;
-begin
-  MainPage := PageFromId(wpSelectDir)//CreateCustomPage(wpWelcome, '', '');
-  DeleteIniCheckBox := TNewCheckBox.Create(MainPage);
-  DeleteIniCheckBox.Checked := True;
-  DeleteIniCheckBox.Parent := MainPage.Surface;
-  DeleteIniCheckBox.Top := 195
-  DeleteIniCheckBox.Left := 0
-  DeleteIniCheckBox.Width := 200
-  DeleteIniCheckBox.Caption := 'Delete previous settings (Scopy.ini)';
-end;
-
-function DeleteIniFile: Boolean;
-begin
-  { here is the Check function used above; if you return True to this }
-  { function, the file will be installed, when False, the file won't }
-  { be installed }
-  Result := DeleteIniCheckBox.Checked;
-end;
+[InstallDelete]
+Type: files; Name: "{userappdata}\ADI\Scopy.ini"; Tasks: deleteini

--- a/scopy.iss.cmakein
+++ b/scopy.iss.cmakein
@@ -55,39 +55,16 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+Name: "deleteini"; Description: Delete previous settings (Scopy.ini)
 
 [Files]
 Source: "c:\scopy_32\*"; DestDir: "{app}"; Check: not Is64BitInstallMode; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "c:\scopy_64\*"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\scopy_64\Scopy.ini"; DestDir: "{userappdata}\ADI"; Check: DeleteIniFile;
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
-[Code]
-var
-  DeleteIniCheckBox: TNewCheckBox;
-
-procedure InitializeWizard;
-var
-  MainPage: TWizardPage;
-begin
-  MainPage := PageFromId(wpSelectDir)//CreateCustomPage(wpWelcome, '', '');
-  DeleteIniCheckBox := TNewCheckBox.Create(MainPage);
-  DeleteIniCheckBox.Checked := True;
-  DeleteIniCheckBox.Parent := MainPage.Surface;
-  DeleteIniCheckBox.Top := 195
-  DeleteIniCheckBox.Left := 0
-  DeleteIniCheckBox.Width := 200
-  DeleteIniCheckBox.Caption := 'Delete previous settings (Scopy.ini)';
-end;
-
-function DeleteIniFile: Boolean;
-begin
-  { here is the Check function used above; if you return True to this }
-  { function, the file will be installed, when False, the file won't }
-  { be installed }
-  Result := DeleteIniCheckBox.Checked;
-end;
+[InstallDelete]
+Type: files; Name: "{userappdata}\ADI\Scopy.ini"; Tasks: deleteini


### PR DESCRIPTION
The checkbox for a task is checked by default, so we don't need to specify
another flag.
Also, the Appveyor job no longer needs to export an empty Scopy.ini.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>