### PR TITLE
Docking mechanism fixes

### DIFF
--- a/resources/stylesheets/templates/default.qss.c
+++ b/resources/stylesheets/templates/default.qss.c
@@ -15,11 +15,25 @@ QWidget {
 }
 
 QDockWidget {
-	titlebar-normal-icon: url();
+	titlebar-normal-icon: url(:/icons/sba_cmb_box_arrow_right.svg);
 }
 
 QDockWidget::title {
 	background-color: transparent;
+}
+
+QDockWidget::float-button {
+	background-color: transparent;
+	border: none;
+}
+
+QDockWidget::float-button:hover {
+	background-color: rgba(255, 255, 255, 30);
+	padding: 2px;
+}
+
+QDockWidget::float-button:hover {
+	background-color: rgba(0, 0, 0, 60);
 }
 
 QToolTip {

--- a/resources/stylesheets/templates/light.qss.c
+++ b/resources/stylesheets/templates/light.qss.c
@@ -15,12 +15,26 @@ QWidget {
 }
 
 QDockWidget {
-	titlebar-normal-icon: url();
+	titlebar-normal-icon: url(:/icons/scopy-light/icons/sba_cmb_box_arrow_right.svg);
 	background-color: #F7F7F7;
 }
 
 QDockWidget::title {
 	background-color: transparent;
+}
+
+QDockWidget::float-button {
+	background-color: transparent;
+	border: none;
+}
+
+QDockWidget::float-button:hover {
+	background-color: rgba(0, 0, 0, 30);
+	padding: 2px;
+}
+
+QDockWidget::float-button:hover {
+	background-color: rgba(0, 0, 0, 60);
 }
 
 QToolTip {

--- a/src/gui/tool_view.cpp
+++ b/src/gui/tool_view.cpp
@@ -185,6 +185,10 @@ QDockWidget *ToolView::createDockableWidget(QWidget *widget, const QString& dock
 	docker->setAllowedAreas(Qt::DockWidgetArea::AllDockWidgetAreas);
 	docker->setWidget(widget);
 
+	// workaround, allows dockWidgets movement
+	widget->setMinimumHeight(50);
+	widget->setMinimumWidth(50);
+
 #ifdef PLOT_MENU_BAR_ENABLED
 	DockerUtils::configureTopBar(docker);
 #endif

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -155,7 +155,7 @@ LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx, adiscope::Filter *filt,
 
 		channelBox->setChecked(true);
 
-		triggerBox->setStyleSheet("QComboBox QAbstractItemView { min-width: 130px; }");
+		triggerBox->setStyleSheet("QComboBox { max-width: 60px; } QComboBox QAbstractItemView { min-width: 130px; }");
 
 		triggerBox->setSizeAdjustPolicy(QComboBox::AdjustToContentsOnFirstShow);
 		for (int i = 1; i < ui->triggerComboBox->count(); ++i) {

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1306,7 +1306,7 @@ void LogicAnalyzer::setupUi()
 	QGridLayout* gridLayout = new QGridLayout(plotWidget);
 	gridLayout->setVerticalSpacing(0);
 	gridLayout->setHorizontalSpacing(0);
-	gridLayout->setContentsMargins(25, 0, 25, 0);
+	gridLayout->setContentsMargins(15, 0, 15, 0);
 	plotWidget->setLayout(gridLayout);
 
 	QSpacerItem *plotSpacer = new QSpacerItem(0, 5,
@@ -1327,23 +1327,24 @@ void LogicAnalyzer::setupUi()
 	vLayout->addWidget(plotWidget);
 	centralWidget->setLayout(vLayout);
 
-	// Add dockable plot
+	if(prefPanel->getCurrent_docking_enabled()) {
 
-	QMainWindow* m_centralMainWindow = new QMainWindow(this);
-	m_centralMainWindow->setCentralWidget(0);
-	m_centralMainWindow->setWindowFlags(Qt::Widget);
-	ui->gridLayoutPlot->addWidget(m_centralMainWindow, 1, 0, 1, 1);
+		// main window for dock widget
+		QMainWindow* mainWindow = new QMainWindow(this);
+		mainWindow->setCentralWidget(0);
+		mainWindow->setWindowFlags(Qt::Widget);
+		ui->gridLayoutPlot->addWidget(mainWindow, 1, 0, 1, 1);
 
-	QDockWidget* docker = new QDockWidget(m_centralMainWindow);
-	docker->setFeatures(docker->features() & ~QDockWidget::DockWidgetClosable);
-	docker->setAllowedAreas(Qt::AllDockWidgetAreas);
-	docker->setWidget(centralWidget);
+		QDockWidget* docker = DockerUtils::createDockWidget(mainWindow, centralWidget);
+
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-	DockerUtils::configureTopBar(docker);
+		DockerUtils::configureTopBar(docker);
 #endif
-
-	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
+	} else {
+		ui->gridLayoutPlot->addWidget(centralWidget, 1, 0, 1, 1);
+	}
 
 
 	m_plot.setAxisVisible(QwtAxis::YLeft, false);

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -426,7 +426,9 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	// plot widget
 	QWidget* centralWidget = new QWidget(this);
 	QGridLayout* gridLayout = new QGridLayout(centralWidget);
-	gridLayout->setContentsMargins(0, 0, 0, 0);
+	gridLayout->setContentsMargins(9, 0, 0, 9);
+	gridLayout->setHorizontalSpacing(10);
+	gridLayout->setVerticalSpacing(0);
 
 	gridLayout->addWidget(bufferPreviewer, 0, 1, 1, 1);
 	gridLayout->addWidget(ui->statusWidget, 1, 1, 1, 1);

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -446,17 +446,43 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	centralWidget->setLayout(gridLayout);
 
 	if(prefPanel->getCurrent_docking_enabled()) {
-		QMainWindow* mainWindow = new QMainWindow(this);
-		mainWindow->setCentralWidget(0);
-		mainWindow->setWindowFlags(Qt::Widget);
-		ui->gridLayout_plots->addWidget(mainWindow, 0, 0);
+		// bode graph
+		QMainWindow* bodeWindow = new QMainWindow(this);
+		bodeWindow->setCentralWidget(0);
+		bodeWindow->setWindowFlags(Qt::Widget);
+		ui->gridLayout_plots->addWidget(bodeWindow, 0, 0);
 
-		QDockWidget* dockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget);
+		QDockWidget* bodeDockWidget = DockerUtils::createDockWidget(bodeWindow, centralWidget);
+		bodeWindow->addDockWidget(Qt::LeftDockWidgetArea, bodeDockWidget);
 
-		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
+
+		// nyquist graph
+		QMainWindow* nyquistWindow = new QMainWindow(this);
+		nyquistWindow->setCentralWidget(0);
+		nyquistWindow->setWindowFlags(Qt::Widget);
+
+		ui->stackedWidgetPage2->layout()->removeWidget(ui->xygraph);
+		ui->stackedWidgetPage2->layout()->addWidget(nyquistWindow);
+
+		QDockWidget* nyquistDockWidget = DockerUtils::createDockWidget(nyquistWindow, ui->xygraph);
+		nyquistWindow->addDockWidget(Qt::LeftDockWidgetArea, nyquistDockWidget);
+
+
+		// nichols graph
+		QMainWindow* nicholsWindow = new QMainWindow(this);
+		nicholsWindow->setCentralWidget(0);
+		nicholsWindow->setWindowFlags(Qt::Widget);
+
+		ui->stackedWidgetPage3->layout()->removeWidget(ui->nicholsgraph);
+		ui->stackedWidgetPage3->layout()->addWidget(nicholsWindow);
+
+		QDockWidget* nicholsDockWidget = DockerUtils::createDockWidget(nicholsWindow, ui->nicholsgraph);
+		nicholsWindow->addDockWidget(Qt::LeftDockWidgetArea, nicholsDockWidget);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-		DockerUtils::configureTopBar(dockWidget);
+		DockerUtils::configureTopBar(bodeDockWidget);
+		DockerUtils::configureTopBar(nyquistDockWidget);
+		DockerUtils::configureTopBar(nicholsDockWidget);
 #endif
 	} else {
 		gridLayout->setHorizontalSpacing(0);

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -423,12 +423,9 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 
 	m_phaseGraph.setVertCursorsHandleEnabled(false);
 
-	// Add dockable plot
-
-	QWidget* widget = new QWidget(this);
-	QGridLayout* gridLayout = new QGridLayout(widget);
-	gridLayout->setVerticalSpacing(0);
-	gridLayout->setHorizontalSpacing(10);
+	// plot widget
+	QWidget* centralWidget = new QWidget(this);
+	QGridLayout* gridLayout = new QGridLayout(centralWidget);
 	gridLayout->setContentsMargins(0, 0, 0, 0);
 
 	gridLayout->addWidget(bufferPreviewer, 0, 1, 1, 1);
@@ -444,24 +441,26 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 
 	gridLayout->addWidget(m_dBgraph.bottomHandlesArea(), 6, 0, 1, 3);
 
-	widget->setLayout(gridLayout);
+	centralWidget->setLayout(gridLayout);
 
+	if(prefPanel->getCurrent_docking_enabled()) {
+		QMainWindow* mainWindow = new QMainWindow(this);
+		mainWindow->setCentralWidget(0);
+		mainWindow->setWindowFlags(Qt::Widget);
+		ui->gridLayout_plots->addWidget(mainWindow, 0, 0);
 
-	QMainWindow* m_centralMainWindow = new QMainWindow(this);
-	m_centralMainWindow->setCentralWidget(0);
-	m_centralMainWindow->setWindowFlags(Qt::Widget);
-	ui->gridLayout_plots->addWidget(m_centralMainWindow, 0, 0);
+		QDockWidget* dockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget);
 
-	QDockWidget* docker = new QDockWidget(m_centralMainWindow);
-	docker->setFeatures(docker->features() & ~QDockWidget::DockWidgetClosable);
-	docker->setAllowedAreas(Qt::AllDockWidgetAreas);
-	docker->setWidget(widget);
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-	DockerUtils::configureTopBar(docker);
+		DockerUtils::configureTopBar(dockWidget);
 #endif
-
-	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
+	} else {
+		gridLayout->setHorizontalSpacing(0);
+		gridLayout->setVerticalSpacing(6);
+		ui->gridLayout_plots->addWidget(centralWidget);
+	}
 
 
 	m_phaseGraph.enableXaxisLabels();

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -388,6 +388,17 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		QDockWidget* plotDockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget, "TimeDomain");
 
 
+		// necessary to move around the dockWidgets
+		centralWidget->setMinimumHeight(50);
+		centralWidget->setMinimumWidth(50);
+
+		fft_plot.setMinimumHeight(50);
+		fft_plot.setMinimumWidth(50);
+
+		xy_plot.setMinimumHeight(50);
+		xy_plot.setMinimumWidth(50);
+
+
 		// histogram widget
 		histWidget = new QWidget(this);
 		QVBoxLayout* histLayout = new QVBoxLayout(histWidget);
@@ -420,6 +431,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 
 
 		// arange all dockers
+#ifdef __ANDROID__
 		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, fftDockWidget);
 		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, histDockWidget);
 		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, plotDockWidget);
