### PR TITLE
SaveRestoreToolSettings: drop usage of Q_DISABLE_COPY_MOVE macro

### DIFF
--- a/src/saverestoretoolsettings.h
+++ b/src/saverestoretoolsettings.h
@@ -9,7 +9,11 @@
 namespace adiscope {
 class SaveRestoreToolSettings
 {
-	Q_DISABLE_COPY_MOVE(SaveRestoreToolSettings)
+	SaveRestoreToolSettings(const SaveRestoreToolSettings &) = delete;
+	SaveRestoreToolSettings &operator=(const SaveRestoreToolSettings &) = delete;
+
+	SaveRestoreToolSettings(SaveRestoreToolSettings &&) = delete;
+	SaveRestoreToolSettings &operator=(SaveRestoreToolSettings &&) = delete;
 public:
 	SaveRestoreToolSettings(Tool *tool);
 	~SaveRestoreToolSettings();


### PR DESCRIPTION
This macro was only introduced in QT 5.13. Manually write the delete copy constructor/assignment and move constructor/assignment so we don't force the usage of Qt 5.13

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>