### PR TITLE
scopy.html: Fix Engineer Zone link on the Scopy homepage.

### DIFF
--- a/resources/scopy.html
+++ b/resources/scopy.html
@@ -11,7 +11,7 @@
    <h1>Welcome to Scopy!</h1><br><br>
 Scopy is a powerful toolbox for signal analysis and generation.<br><br>
 Please visit <a href="https://wiki.analog.com/university/tools/m2k/scopy">our wiki</a> for more information about Scopy.<br>
-If you need help, drop a message on our <a href="https://ez.analog.com/community/linux-device-drivers/linux-software-drivers">Engineer Zone</a>.<br>
+If you need help, drop a message on our <a href="https://ez.analog.com/adieducation/university-program">Engineer Zone</a>.<br>
 </td>
  </tr>
 


### PR DESCRIPTION
A lot of questions get posted in the wrong section of EZ (this link might
be one reason why?)

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>