@@ -428,6 +440,15 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		mainWindow->tabifyDockWidget(plotDockWidget, histDockWidget);
 		mainWindow->tabifyDockWidget(plotDockWidget, fftDockWidget);
 		mainWindow->tabifyDockWidget(plotDockWidget, xyDockWidget);
+#else
+		mainWindow->addDockWidget(Qt::RightDockWidgetArea, fftDockWidget);
+		mainWindow->addDockWidget(Qt::RightDockWidgetArea, xyDockWidget);
+		mainWindow->tabifyDockWidget(fftDockWidget, xyDockWidget);
+
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, histDockWidget);
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, plotDockWidget);
+		mainWindow->tabifyDockWidget(plotDockWidget, histDockWidget);
+#endif
 
 #ifdef PLOT_MENU_BAR_ENABLED
 		DockerUtils::configureTopBar(plotDockWidget);
@@ -444,7 +465,17 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		QWidget *w = gridL->itemAtPosition(1, 0)->widget();
 		gridL->addWidget(&xy_plot, 1, 0);
 		gridL->addWidget(w, 2, 0);
+
+		fft_plot.setMinimumHeight(250);
+		fft_plot.setMinimumWidth(500);
 	}
+
+		hist_plot.setMinimumHeight(60);
+		hist_plot.setMinimumWidth(25);
+		hist_plot.setMaximumWidth(25);
+
+	//	xy_plot.setMinimumHeight(50);
+	//	xy_plot.setMinimumWidth(50);
 
 	/* Default plot settings */
 	plot.setSampleRate(active_sample_rate, 1, "");
@@ -481,16 +512,6 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 	plot.setAxisVisible(QwtAxis::YLeft, false);
 	plot.setAxisVisible(QwtAxis::XBottom, false);
 	plot.setUsingLeftAxisScales(false);
-
-	fft_plot.setMinimumHeight(250);
-	fft_plot.setMinimumWidth(500);
-
-	hist_plot.setMinimumHeight(60);
-	hist_plot.setMinimumWidth(25);
-	hist_plot.setMaximumWidth(25);
-
-//	xy_plot.setMinimumHeight(50);
-//	xy_plot.setMinimumWidth(50);
 
 	xy_plot.setVertUnitsPerDiv(5);
 	xy_plot.setHorizUnitsPerDiv(5);

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -342,7 +342,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 	gridPlot = new QGridLayout(plotWidget);
 	gridPlot->setVerticalSpacing(0);
 	gridPlot->setHorizontalSpacing(0);
-	gridPlot->setContentsMargins(0, 0, 0, 0);
+	gridPlot->setContentsMargins(9, 0, 9, 0);
 	plotWidget->setLayout(gridPlot);
 
 	QSpacerItem *plotSpacer = new QSpacerItem(0, 5,
@@ -382,7 +382,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt,
 		QMainWindow* mainWindow = new QMainWindow(this);
 		mainWindow->setCentralWidget(0);
 		mainWindow->setWindowFlags(Qt::Widget);
-		ui->gridLayoutPlot->addWidget(mainWindow, 1, 0, 1, 1);
+		ui->gridLayoutPlot->addWidget(mainWindow, 0, 0, 1, 1);
 
 		// time domain plot dock
 		QDockWidget* plotDockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget, "TimeDomain");

