### PR TITLE
preferences: Fix preferences initialization at startup, don't rely on showEvent() to initialize them.

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -320,6 +320,7 @@ Preferences::Preferences(QWidget *parent) :
 		requestRestart();
 	});
 	pref_ptr = this;
+	initializePreferences();
 }
 
 void Preferences::save() {
@@ -403,7 +404,7 @@ void Preferences::notifyChange()
 	Q_EMIT notify();
 }
 
-void Preferences::showEvent(QShowEvent *event)
+void Preferences::initializePreferences()
 {
 
 	setDynamicProperty(ui->sigGenNrPeriods, "invalid", false);
@@ -452,7 +453,11 @@ void Preferences::showEvent(QShowEvent *event)
 	ui->loggingUnavailableLabel->setVisible(true);
 	m_logging_enabled = false;
 #endif
+}
 
+void Preferences::showEvent(QShowEvent *event)
+{
+	initializePreferences();
 	QWidget::showEvent(event);
 }
 

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -213,6 +213,7 @@ private:
 	Preferences_API *pref_api;
 
 	ScopyColorEditor *m_colorEditor;
+	void initializePreferences();
 };
 
 class Preferences_API : public ApiObject


### PR DESCRIPTION
Preference checkboxes get visually updated only on showEvent, but they trigger other changes in the preference mechanism (example: OpenGL default on Android/MacOS/Windows - setup env var which is used in the app later on). They should be initialized in the constructor, right after creating the preference menu. We shouldn't rely on showEvent and wait until the Preference menu is opened.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>