### PR TITLE
MacOS and Linux builds: Lock libiio version to v0.21 for now.

### DIFF
--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -141,7 +141,7 @@ build_boost() {
 	echo "### Building boost - version $BOOST_VERSION_FILE"
 
 	cd ~
-	wget https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_FILE.tar.gz
+	wget https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_FILE.tar.gz
 	tar -xzf boost_$BOOST_VERSION_FILE.tar.gz
 	cd boost_$BOOST_VERSION_FILE
 	patch -p1 <  ${WORKDIR}/projects/scopy/CI/appveyor/patches/boost-darwin.patch

--- a/CI/appveyor/install_macos_deps.sh
+++ b/CI/appveyor/install_macos_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LIBIIO_BRANCH=master
+LIBIIO_VERSION=v0.21
 LIBAD9361_BRANCH=master
 LIBM2K_BRANCH=master
 GRIIO_BRANCH=upgrade-3.8
@@ -65,10 +65,12 @@ QMAKE="$(command -v qmake)"
 CMAKE_OPTS="-DCMAKE_PREFIX_PATH=$STAGINGDIR -DCMAKE_INSTALL_PREFIX=$STAGINGDIR"
 
 build_libiio() {
-	echo "### Building libiio - branch $LIBIIO_BRANCH"
+	echo "### Building libiio - version $LIBIIO_VERSION"
 
 	cd ~
-	git clone --depth 1 https://github.com/analogdevicesinc/libiio.git -b $LIBIIO_BRANCH ${WORKDIR}/libiio
+	git clone https://github.com/analogdevicesinc/libiio.git ${WORKDIR}/libiio
+	cd ${WORKDIR}/libiio
+	git checkout $LIBIIO_VERSION
 
 	mkdir ${WORKDIR}/libiio/build-${ARCH}
 	cd ${WORKDIR}/libiio/build-${ARCH}

--- a/CI/appveyor/install_ubuntu_18_deps.sh
+++ b/CI/appveyor/install_ubuntu_18_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LIBIIO_BRANCH=master
+LIBIIO_VERSION=v0.21
 LIBAD9361_BRANCH=master
 GLOG_BRANCH=v0.4.0
 LIBM2K_BRANCH=master
@@ -45,10 +45,12 @@ install_apt() {
 }
 
 build_libiio() {
-	echo "### Building libiio - branch $LIBIIO_BRANCH"
+	echo "### Building libiio - version $LIBIIO_VERSION"
 
 	cd ~
-	git clone --depth 1 https://github.com/analogdevicesinc/libiio.git -b $LIBIIO_BRANCH ${WORKDIR}/libiio
+	git clone https://github.com/analogdevicesinc/libiio.git ${WORKDIR}/libiio
+	cd ${WORKDIR}/libiio
+	git checkout $LIBIIO_VERSION
 
 	mkdir ${WORKDIR}/libiio/build-${ARCH}
 	cd ${WORKDIR}/libiio/build-${ARCH}

--- a/CI/appveyor/install_ubuntu_20_deps.sh
+++ b/CI/appveyor/install_ubuntu_20_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LIBIIO_BRANCH=master
+LIBIIO_VERSION=v0.21
 LIBAD9361_BRANCH=master
 GLOG_BRANCH=v0.4.0
 LIBM2K_BRANCH=master
@@ -36,10 +36,12 @@ install_apt() {
 }
 
 build_libiio() {
-	echo "### Building libiio - branch $LIBIIO_BRANCH"
+	echo "### Building libiio - version $LIBIIO_VERSION"
 
 	cd ~
-	git clone --depth 1 https://github.com/analogdevicesinc/libiio.git -b $LIBIIO_BRANCH ${WORKDIR}/libiio
+	git clone https://github.com/analogdevicesinc/libiio.git ${WORKDIR}/libiio
+	cd ${WORKDIR}/libiio
+	git checkout $LIBIIO_VERSION
 
 	mkdir ${WORKDIR}/libiio/build-${ARCH}
 	cd ${WORKDIR}/libiio/build-${ARCH}


### PR DESCRIPTION
Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>