--- a/src/oscilloscope.hpp
+++ b/src/oscilloscope.hpp
@@ -314,9 +314,9 @@ namespace adiscope {
 		CustomPlotPositionButton *cursorsPositionButton;
 
 		QGridLayout* gridPlot;
-		QDockWidget* fftDocker;
-		QDockWidget* xyDocker;
-		QDockWidget* histDocker;
+		QDockWidget* fftDockWidget;
+		QDockWidget* xyDockWidget;
+		QDockWidget* histDockWidget;
 		QWidget* histWidget;
 
 		MouseWheelWidgetGuard *wheelEventGuard;

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -78,8 +78,8 @@ CapturePlot::CapturePlot(QWidget *parent,  bool isdBgraph, unsigned int xNumDivs
 	d_currentHandleInitPx(30),
 	d_maxBufferError(nullptr)
 {
-//	setMinimumHeight(200);
-//	setMinimumWidth(450);
+	setMinimumHeight(200);
+	setMinimumWidth(450);
 
 	/* Initial colors scheme */
 	d_trigAactiveLinePen = QPen(QColor(255, 255, 255), 2, Qt::SolidLine);

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -273,6 +273,8 @@ void PatternGenerator::setupUi()
 
 	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
 
+	// TODO: do we want the buffer previewer in this tool?
+	m_ui->hLayoutBufferPreview->hide();
 
 	m_plot.setAxisVisible(QwtAxis::YLeft, false);
 	m_plot.setAxisVisible(QwtAxis::XBottom, false);

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -231,14 +231,14 @@ void PatternGenerator::setupUi()
 	// set default menu width to 0
 	m_ui->rightMenu->setMaximumWidth(0);
 
-	// Add docking plot
 
-	QWidget* widget = new QWidget(this);
-	QGridLayout* gridLayout = new QGridLayout(widget);
+	// plot widget
+	QWidget* centralWidget = new QWidget(this);
+	QGridLayout* gridLayout = new QGridLayout(centralWidget);
 	gridLayout->setVerticalSpacing(0);
 	gridLayout->setHorizontalSpacing(0);
 	gridLayout->setContentsMargins(0, 0, 0, 0);
-	widget->setLayout(gridLayout);
+	centralWidget->setLayout(gridLayout);
 
 	QSpacerItem *plotSpacer = new QSpacerItem(0, 5,
 		QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -255,23 +255,25 @@ void PatternGenerator::setupUi()
 	gridLayout->addWidget(m_plot.bottomHandlesArea(), 3, 0, 1, 4);
 	gridLayout->addItem(plotSpacer, 4, 0, 1, 4);
 
+	if(prefPanel->getCurrent_docking_enabled()) {
 
-	QMainWindow* m_centralMainWindow = new QMainWindow(this);
-	m_centralMainWindow->setCentralWidget(0);
-	m_centralMainWindow->setWindowFlags(Qt::Widget);
-	m_ui->gridLayoutPlot->addWidget(m_centralMainWindow, 1, 0, 1, 1);
+		// main window for dock widget
+		QMainWindow* mainWindow = new QMainWindow(this);
+		mainWindow->setCentralWidget(0);
+		mainWindow->setWindowFlags(Qt::Widget);
+		m_ui->gridLayoutPlot->addWidget(mainWindow, 1, 0, 1, 1);
 
-	QDockWidget* docker = new QDockWidget(m_centralMainWindow);
-	docker->setFeatures(docker->features() & ~QDockWidget::DockWidgetClosable);
-	docker->setAllowedAreas(Qt::AllDockWidgetAreas);
-	docker->setWidget(widget);
+		QDockWidget* dockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget);
+
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-	DockerUtils::configureTopBar(docker);
+		DockerUtils::configureTopBar(dockWidget);
 #endif
+	} else {
+		m_ui->gridLayoutPlot->addWidget(centralWidget, 0, 0, 1, 1);
+	}
 
-
-	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
 
 	// TODO: do we want the buffer previewer in this tool?
 	m_ui->hLayoutBufferPreview->hide();

--- a/src/patterngenerator/pattern_generator.cpp
+++ b/src/patterngenerator/pattern_generator.cpp
@@ -237,7 +237,7 @@ void PatternGenerator::setupUi()
 	QGridLayout* gridLayout = new QGridLayout(centralWidget);
 	gridLayout->setVerticalSpacing(0);
 	gridLayout->setHorizontalSpacing(0);
-	gridLayout->setContentsMargins(0, 0, 0, 0);
+	gridLayout->setContentsMargins(25, 0, 25, 0);
 	centralWidget->setLayout(gridLayout);
 
 	QSpacerItem *plotSpacer = new QSpacerItem(0, 5,

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -150,6 +150,10 @@ public:
 	double getTarget_fps() const;
 	void setTarget_fps(double newTarget_fps);
 
+	bool getDocking_enabled() const;
+	void setDocking_enabled(bool value);
+	bool getCurrent_docking_enabled() const;
+
 Q_SIGNALS:
 
 	void notify();
@@ -203,6 +207,8 @@ private:
 	bool m_show_plot_fps;
 	bool m_use_open_gl;
 	int m_target_fps;
+	bool m_docking_enabled;
+	bool m_current_docking_state;
 
 	Preferences_API *pref_api;
 
@@ -244,6 +250,7 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool showPlotFps READ getShowPlotFps WRITE setShowPlotFps)
 	Q_PROPERTY(bool useOpenGl READ getUseOpenGl WRITE setUseOpenGl)
 	Q_PROPERTY(double targetFps READ getTargetFps WRITE setTargetFps)
+	Q_PROPERTY(bool docking_enabled READ getDockingEnabled WRITE setDockingEnabled)
 
 
 public:
@@ -341,6 +348,9 @@ public:
 
 	QStringList getUserStylesheets() const;
 	void setUserStylesheets(const QStringList &userStylesheets);
+
+	bool getDockingEnabled() const;
+	void setDockingEnabled(const bool& first);
 
 private:
 	Preferences *preferencePanel;

--- a/src/qtgui_util.cc
+++ b/src/qtgui_util.cc
@@ -177,6 +177,11 @@ QDockWidget *DockerUtils::createDockWidget(QMainWindow *mainWindow, QWidget *wid
 	dockWidget->setAllowedAreas(Qt::AllDockWidgetAreas);
 	dockWidget->setWidget(widget);
 
+#ifdef __ANDROID__
+	dockWidget->setFeatures(dockWidget->features() & ~QDockWidget::DockWidgetClosable
+				& ~QDockWidget::DockWidgetFloatable);
+#endif
+
 	return dockWidget;
 }
 

--- a/src/qtgui_util.cc
+++ b/src/qtgui_util.cc
@@ -188,19 +188,28 @@ QDockWidget *DockerUtils::createDockWidget(QMainWindow *mainWindow, QWidget *wid
 void DockerUtils::configureTopBar(QDockWidget *docker)
 {
 	connect(docker, &QDockWidget::topLevelChanged, [=](bool topLevel){
+		QString icon_path = "";
+
+		if (QIcon::themeName() == "scopy-default") {
+			icon_path +=":/icons";
+		} else {
+			icon_path +=":/icons/scopy-light/icons";
+		}
+
 		if(topLevel) {
 			docker->setWindowFlags(Qt::CustomizeWindowHint |
 							Qt::Window |
 							Qt::WindowMinimizeButtonHint |
 							Qt::WindowMaximizeButtonHint);
 			docker->show();
+
 			docker->setStyleSheet("QDockWidget {"
-						"titlebar-normal-icon: url(:/icons/close_hovered.svg);"
+						"titlebar-normal-icon: url(" + icon_path + "/sba_cmb_box_arrow.svg);"
 						"}");
 			docker->setContentsMargins(10, 0, 10, 10);
 		} else {
 			docker->setStyleSheet("QDockWidget {"
-						  "titlebar-normal-icon: url();"
+						  "titlebar-normal-icon: url(" + icon_path + "/sba_cmb_box_arrow_right.svg);"
 						  "}");
 			docker->setContentsMargins(0, 0, 0, 0);
 		}

--- a/src/qtgui_util.cc
+++ b/src/qtgui_util.cc
@@ -170,6 +170,16 @@ bool Util::compareNatural(const std::string& a, const std::string& b) {
 	return (compareNatural(a_new, b_new));
 }
 
+QDockWidget *DockerUtils::createDockWidget(QMainWindow *mainWindow, QWidget *widget, const QString &title)
+{
+	QDockWidget* dockWidget = new QDockWidget(title, mainWindow);
+	dockWidget->setFeatures(dockWidget->features() & ~QDockWidget::DockWidgetClosable);
+	dockWidget->setAllowedAreas(Qt::AllDockWidgetAreas);
+	dockWidget->setWidget(widget);
+
+	return dockWidget;
+}
+
 void DockerUtils::configureTopBar(QDockWidget *docker)
 {
 	connect(docker, &QDockWidget::topLevelChanged, [=](bool topLevel){

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -601,44 +601,47 @@ SignalGenerator::SignalGenerator(struct iio_context *_ctx, Filter *filt,
 
 	m_plot->enableTimeTrigger(false);
 
-	// Add docking plot
+	// plot widget
+	QWidget* centralWidget = new QWidget();
+	QGridLayout *gridLayout = new QGridLayout();
+	gridLayout->setVerticalSpacing(0);
+	gridLayout->setHorizontalSpacing(0);
+	gridLayout->setContentsMargins(0, 0, 0, 5);
 
-	QWidget* widget = new QWidget();
-	QGridLayout *gridplot = new QGridLayout();
+	gridLayout->addWidget(m_plot->topArea(), 0, 0);
+	gridLayout->addWidget(m_plot->topHandlesArea(), 1, 0);
+	gridLayout->addWidget(m_plot, 2, 0);
 
-	gridplot->addWidget(m_plot->topArea(), 0, 0);
-	gridplot->addWidget(m_plot->topHandlesArea(), 1, 0);
-	gridplot->addWidget(m_plot, 2, 0);
-
-	gridplot->setVerticalSpacing(0);
-	gridplot->setHorizontalSpacing(0);
-	gridplot->setContentsMargins(0, 0, 0, 0);
-	widget->setLayout(gridplot);
+	centralWidget->setLayout(gridLayout);
 
 	ui->plot->removeWidget(ui->instrumentNotes);
 
-	QMainWindow* m_centralMainWindow = new QMainWindow(this);
-	m_centralMainWindow->setCentralWidget(0);
-	m_centralMainWindow->setWindowFlags(Qt::Widget);
-	ui->plot->addWidget(m_centralMainWindow, 0, 0);
+	if(prefPanel->getCurrent_docking_enabled()) {
 
-	QDockWidget* docker = new QDockWidget(m_centralMainWindow);
-	docker->setFeatures(docker->features() & ~QDockWidget::DockWidgetClosable);
-	docker->setAllowedAreas(Qt::AllDockWidgetAreas);
-	docker->setWidget(widget);
-	docker->setContentsMargins(0, 0, 0, 10);
+		// main window for dock widget
+		QMainWindow* mainWindow = new QMainWindow(this);
+		mainWindow->setCentralWidget(0);
+		mainWindow->setWindowFlags(Qt::Widget);
+		ui->plot->addWidget(mainWindow, 0, 0);
+
+		QDockWidget* dockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget);
+		dockWidget->setContentsMargins(0, 0, 0, 10);
+
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-	DockerUtils::configureTopBar(docker);
+		DockerUtils::configureTopBar(dockWidget);
 #endif
 
-	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
-
-	ui->plot->addWidget(ui->instrumentNotes, 3, 0);
+	} else {
+		ui->plot->addWidget(centralWidget);
+	}
 
 	connect(ui->toggleMenuBtn, &QPushButton::toggled, [=](bool toggled){
 		ui->rightMenu->toggleMenu(toggled);
 	});
+
+	ui->plot->addWidget(ui->instrumentNotes, 1, 0);
 }
 
 SignalGenerator::~SignalGenerator()

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -254,7 +254,7 @@ SpectrumAnalyzer::SpectrumAnalyzer(struct iio_context *ctx, Filter *filt,
 	// plot widget
 	QWidget* centralWidget = new QWidget(this);
 	QVBoxLayout* vLayout = new QVBoxLayout(centralWidget);
-	vLayout->setContentsMargins(0, 0, 0, 0);
+	vLayout->setContentsMargins(20, 0, 20, 20);
 	vLayout->setSpacing(10);
 	centralWidget->setLayout(vLayout);
 

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -250,12 +250,12 @@ SpectrumAnalyzer::SpectrumAnalyzer(struct iio_context *ctx, Filter *filt,
 	measure_settings_init();
 #endif
 
-	// Add dockable plot
 
+	// plot widget
 	QWidget* centralWidget = new QWidget(this);
 	QVBoxLayout* vLayout = new QVBoxLayout(centralWidget);
 	vLayout->setContentsMargins(0, 0, 0, 0);
-	vLayout->setSpacing(6);
+	vLayout->setSpacing(10);
 	centralWidget->setLayout(vLayout);
 
 #ifdef SPECTRAL_MSR
@@ -270,23 +270,25 @@ SpectrumAnalyzer::SpectrumAnalyzer(struct iio_context *ctx, Filter *filt,
 	ui->widgetPlotContainer->layout()->removeWidget(ui->markerTable);
 	vLayout->addWidget(ui->markerTable);
 
+	if(prefPanel->getCurrent_docking_enabled()) {
 
-	QMainWindow* m_centralMainWindow = new QMainWindow(this);
-	m_centralMainWindow->setCentralWidget(0);
-	m_centralMainWindow->setWindowFlags(Qt::Widget);
-	ui->gridLayout_plot->addWidget(m_centralMainWindow, 1, 0, 1, 1);
+		// main window for dock widget
+		QMainWindow* mainWindow = new QMainWindow(this);
+		mainWindow->setCentralWidget(0);
+		mainWindow->setWindowFlags(Qt::Widget);
+		ui->gridLayout_plot->addWidget(mainWindow, 1, 0, 1, 1);
 
-	QDockWidget* docker = new QDockWidget(m_centralMainWindow);
-	docker->setFeatures(docker->features() & ~QDockWidget::DockWidgetClosable);
-	docker->setAllowedAreas(Qt::AllDockWidgetAreas);
-	docker->setWidget(centralWidget);
+		QDockWidget* dockWidget = DockerUtils::createDockWidget(mainWindow, centralWidget);
+
+		mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
 
 #ifdef PLOT_MENU_BAR_ENABLED
-	DockerUtils::configureTopBar(docker);
+		DockerUtils::configureTopBar(dockWidget);
 #endif
 
-
-	m_centralMainWindow->addDockWidget(Qt::LeftDockWidgetArea, docker);
+	} else {
+		ui->gridLayout_plot->addWidget(centralWidget, 1, 0, 1, 1);
+	}
 
 
 	fft_plot->enableXaxisLabels();

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -62,6 +62,10 @@ Tool::Tool(struct iio_context *ctx, ToolMenuItem *toolMenuItem,
 #endif
 	connect(this, &Tool::detachedState,
 		toolMenuItem, &ToolMenuItem::setDetached);
+
+	// fixes bad ui rendering when dock->minimize->maximize
+	// TODO: may be removed after ToolLauncher refactoring
+	this->setVisible(false);
 }
 
 Tool::~Tool()

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,7 @@
 #include <qwt_picker_machine.h>
 #include <QWidget>
 #include <QDockWidget>
+#include <QMainWindow>
 
 class QwtDblClickPlotPicker: public QwtPlotPicker
 {
@@ -70,6 +71,7 @@ public:
 class DockerUtils : public QObject
 {
 public:
+	static QDockWidget* createDockWidget(QMainWindow* mainWindow, QWidget* widget, const QString& title = "");
 	static void configureTopBar(QDockWidget* docker);
 };
 

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -476,7 +476,7 @@
                 <string notr="true"/>
                </property>
                <property name="currentIndex">
-                <number>2</number>
+                <number>3</number>
                </property>
                <widget class="QWidget" name="channelSettings">
                 <property name="minimumSize">
@@ -526,8 +526,8 @@
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>200</width>
-                      <height>329</height>
+                      <width>400</width>
+                      <height>474</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1330,7 +1330,7 @@ color: rgba(255,255,255,51);
                </widget>
                <widget class="QWidget" name="generalSettings">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
@@ -1362,6 +1362,12 @@ color: rgba(255,255,255,51);
                  </property>
                  <item>
                   <widget class="QScrollArea" name="generalSettingsScrollArea">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="frameShape">
                     <enum>QFrame::NoFrame</enum>
                    </property>
@@ -1377,11 +1383,11 @@ color: rgba(255,255,255,51);
                       <x>0</x>
                       <y>0</y>
                       <width>420</width>
-                      <height>304</height>
+                      <height>474</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
@@ -1449,9 +1455,15 @@ color: rgba(255,255,255,51);
                          <verstretch>0</verstretch>
                         </sizepolicy>
                        </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>300</width>
+                         <height>30</height>
+                        </size>
+                       </property>
                        <property name="maximumSize">
                         <size>
-                         <width>400</width>
+                         <width>300</width>
                          <height>30</height>
                         </size>
                        </property>
@@ -1462,8 +1474,8 @@ color: rgba(255,255,255,51);
                         <string notr="true">QPushButton {
 min-height: 30px;
 max-height: 30px;
-min-width: 400px;
-max-width: 400px;
+min-width: 300px;
+max-width: 300px;
 background-color: black;
 border-radius: 4px;
 }
@@ -1475,8 +1487,8 @@ background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop
 QWidget#handle {
 min-height: 30px;
 max-height: 30px;
-min-width: 200px;
-max-width: 200px;
+min-width: 150px;
+max-width: 150px;
 background-color: #4a64ff;
 border-radius: 2px;
 }
@@ -1495,8 +1507,8 @@ QLabel#on {
 margin-top: 0px;
 min-height:30px;
 max-height:30px;
-min-width:200px;
-max-width:200px;
+min-width:150px;
+max-width:150px;
 qproperty-alignment: AlignCenter AlignCenter;
 margin-left: 0px;
 color: white;
@@ -1510,9 +1522,9 @@ QLabel#off {
 margin-top: 0px;
 min-height:30px;
 max-height:30px;
-min-width:200px;
-max-width:200px;
-margin-left: 200px;
+min-width:150px;
+max-width:150px;
+margin-left: 150px;
 color: white;
 qproperty-alignment: AlignCenter AlignCenter;
 }
@@ -1552,7 +1564,7 @@ color: rgba(255,255,255,51);
                        </property>
                        <property name="sizeHint" stdset="0">
                         <size>
-                         <width>400</width>
+                         <width>200</width>
                          <height>20</height>
                         </size>
                        </property>
@@ -1967,44 +1979,47 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
   <customwidget>
    <class>adiscope::CustomPushButton</class>
    <extends>QPushButton</extends>
-   <header>gui/customPushButton.hpp</header>
+   <header location="global">gui/customPushButton.hpp</header>
   </customwidget>
   <customwidget>
    <class>adiscope::DetachDragZone</class>
    <extends>QWidget</extends>
-   <header>gui/detachdragzone.h</header>
+   <header location="global">gui/detachdragzone.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::MenuAnim</class>
    <extends>QWidget</extends>
-   <header>gui/menu_anim.hpp</header>
+   <header location="global">gui/menu_anim.hpp</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::InstrumentNotes</class>
    <extends>QWidget</extends>
-   <header>gui/instrumentnotes.h</header>
+   <header location="global">gui/instrumentnotes.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::RunSingleWidget</class>
    <extends>QWidget</extends>
-   <header>gui/runsinglewidget.h</header>
+   <header location="global">gui/runsinglewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>adiscope::LinkedButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">gui/linked_button.hpp</header>
   </customwidget>
   <customwidget>
    <class>adiscope::CustomSwitch</class>
    <extends>QPushButton</extends>
    <header>gui/customSwitch.hpp</header>
   </customwidget>
-  <customwidget>
-   <class>adiscope::LinkedButton</class>
-   <extends>QPushButton</extends>
-   <header>gui/linked_button.hpp</header>
-  </customwidget>
  </customwidgets>
  <resources>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
   <include location="../resources/resources.qrc"/>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -269,6 +269,15 @@
            <property name="leftMargin">
             <number>0</number>
            </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QWidget" name="hLayoutBufferPreview" native="true">
              <layout class="QHBoxLayout" name="hLayout_buffPreview">
@@ -279,7 +288,7 @@
                <number>20</number>
               </property>
               <property name="topMargin">
-               <number>0</number>
+               <number>5</number>
               </property>
               <property name="rightMargin">
                <number>20</number>

--- a/ui/measure_panel.ui
+++ b/ui/measure_panel.ui
@@ -28,7 +28,10 @@
   <property name="styleSheet">
    <string notr="true"/>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -41,10 +44,48 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <property name="spacing">
-    <number>0</number>
-   </property>
-   <item row="2" column="0" colspan="3">
+   <item>
+    <widget class="QScrollArea" name="scrollArea_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>348</width>
+        <height>16</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
     <widget class="adiscope::OscCustomScrollArea" name="scrollArea">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -190,23 +231,7 @@
      </widget>
     </widget>
    </item>
-   <item row="0" column="1">
-    <spacer name="verticalSpacerTop">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
+   <item>
     <widget class="Line" name="line_2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -226,47 +251,6 @@
      <property name="line_separator" stdset="0">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QScrollArea" name="scrollArea_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAsNeeded</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>348</width>
-        <height>16</height>
-       </rect>
-      </property>
-     </widget>
     </widget>
    </item>
   </layout>

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -262,10 +262,16 @@
                  <property name="spacing">
                   <number>0</number>
                  </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
                  <property name="topMargin">
                   <number>0</number>
                  </property>
                  <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
                   <number>0</number>
                  </property>
                  <item>

--- a/ui/oscilloscope.ui
+++ b/ui/oscilloscope.ui
@@ -259,10 +259,31 @@ Signal View</string>
            <bool>true</bool>
           </property>
           <layout class="QVBoxLayout" name="plot_and_buffPreviewer">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QWidget" name="hLayoutBufferPreview" native="true">
              <layout class="QHBoxLayout" name="hLayout_buffPreview">
               <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>5</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -281,6 +302,9 @@ Signal View</string>
               <item>
                <layout class="QVBoxLayout" name="vLayoutBufferSlot">
                 <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
                  <number>0</number>
                 </property>
                </layout>
@@ -336,13 +360,13 @@ Signal View</string>
                 <item>
                  <layout class="QGridLayout" name="gridLayoutPlot">
                   <property name="leftMargin">
-                   <number>25</number>
+                   <number>0</number>
                   </property>
                   <property name="topMargin">
                    <number>0</number>
                   </property>
                   <property name="rightMargin">
-                   <number>25</number>
+                   <number>0</number>
                   </property>
                   <property name="bottomMargin">
                    <number>0</number>
@@ -362,7 +386,7 @@ Signal View</string>
                     <number>1</number>
                    </property>
                    <property name="topMargin">
-                    <number>1</number>
+                    <number>0</number>
                    </property>
                    <property name="bottomMargin">
                     <number>3</number>
@@ -426,86 +450,103 @@ Signal View</string>
                 </layout>
                </widget>
               </item>
-              <item row="1" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_4">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="leftMargin">
-                 <number>20</number>
-                </property>
-                <property name="rightMargin">
-                 <number>20</number>
-                </property>
-                <item>
-                 <spacer name="horizontalSpacer_12">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QWidget" name="hist_widget" native="true">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>20</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <layout class="QHBoxLayout" name="hist_layout">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_13">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
               <item row="3" column="0">
                <widget class="adiscope::InstrumentNotes" name="instrumentNotes" native="true"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QWidget" name="histogram_container" native="true">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>100</height>
+                 </size>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>20</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>9</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>20</number>
+                 </property>
+                 <item>
+                  <spacer name="horizontalSpacer_12">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="hist_widget" native="true">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>20</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>70</height>
+                    </size>
+                   </property>
+                   <layout class="QHBoxLayout" name="hist_layout">
+                    <property name="spacing">
+                     <number>0</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_13">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
               </item>
              </layout>
             </widget>

--- a/ui/oscilloscope.ui
+++ b/ui/oscilloscope.ui
@@ -64,9 +64,6 @@
         <property name="spacing">
          <number>40</number>
         </property>
-        <property name="leftMargin">
-         <number>40</number>
-        </property>
         <property name="topMargin">
          <number>15</number>
         </property>
@@ -76,6 +73,22 @@
         <property name="bottomMargin">
          <number>9</number>
         </property>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item>
          <widget class="adiscope::LinkedButton" name="btnHelp">
           <property name="text">
@@ -150,7 +163,7 @@ Signal View</string>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>10</width>
+            <width>40</width>
             <height>20</height>
            </size>
           </property>
@@ -163,7 +176,7 @@ Signal View</string>
          <widget class="QWidget" name="widget" native="true">
           <property name="minimumSize">
            <size>
-            <width>95</width>
+            <width>30</width>
             <height>0</height>
            </size>
           </property>
@@ -246,18 +259,6 @@ Signal View</string>
            <bool>true</bool>
           </property>
           <layout class="QVBoxLayout" name="plot_and_buffPreviewer">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
            <item>
             <widget class="QWidget" name="hLayoutBufferPreview" native="true">
              <layout class="QHBoxLayout" name="hLayout_buffPreview">
@@ -318,10 +319,7 @@ Signal View</string>
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="1" column="0">
-               <widget class="adiscope::InstrumentNotes" name="instrumentNotes" native="true"/>
-              </item>
-              <item row="0" column="0">
+              <item row="2" column="0">
                <layout class="QVBoxLayout" name="plot_and_scales">
                 <property name="spacing">
                  <number>0</number>
@@ -336,25 +334,23 @@ Signal View</string>
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QWidget" name="plotWidget" native="true">
-                  <layout class="QGridLayout" name="gridLayoutPlot">
-                   <property name="leftMargin">
-                    <number>25</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>1</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>25</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>1</number>
-                   </property>
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                  </layout>
-                 </widget>
+                 <layout class="QGridLayout" name="gridLayoutPlot">
+                  <property name="leftMargin">
+                   <number>25</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>25</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="spacing">
+                   <number>0</number>
+                  </property>
+                 </layout>
                 </item>
                 <item>
                  <widget class="QWidget" name="scalesWidget" native="true">
@@ -369,7 +365,7 @@ Signal View</string>
                     <number>1</number>
                    </property>
                    <property name="bottomMargin">
-                    <number>0</number>
+                    <number>3</number>
                    </property>
                    <item>
                     <layout class="QHBoxLayout" name="chn_scales">
@@ -398,6 +394,310 @@ Signal View</string>
                  </widget>
                 </item>
                </layout>
+              </item>
+              <item row="0" column="0">
+               <widget class="QWidget" name="container_fft_plot" native="true">
+                <layout class="QGridLayout" name="gridLayoutFFT">
+                 <property name="leftMargin">
+                  <number>20</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="horizontalSpacing">
+                  <number>2</number>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <layout class="QHBoxLayout" name="hlayout_fft">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <property name="rightMargin">
+                 <number>20</number>
+                </property>
+                <item>
+                 <spacer name="horizontalSpacer_12">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QWidget" name="hist_widget" native="true">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>20</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <layout class="QHBoxLayout" name="hist_layout">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_13">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="3" column="0">
+               <widget class="adiscope::InstrumentNotes" name="instrumentNotes" native="true"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="xy_plot_container" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="plot_container" stdset="0">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <item row="1" column="0">
+            <widget class="QWidget" name="widget_xy_plot_bottom" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>58</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>58</height>
+              </size>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>399</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_4">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+               </layout>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_10">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>5</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QWidget" name="widget_xy_plot_top" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>45</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>45</height>
+              </size>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_5">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+               </layout>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>10</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>2</width>
+                  <height>10</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </widget>
@@ -689,36 +989,36 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
   <customwidget>
    <class>adiscope::CustomPushButton</class>
    <extends>QPushButton</extends>
-   <header>gui/customPushButton.hpp</header>
+   <header location="global">gui/customPushButton.hpp</header>
   </customwidget>
   <customwidget>
    <class>adiscope::DetachDragZone</class>
    <extends>QWidget</extends>
-   <header>gui/detachdragzone.h</header>
+   <header location="global">gui/detachdragzone.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::MenuAnim</class>
    <extends>QWidget</extends>
-   <header>gui/menu_anim.hpp</header>
+   <header location="global">gui/menu_anim.hpp</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::InstrumentNotes</class>
    <extends>QWidget</extends>
-   <header>gui/instrumentnotes.h</header>
+   <header location="global">gui/instrumentnotes.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::RunSingleWidget</class>
    <extends>QWidget</extends>
-   <header>gui/runsinglewidget.h</header>
+   <header location="global">gui/runsinglewidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>adiscope::LinkedButton</class>
    <extends>QPushButton</extends>
-   <header>gui/linked_button.hpp</header>
+   <header location="global">gui/linked_button.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/ui/pattern_generator.ui
+++ b/ui/pattern_generator.ui
@@ -386,13 +386,13 @@
                <item>
                 <layout class="QGridLayout" name="gridLayoutPlot">
                  <property name="leftMargin">
-                  <number>25</number>
+                  <number>0</number>
                  </property>
                  <property name="topMargin">
                   <number>0</number>
                  </property>
                  <property name="rightMargin">
-                  <number>25</number>
+                  <number>0</number>
                  </property>
                  <property name="bottomMargin">
                   <number>0</number>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -72,9 +72,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-60</y>
+        <y>0</y>
         <width>1068</width>
-        <height>829</height>
+        <height>849</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -225,7 +225,875 @@
                <property name="verticalSpacing">
                 <number>10</number>
                </property>
-               <item row="8" column="0">
+               <item row="1" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_12">
+                 <item>
+                  <widget class="QCheckBox" name="userNotesCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_12">
+                   <property name="text">
+                    <string>Enable user notes in main page</string>
+                   </property>
+                   <property name="margin">
+                    <number>0</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="5" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_31">
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="autoUpdatesCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_29">
+                   <property name="text">
+                    <string>Enable automatic update checking</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_23">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="12" column="1">
+                <layout class="QVBoxLayout" name="verticalLayout_8">
+                 <property name="spacing">
+                  <number>10</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_27">
+                   <item>
+                    <widget class="QLabel" name="label_27">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>DEBUG</string>
+                     </property>
+                     <property name="subsection_label" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line_7">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="subsection_line" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_36">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="showPlotFps">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_25">
+                     <property name="text">
+                      <string>Show plot FPS</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_25">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_34">
+                     <item>
+                      <widget class="QCheckBox" name="enableLoggingCheckBox">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="LoggingLabel">
+                       <property name="text">
+                        <string>Enable Session Logging (Only for Debugging, Bugreporting)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_24">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="loggingUnavailableLabel">
+                     <property name="styleSheet">
+                      <string notr="true">color:red</string>
+                     </property>
+                     <property name="text">
+                      <string>Currently unavailable: libm2k logging system is disabled</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_28">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="debugInstrumentCheckbox">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_26">
+                     <property name="text">
+                      <string>Enable IIO Debug Instrument (Requires Scopy restart)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_21">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_26">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="debugMessagesCheckbox">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="debugMessagesLbl">
+                     <property name="text">
+                      <string>Enable Debug Messages (Only for Debugging, Bugreporting)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_20">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_35">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="useOpenGl">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_31">
+                     <property name="text">
+                      <string>Use hardware accelerated plotting - OpenGL (EXPERIMENTAL)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_26">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+               <item row="3" column="0">
+                <widget class="QWidget" name="extScriptWidget" native="true">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_14">
+                  <property name="spacing">
+                   <number>0</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_23">
+                    <item>
+                     <widget class="QCheckBox" name="extScriptCheckBox">
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_14">
+                      <property name="text">
+                       <string>Run external scripts (Experimental)</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_10">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_25">
+                 <item>
+                  <widget class="QCheckBox" name="instrumentNotesCheckbox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_24">
+                   <property name="text">
+                    <string>Enable all instrument notes</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_19">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="11" column="0">
+                <layout class="QVBoxLayout" name="verticalLayout_4">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_8">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>SPECTRUM ANALYZER </string>
+                     </property>
+                     <property name="subsection_label" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line_3">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="subsection_line" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_6">
+                   <item>
+                    <widget class="QCheckBox" name="spectrumVisiblePeakSearch">
+                     <property name="text">
+                      <string/>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_5">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>Only search marker peaks in visible domain</string>
+                     </property>
+                     <property name="margin">
+                      <number>0</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_6">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+               <item row="4" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_29">
+                 <item>
+                  <widget class="QCheckBox" name="tempLutCalibCheckbox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_28">
+                   <property name="text">
+                    <string>Attempt temperature-based calibration (EXPERIMENTAL)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_22">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="3" column="1">
+                <widget class="QWidget" name="manualCalibWidget" native="true">
+                 <layout class="QHBoxLayout" name="horizontalLayout_15">
+                  <property name="spacing">
+                   <number>0</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_24">
+                    <item>
+                     <widget class="QCheckBox" name="manualCalibCheckBox">
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_15">
+                      <property name="text">
+                       <string>Scriptable manual calibration</string>
+                      </property>
+                      <property name="margin">
+                       <number>0</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_11">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_18">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>10</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>10</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="label_21">
+                   <property name="text">
+                    <string>Language (requires app restart)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_17">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="languageCombo">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="10" column="1">
+                <widget class="QWidget" name="SignalGenerator" native="true">
+                 <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_10">
+                    <property name="spacing">
+                     <number>6</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="label_9">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>SIGNAL GENERATOR </string>
+                      </property>
+                      <property name="subsection_label" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="Line" name="line_4">
+                      <property name="minimumSize">
+                       <size>
+                        <width>0</width>
+                        <height>1</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>1</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="subsection_line" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_4">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>5</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="label_3">
+                      <property name="text">
+                       <string>Number of displayed periods </string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="sigGenNrPeriods">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="styleSheet">
+                       <string notr="true">
+QLineEdit[invalid=true] {
+border-color: red;
+color: red;
+}
+QLineEdit[valid=true] {
+border-color: grey;
+color: white;
+}</string>
+                      </property>
+                      <property name="text">
+                       <string>1</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_2">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_5">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Expanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_16">
+                 <item>
+                  <widget class="QCheckBox" name="enableAnimCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_16">
+                   <property name="text">
+                    <string>Enable animations</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_12">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="9" column="0">
+                <spacer name="verticalSpacer_8">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>15</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <item>
+                  <widget class="QCheckBox" name="saveSessionCheckBox">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_4">
+                   <property name="text">
+                    <string>Save session when closing Scopy</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_3">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="10" column="0">
                 <widget class="QWidget" name="Oscilloscope_2" native="true">
                  <layout class="QGridLayout" name="gridLayout_2">
                   <property name="leftMargin">
@@ -466,518 +1334,7 @@
                  </layout>
                 </widget>
                </item>
-               <item row="10" column="1">
-                <layout class="QVBoxLayout" name="verticalLayout_8">
-                 <property name="spacing">
-                  <number>10</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_27">
-                   <item>
-                    <widget class="QLabel" name="label_27">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>DEBUG</string>
-                     </property>
-                     <property name="subsection_label" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line_7">
-                     <property name="minimumSize">
-                      <size>
-                       <width>0</width>
-                       <height>1</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>1</height>
-                      </size>
-                     </property>
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="subsection_line" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_36">
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="showPlotFps">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="label_25">
-                     <property name="text">
-                      <string>Show plot FPS</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_25">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QVBoxLayout" name="verticalLayout_10">
-                   <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_34">
-                     <item>
-                      <widget class="QCheckBox" name="enableLoggingCheckBox">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="LoggingLabel">
-                       <property name="text">
-                        <string>Enable Session Logging (Only for Debugging, Bugreporting)</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <spacer name="horizontalSpacer_24">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>40</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                    </layout>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="loggingUnavailableLabel">
-                     <property name="styleSheet">
-                      <string notr="true">color:red</string>
-                     </property>
-                     <property name="text">
-                      <string>Currently unavailable: libm2k logging system is disabled</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_28">
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="debugInstrumentCheckbox">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="label_26">
-                     <property name="text">
-                      <string>Enable IIO Debug Instrument (Requires Scopy restart)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_21">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_26">
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="debugMessagesCheckbox">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="debugMessagesLbl">
-                     <property name="text">
-                      <string>Enable Debug Messages (Only for Debugging, Bugreporting)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_20">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_35">
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="useOpenGl">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="label_31">
-                     <property name="text">
-                      <string>Use hardware accelerated plotting - OpenGL (EXPERIMENTAL)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_26">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_25">
-                 <item>
-                  <widget class="QCheckBox" name="instrumentNotesCheckbox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_24">
-                   <property name="text">
-                    <string>Enable all instrument notes</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_19">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="3" column="1">
-                <widget class="QWidget" name="manualCalibWidget" native="true">
-                 <layout class="QHBoxLayout" name="horizontalLayout_15">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_24">
-                    <item>
-                     <widget class="QCheckBox" name="manualCalibCheckBox">
-                      <property name="text">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="label_15">
-                      <property name="text">
-                       <string>Scriptable manual calibration</string>
-                      </property>
-                      <property name="margin">
-                       <number>0</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_11">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
-                 <item>
-                  <widget class="QCheckBox" name="saveSessionCheckBox">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_4">
-                   <property name="text">
-                    <string>Save session when closing Scopy</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_3">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="8" column="1">
-                <widget class="QWidget" name="SignalGenerator" native="true">
-                 <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <property name="spacing">
-                   <number>6</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_10">
-                    <property name="spacing">
-                     <number>6</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <widget class="QLabel" name="label_9">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>SIGNAL GENERATOR </string>
-                      </property>
-                      <property name="subsection_label" stdset="0">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="Line" name="line_4">
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>1</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>16777215</width>
-                        <height>1</height>
-                       </size>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="subsection_line" stdset="0">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <spacer name="verticalSpacer_4">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeType">
-                     <enum>QSizePolicy::Fixed</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>5</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="QLabel" name="label_3">
-                      <property name="text">
-                       <string>Number of displayed periods </string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="sigGenNrPeriods">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="styleSheet">
-                       <string notr="true">
-QLineEdit[invalid=true] {
-border-color: red;
-color: red;
-}
-QLineEdit[valid=true] {
-border-color: grey;
-color: white;
-}</string>
-                      </property>
-                      <property name="text">
-                       <string>1</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_2">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <spacer name="verticalSpacer_5">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeType">
-                     <enum>QSizePolicy::Expanding</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="10" column="0">
+               <item row="12" column="0">
                 <layout class="QVBoxLayout" name="LogicAnalyzer">
                  <property name="spacing">
                   <number>6</number>
@@ -1079,7 +1436,120 @@ color: white;
                  </item>
                 </layout>
                </item>
-               <item row="9" column="1">
+               <item row="2" column="0">
+                <layout class="QHBoxLayout" name="decodersWidget">
+                 <item>
+                  <widget class="QCheckBox" name="decodersCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_19">
+                   <property name="text">
+                    <string>Enable digital decoders</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_15">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="1">
+                <widget class="QWidget" name="doubleClickToDetachWidget" native="true">
+                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QCheckBox" name="doubleClickCheckBox">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label">
+                    <property name="text">
+                     <string>Double click to detach a tool</string>
+                    </property>
+                    <property name="margin">
+                     <number>0</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_5">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <item>
+                  <widget class="QCheckBox" name="advancedInfoCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_11">
+                   <property name="text">
+                    <string>Show advanced device information</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="11" column="1">
                 <widget class="QWidget" name="NetworkAnalyzer" native="true">
                  <layout class="QVBoxLayout" name="verticalLayout_5">
                   <property name="spacing">
@@ -1226,361 +1696,7 @@ color: white;
                  </layout>
                 </widget>
                </item>
-               <item row="3" column="0">
-                <widget class="QWidget" name="extScriptWidget" native="true">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_14">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_23">
-                    <item>
-                     <widget class="QCheckBox" name="extScriptCheckBox">
-                      <property name="text">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="label_14">
-                      <property name="text">
-                       <string>Run external scripts (Experimental)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_10">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <layout class="QHBoxLayout" name="decodersWidget">
-                 <item>
-                  <widget class="QCheckBox" name="decodersCheckBox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_19">
-                   <property name="text">
-                    <string>Enable digital decoders</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_15">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="4" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_16">
-                 <item>
-                  <widget class="QCheckBox" name="enableAnimCheckBox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_16">
-                   <property name="text">
-                    <string>Enable animations</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_12">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="0" column="1">
-                <widget class="QWidget" name="doubleClickToDetachWidget" native="true">
-                 <layout class="QHBoxLayout" name="horizontalLayout_5">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QCheckBox" name="doubleClickCheckBox">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="label">
-                    <property name="text">
-                     <string>Double click to detach a tool</string>
-                    </property>
-                    <property name="margin">
-                     <number>0</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="horizontalSpacer_5">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <layout class="QVBoxLayout" name="verticalLayout_4">
-                 <property name="spacing">
-                  <number>6</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_9">
-                   <property name="spacing">
-                    <number>6</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="label_8">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>SPECTRUM ANALYZER </string>
-                     </property>
-                     <property name="subsection_label" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line_3">
-                     <property name="minimumSize">
-                      <size>
-                       <width>0</width>
-                       <height>1</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>1</height>
-                      </size>
-                     </property>
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="subsection_line" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_6">
-                   <item>
-                    <widget class="QCheckBox" name="spectrumVisiblePeakSearch">
-                     <property name="text">
-                      <string/>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="label_5">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Only search marker peaks in visible domain</string>
-                     </property>
-                     <property name="margin">
-                      <number>0</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_6">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </item>
-               <item row="6" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_33">
-                 <item>
-                  <widget class="QLabel" name="label_30">
-                   <property name="text">
-                    <string>Theme</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxTheme"/>
-                 </item>
-                </layout>
-               </item>
-               <item row="4" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_29">
-                 <item>
-                  <widget class="QCheckBox" name="tempLutCalibCheckbox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_28">
-                   <property name="text">
-                    <string>Attempt temperature-based calibration (EXPERIMENTAL)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_22">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
-                 <item>
-                  <widget class="QCheckBox" name="advancedInfoCheckBox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_11">
-                   <property name="text">
-                    <string>Show advanced device information</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_7">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="7" column="1">
+               <item row="9" column="1">
                 <widget class="QWidget" name="widget" native="true">
                  <layout class="QVBoxLayout" name="verticalLayout_6">
                   <property name="spacing">
@@ -1598,172 +1714,8 @@ color: white;
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_18">
-                    <property name="spacing">
-                     <number>0</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>10</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>10</number>
-                    </property>
-                    <item>
-                     <widget class="QLabel" name="label_21">
-                      <property name="text">
-                       <string>Language (requires app restart)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_17">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Fixed</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="languageCombo">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
                  </layout>
                 </widget>
-               </item>
-               <item row="5" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_31">
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QCheckBox" name="autoUpdatesCheckBox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_29">
-                   <property name="text">
-                    <string>Enable automatic update checking</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_23">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_12">
-                 <item>
-                  <widget class="QCheckBox" name="userNotesCheckBox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_12">
-                   <property name="text">
-                    <string>Enable user notes in main page</string>
-                   </property>
-                   <property name="margin">
-                    <number>0</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_8">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="6" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_30">
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QCheckBox" name="skipCalCheckbox">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_26">
-                   <property name="text">
-                    <string>Skip calibration if already calibrated (needs FW &gt;= 0.26)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_21">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="7" column="0">
-                <spacer name="verticalSpacer_8">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>15</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
                <item row="5" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayout_37">
@@ -1802,6 +1754,85 @@ color: white;
                     </property>
                    </item>
                   </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="6" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_40">
+                 <item>
+                  <widget class="QCheckBox" name="enableDockableWidgetsCheckBox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_33">
+                   <property name="text">
+                    <string>Enable dockable widgets</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_27">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="8" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_33">
+                 <item>
+                  <widget class="QLabel" name="label_30">
+                   <property name="text">
+                    <string>Theme</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxTheme"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="6" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_30">
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="skipCalCheckbox">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_26">
+                   <property name="text">
+                    <string>Skip calibration if already calibrated (needs FW &gt;= 0.26)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_21">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>

--- a/ui/spectrum_analyzer.ui
+++ b/ui/spectrum_analyzer.ui
@@ -296,16 +296,16 @@ min-width: 6em;
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <property name="leftMargin">
-            <number>20</number>
+            <number>0</number>
            </property>
            <property name="topMargin">
             <number>0</number>
            </property>
            <property name="rightMargin">
-            <number>20</number>
+            <number>0</number>
            </property>
            <property name="bottomMargin">
-            <number>20</number>
+            <number>0</number>
            </property>
            <property name="horizontalSpacing">
             <number>0</number>


### PR DESCRIPTION
- re-added the fixed plots 
- added preferences option for dockable/undockable widgets
- re-arranged QDockWidgets 
- styled QDockWidgets
- removed margins surrounding plots
- disabled floating widgets on android
- fixed size of general setting menu in logic analyzer
- cherry-picked from #1190 : hide buffer previewer for logic analyzer, re-added min sized for capture plot, fix bad UI rendering 