### PR TITLE
FftDisplayPlot.cc: Use update instead of repaint 

### DIFF
--- a/src/FftDisplayPlot.cc
+++ b/src/FftDisplayPlot.cc
@@ -223,8 +223,8 @@ void FftDisplayPlot::replot()
 		return;
 	}
 
-	d_leftHandlesArea->repaint();
-	d_bottomHandlesArea->repaint();
+	d_leftHandlesArea->update();
+	d_bottomHandlesArea->update();
 
 	BasicPlot::replot();
 }
@@ -268,7 +268,7 @@ void FftDisplayPlot::setupReadouts()
 
 void FftDisplayPlot::updateHandleAreaPadding()
 {
-	d_leftHandlesArea->repaint();
+	d_leftHandlesArea->update();
 	d_bottomHandlesArea->setLeftPadding(d_leftHandlesArea->width());
 	d_bottomHandlesArea->setRightPadding(50);
 


### PR DESCRIPTION
Calling repaint tries to force an immediate repaint and causes hangs on MacOS - in software rendering mode).

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>