### PR TITLE
debugger.cpp: Change the comparison for channel sorting using std::sort.

### DIFF
--- a/src/debugger.cpp
+++ b/src/debugger.cpp
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "utils.h"
 #include "debugger.h"
 #include "ui_debugger.h"
 #include <QDebug>
@@ -104,7 +105,10 @@ void Debugger::updateChannelComboBox(QString devName)
 		channels.append(QString("None"));
 	}
 
-	std::sort(channels.begin(), channels.end(), std::less_equal<QString>());
+	std::sort(channels.begin(), channels.end(), [](QString a, QString b) {
+		return Util::compareNatural(a.toStdString(), b.toStdString());
+	});
+
 	ui->ChannelComboBox->addItems(channels);
 
 	updateAttributeComboBox(ui->ChannelComboBox->currentText());

--- a/src/qtgui_util.cc
+++ b/src/qtgui_util.cc
@@ -40,6 +40,9 @@
  */
 
 #include "utils.h"
+#include <sstream>
+#include <string>
+#include <algorithm>
 #include <QDebug>
 #include <QSizePolicy>
 
@@ -130,5 +133,40 @@ QString Util::loadStylesheetFromFile(const QString &path)
 	file.open(QFile::ReadOnly);
 	QString stylesheet = QString::fromLatin1(file.readAll());
 	return stylesheet;
+}
+
+bool Util::compareNatural(const std::string& a, const std::string& b) {
+	if (a == b) {
+		return (a < b);
+	} else if (a.empty()) {
+		return true;
+	} else if (b.empty()) {
+		return false;
+	} else if (std::isdigit(a[0]) && !std::isdigit(b[0])) {
+		return true;
+	} else if (!std::isdigit(a[0]) && std::isdigit(b[0])) {
+		return false;
+	} else if (!std::isdigit(a[0]) && !std::isdigit(b[0])) {
+		if (a[0] == b[0]) {
+			return compareNatural(a.substr(1), b.substr(1));
+		}
+		return (a < b);
+	}
+
+	std::istringstream string_stream_a(a);
+	std::istringstream string_stream_b(b);
+
+	int int_a, int_b;
+	std::string a_new, b_new;
+
+	string_stream_a >> int_a;
+	string_stream_b >> int_b;
+	if (int_a != int_b) {
+		return (int_a < int_b);
+	}
+
+	std::getline(string_stream_a, a_new);
+	std::getline(string_stream_b, b_new);
+	return (compareNatural(a_new, b_new));
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -61,6 +61,7 @@ public:
 	static void retainWidgetSizeWhenHidden(QWidget *w, bool retain = true);
 	static void setWidgetNrOfChars(QWidget *w, int minNrOfChars, int maxNrOfChars=0);
 	static QString loadStylesheetFromFile(const QString &path);
+	static bool compareNatural(const std::string &a, const std::string &b);
 };
 
 #endif /* M2K_UTILS_H */


### PR DESCRIPTION
From the docs: The comparison predicate must define a strict weak ordering.
This fixes an issue/crash that only appeared on MacOS due to libc++
in LLVM - which compares an element with itself.
We now use a function to compare strings naturally.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>