### PR TITLE
PatternGenerator: Set min sampling frequency to 1kHz.

### DIFF
--- a/src/patterngenerator/patterns/patterns.cpp
+++ b/src/patterngenerator/patterns/patterns.cpp
@@ -150,7 +150,7 @@ void Pattern::setNrOfChannels(int channels)
 
 uint32_t Pattern::get_min_sampling_freq()
 {
-	return 1; // minimum 1 hertz if not specified otherwise
+	return 1000; // minimum 1 kHz if not specified otherwise
 }
 
 uint32_t Pattern::get_required_nr_of_samples(uint32_t sample_rate,


### PR DESCRIPTION
This change will avoid creation of tiny buffers.
Number Pattern uses this function.

Signed-off-by: Teo Perisanu <Teo.Perisanu@analog.com>