### PR TITLE
Appveyor: Use mingw64/bin/windres as RC compiler for 64 bit.

### DIFF
--- a/CI/appveyor/build_appveyor_mingw.sh
+++ b/CI/appveyor/build_appveyor_mingw.sh
@@ -5,6 +5,8 @@ set -e
 export PATH=/bin:/usr/bin:/${MINGW_VERSION}/bin:/c/Program\ Files/Git/cmd:/c/Windows/System32:/c/Program\ Files/7-Zip:/c/Program\ Files\ \(x86\)/Inno\ Setup\ \5:/c/Program\ Files/Appveyor/BuildAgent
 echo $PATH
 
+RC_COMPILER_OPT="-DCMAKE_RC_COMPILER=/c/msys64/${MINGW_VERSION}/bin/windres.exe"
+
 WORKDIR=${PWD}
 echo BUILD_NO $BUILD_NO
 JOBS=$(nproc)


### PR DESCRIPTION
Appveyor build failed because the RC compiler detection failed.
This might be caused by the CMake package update (checked repo.msys2.org and the update was done 2 days ago, when the builds started failing).
CMake does not detect an appropriate compiler for RC, so we point it to the right path.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>