### PR TITLE
ci: azure: fix cmake-format not in PATH

### DIFF
--- a/ci/azure/lib.sh
+++ b/ci/azure/lib.sh
@@ -88,7 +88,7 @@ check_clangformat() {
 }
 
 check_cmakeformat() {
-    find . -type f -iname CMakeLists.txt ! -path "*old*" -o -type f -iname "*.cmake" ! -path "*old*" | xargs cmake-format -i
+    find . -type f -iname CMakeLists.txt ! -path "*old*" -o -type f -iname "*.cmake" ! -path "*old*" | xargs /home/vsts/.local/bin/cmake-format -i
 
     git diff --exit-code || {
         echo_red "The cmake files are not properly formatted."


### PR DESCRIPTION
Since the feature was implemented, pip install cmakelang will no longer add the tools(including cmake-format) to PATH, so we need to call the executable with the full path

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>