### PR TITLE
phonehome: fix phonehome firmware label

### DIFF
--- a/src/info_page.cpp
+++ b/src/info_page.cpp
@@ -63,20 +63,6 @@ InfoPage::InfoPage(QString uri, Preferences *pref, PhoneHome* phoneHome,
 		this, SLOT(ledTimeout()));
 	connect(m_blink_timer, SIGNAL(timeout()),
 		this, SLOT(blinkTimeout()));
-	connect(m_phoneHome, &PhoneHome::m2kVersionChanged, this, [=] {
-		const int checked = dynamic_cast<M2kInfoPage*>(this)->checkLatestFwVersion(m_info_params.value("Firmware version"));
-		if (checked == 1) {
-			ui->lblFirmware->setText("Firmware is up to date!");
-		} else if (checked == 0) {
-			const QString message = "New firmware version is available. "
-							  "Download " + m_phoneHome->getM2kVersion() + " "
-							  "<a href=\"";
-			ui->lblFirmware->setText(message + m_phoneHome->getM2kLink() + "\">here</a>");
-			ui->lblFirmware->setTextFormat(Qt::RichText);
-			ui->lblFirmware->setTextInteractionFlags(Qt::TextBrowserInteraction);
-			ui->lblFirmware->setOpenExternalLinks(true);
-		}
-	});
 	readPreferences();
 	setStatusLabel(ui->lblCalibrationInfo);
 	setStatusLabel(ui->lblCalibrationStatus);
@@ -248,6 +234,23 @@ void InfoPage::refreshInfoWidget()
 		setStatusLabel(ui->lblIdentifyStatus);
 	else
 		setStatusLabel(ui->lblIdentifyStatus, tr("Your hardware revision does not support the identify feature"));
+
+	if(m_phoneHome->getDone())
+	{
+		const int checked = dynamic_cast<M2kInfoPage*>(this)->checkLatestFwVersion(m_info_params.value("Firmware version"));
+		if (checked == 1) {
+			ui->lblFirmware->setText(tr("Firmware is up to date!"));
+		} else if (checked == 0) {
+			const QString message = tr("New firmware version is available. ") +
+							  "Download " + m_phoneHome->getM2kVersion() + " "
+							  "<a href=\"";
+			ui->lblFirmware->setText(message + m_phoneHome->getM2kLink() + "\">here</a>");
+			ui->lblFirmware->setTextFormat(Qt::RichText);
+			ui->lblFirmware->setTextInteractionFlags(Qt::TextBrowserInteraction);
+			ui->lblFirmware->setOpenExternalLinks(true);
+		}
+	}
+
 
 	if(supportsCalibration())
 		ui->btnCalibrate->setVisible(true);

--- a/src/phonehome.cpp
+++ b/src/phonehome.cpp
@@ -25,9 +25,14 @@
 
 using namespace adiscope;
 
+bool PhoneHome::getDone() const
+{
+	return done;
+}
+
 PhoneHome::PhoneHome(QSettings *settings, Preferences *pref) :
 	ApiObject(), m_timestamp(0), m_versionsJson(""),
-	preferences(pref), settings(settings)
+	preferences(pref), settings(settings), done(false)
 {
 	setObjectName("phonehome");
 	load(*settings);
@@ -73,8 +78,10 @@ void PhoneHome::extractVersionStringsFromJson(const QJsonDocument &doc)
 	m_m2kVersion = content["m2k-fw"].toMap()["version"].toString();
 	m_scopyLink = content["scopy"].toMap()["link"].toString();
 	m_m2kLink = content["m2k-fw"].toMap()["link"].toString();
+	done = true;
 	Q_EMIT scopyVersionChanged();
 	Q_EMIT m2kVersionChanged();
+
 }
 
 void PhoneHome::onVersionsRequestFinished(QNetworkReply* reply)

--- a/src/phonehome.h
+++ b/src/phonehome.h
@@ -43,6 +43,7 @@ private:
 	PhoneHome* instance;
 	Preferences* preferences;
 	QSettings *settings;
+	bool done;
 
 
 	Q_PROPERTY(QString timestamp READ getTimestamp WRITE setTimestamp)
@@ -62,6 +63,7 @@ public:
 	void setTimestamp(QString);
 	QString getVersionsJson() const;
 	void setVersionsJson(const QString &val);
+	bool getDone() const;
 
 Q_SIGNALS:
 	void scopyVersionCheckRequested();


### PR DESCRIPTION
The phonehome firmware label was updated before actually getting firmware
information from the board, causing it to always return firmware update
required

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>