### PR TITLE
inside_flatpak_docker.sh: Run the preprocess step to generate the json file, then disable the auto preprocessing at build time.

### DIFF
--- a/CI/appveyor/inside_flatpak_docker.sh
+++ b/CI/appveyor/inside_flatpak_docker.sh
@@ -14,6 +14,13 @@ cd "$REPO_LOCAL"
 # the cache should be updated from time to time locally
 git fetch && git reset origin/master --hard
 
+# Run the preprocess step to generate org.adi.Scopy.json
+make preprocess
+
+# Disable the preprocess step; The Json file will now be modified and
+# we don't want to re-generate it at the build step
+export EN_PREPROCESS=false
+
 # check the number of elements in the json file in order to get the last element, which is Scopy
 cnt=$( echo `jq '.modules | length' org.adi.Scopy.json` )
 cnt=$(($cnt-1))


### PR DESCRIPTION
Otherwise we don't build the current commit for Scopy, we just build
what's hardcoded in the json.c file.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>