### PR TITLE
InfoPage: M2kInfoPage specific methods should only be called from M2k…

### DIFF
--- a/src/info_page.cpp
+++ b/src/info_page.cpp
@@ -235,23 +235,6 @@ void InfoPage::refreshInfoWidget()
 	else
 		setStatusLabel(ui->lblIdentifyStatus, tr("Your hardware revision does not support the identify feature"));
 
-	if(m_phoneHome->getDone())
-	{
-		const int checked = dynamic_cast<M2kInfoPage*>(this)->checkLatestFwVersion(m_info_params.value("Firmware version"));
-		if (checked == 1) {
-			ui->lblFirmware->setText(tr("Firmware is up to date!"));
-		} else if (checked == 0) {
-			const QString message = tr("New firmware version is available. ") +
-							  "Download " + m_phoneHome->getM2kVersion() + " "
-							  "<a href=\"";
-			ui->lblFirmware->setText(message + m_phoneHome->getM2kLink() + "\">here</a>");
-			ui->lblFirmware->setTextFormat(Qt::RichText);
-			ui->lblFirmware->setTextInteractionFlags(Qt::TextBrowserInteraction);
-			ui->lblFirmware->setOpenExternalLinks(true);
-		}
-	}
-
-
 	if(supportsCalibration())
 		ui->btnCalibrate->setVisible(true);
 
@@ -455,9 +438,29 @@ M2kInfoPage::~M2kInfoPage()
 
 }
 
+
+void M2kInfoPage::updateFwVersionWidget() {
+	if(m_phoneHome->getDone())
+	{
+		const int checked = this->checkLatestFwVersion(m_info_params.value("Firmware version"));
+		if (checked == 1) {
+			ui->lblFirmware->setText(tr("Firmware is up to date!"));
+		} else if (checked == 0) {
+			const QString message = tr("New firmware version is available. ") +
+							  "Download " + m_phoneHome->getM2kVersion() + " "
+							  "<a href=\"";
+			ui->lblFirmware->setText(message + m_phoneHome->getM2kLink() + "\">here</a>");
+			ui->lblFirmware->setTextFormat(Qt::RichText);
+			ui->lblFirmware->setTextInteractionFlags(Qt::TextBrowserInteraction);
+			ui->lblFirmware->setOpenExternalLinks(true);
+		}
+	}
+}
+
 void M2kInfoPage::getDeviceInfo()
 {
 	InfoPage::getDeviceInfo();
+	updateFwVersionWidget();
 	refreshTemperature();
 }
 

--- a/src/info_page.hpp
+++ b/src/info_page.hpp
@@ -131,6 +131,7 @@ public:
 	~M2kInfoPage();
 
 	void getDeviceInfo() override;
+	void updateFwVersionWidget();
 	void setCtx(iio_context *ctx) override;
 	int checkLatestFwVersion(const QString &currentVersion) const;
 


### PR DESCRIPTION
…InfoPage objects

This caused a bug that crashes Scopy when connecting non-m2k devices.
When connecting M2k, InfoPage gets constructed first, and eventually
M2kInfoPage, however InfoPage cannot be dynamically cast to M2kInfoPage
before construction when calling dynamic_cast<M2kInfoPage*>

Simplified whole process by moving firmware check to M2kInfoPage only

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>