### PR TITLE
Appveyor: fix MacOS job

### DIFF
--- a/CI/appveyor/build_appveyor_macos.sh
+++ b/CI/appveyor/build_appveyor_macos.sh
@@ -10,7 +10,7 @@ if [ -f /opt/qt59/bin/qt59-env.sh ] ; then
 fi
 
 if command -v brew ; then
-	QT_PATH="$(brew --prefix qt)/bin"
+	QT_PATH="$(brew --prefix ${QT_FORMULAE})/bin"
 	export PATH="${QT_PATH}:$PATH"
 fi
 

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -16,7 +16,7 @@ BOOST_VERSION_FILE=1_73_0
 BOOST_VERSION=1.73.0
 
 PYTHON="python3"
-PACKAGES=" qt pkg-config cmake fftw bison gettext autoconf automake libtool libzip glib libusb glog $PYTHON"
+PACKAGES=" ${QT_FORMULAE} pkg-config cmake fftw bison gettext autoconf automake libtool libzip glib libusb glog $PYTHON"
 PACKAGES="$PACKAGES doxygen wget gnu-sed libmatio dylibbundler libxml2"
 
 set -e
@@ -48,7 +48,8 @@ pip3 install mako six
 pwd
 source ./projects/scopy/CI/appveyor/before_install_lib.sh
 
-QT_PATH="$(brew --prefix qt)/bin"
+QT_PATH="$(brew --prefix ${QT_FORMULAE})/bin"
+
 export PATH="/usr/local/bin:$PATH"
 export PATH="/usr/local/opt/bison/bin:$PATH"
 export PATH="${QT_PATH}:$PATH"

--- a/CI/appveyor/package_darwin.sh
+++ b/CI/appveyor/package_darwin.sh
@@ -80,12 +80,17 @@ sudo install_name_tool -change ${ad9361rpath} @executable_path/../Frameworks/${a
 sudo install_name_tool -change ${pythonidrpath} @executable_path/../Frameworks/${pythonid} ./Scopy.app/Contents/Frameworks/libsigrokdecode*
 sudo install_name_tool -change ${libusbpath} @executable_path/../Frameworks/${libusbid} ./Scopy.app/Contents/Frameworks/iio.framework/iio
 
+if command -v brew ; then
+	QT_PATH="$(brew --prefix ${QT_FORMULAE})/bin"
+	export PATH="${QT_PATH}:$PATH"
+fi
+
 ## Bundle the Qt libraries
-sudo /usr/local/opt/qt/bin/macdeployqt Scopy.app
+sudo macdeployqt Scopy.app
 
 curl -o /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
 sudo python /tmp/macdeployqtfix.py ./Scopy.app/Contents/MacOS/Scopy /usr/local/opt/qt/
 sudo python /tmp/macdeployqtfix.py ./Scopy.app/Contents/MacOS/Scopy ./Scopy.app/Contents/Frameworks/
 
-sudo /usr/local/opt/qt/bin/macdeployqt Scopy.app -dmg
+sudo macdeployqt Scopy.app -dmg
 ls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ environment:
           DEPLOY_FILE: "/Users/appveyor/projects/scopy/build/Scopy.dmg"
           C_COMPILER: -DCMAKE_C_COMPILER=/usr/bin/gcc
           CXX_COMPILER: -DCMAKE_CXX_COMPILER=/usr/bin/g++
+          QT_FORMULAE: "qt5"
 
         - ARCH: x86_64
           ARCH_BIT: 64


### PR DESCRIPTION
Install qt5 and make sure that the correct path to it is found and used for tools like qmake and macdeployqt

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>