### PR TITLE
LogicAnalyzer: fix bug when closing scopy while logic is running

### DIFF
--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -260,17 +260,17 @@ LogicAnalyzer::~LogicAnalyzer()
 
 	disconnect(prefPanel, &Preferences::notify, this, &LogicAnalyzer::readPreferences);
 
-	for (auto &curve : m_plotCurves) {
-		m_plot.removeDigitalPlotCurve(curve);
-		delete curve;
-	}
-
 	if (m_captureThread) {
 		m_stopRequested = true;
 		m_m2kDigital->cancelAcquisition();
 		m_captureThread->join();
 		delete m_captureThread;
 		m_captureThread = nullptr;
+	}
+
+	for (auto &curve : m_plotCurves) {
+		m_plot.removeDigitalPlotCurve(curve);
+		delete curve;
 	}
 
 	if (m_buffer) {


### PR DESCRIPTION
Make sure to delete the plot curves after closing the capture thread, otherwise while the thread is being stopped it might emit that new data is available to some curves that are deleted, resulting in a segfault

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>