### PR TITLE
macOS: Do not replace app icon with low-resolution .ico on startup

### DIFF
--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -137,8 +137,10 @@ ToolLauncher::ToolLauncher(QString prevCrashDump, QWidget *parent) :
 	registerNativeMethods();
 #endif
 
+#ifndef __APPLE__
 	setWindowIcon(QIcon(":/icon.ico"));
 	QApplication::setWindowIcon(QIcon(":/icon.ico"));
+#endif
 
 	// TO DO: remove this when the About menu becomes available
 	setWindowTitle(QString("Scopy - ") + QString("v"+QString(PROJECT_VERSION)) + " - " + QString(SCOPY_VERSION_GIT));


### PR DESCRIPTION
macOS bundle already comes with high-resolution `.icns` file. Calling unconditionally `QApplication::setWindowIcon(QIcon(":/icon.ico"))` causes macOS replace high quality icon with low resolution one.

Alternatively we might want to limit `setWindowIcon` to Windows platform.