### PR TITLE
android: fix gnuradio in external storage bug

### DIFF
--- a/android/src/org/adi/scopy/ScopyApplication.java
+++ b/android/src/org/adi/scopy/ScopyApplication.java
@@ -34,16 +34,19 @@ public class ScopyApplication extends QtApplication
 	public void onCreate()
 	{
 		String apk = getApplicationInfo().sourceDir;
+		String cache = getApplicationContext().getCacheDir().toString();
 		System.out.println("sourcedir: "+ getApplicationInfo().sourceDir);
 		System.out.println("public sourcedir: "+ getApplicationInfo().publicSourceDir);
 		String libdir = getApplicationInfo().nativeLibraryDir;
 		System.out.println("native library dir:" + libdir);
-		System.out.println("Hello application !");
+		System.out.println("applcation cache dir:" + cache);
+		System.out.println("Hello Scopy !");
 
 		try {
 		    Os.setenv("PYTHONHOME",".",true);
 		    Os.setenv("PYTHONPATH",apk + "/assets/python3.8",true);
 		    Os.setenv("SIGROKDECODE_DIR", apk + "/assets/libsigrokdecode/decoders",true);
+		    Os.setenv("APPDATA", cache, true);
 		    Os.setenv("LD_LIBRARY_PATH", libdir, true);
 		    Os.setenv("IIOEMU_BIN", libdir+"/iio-emu.so", true);
 


### PR DESCRIPTION
Previously the application crashes if there is no gnuradio folder in
external storage root. This fixes it by setting an envvar to the cache
of the application.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>