### PR TITLE
Temporary: Use another docker image for the Android builds, with debug libs.

### DIFF
--- a/.github/workflows/androidbuild.yml
+++ b/.github/workflows/androidbuild.yml
@@ -10,14 +10,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Pull the Docker Image
-      run: docker pull analogdevices/scopy-build:android
+      run: docker pull ioanachelaruu/scopy-android:debug
     - name: Run Docker Image
       run: |
             docker run --privileged --net=host \
                 -v `pwd`:$GITHUB_WORKSPACE:rw \
                 -e "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" \
                 -e "BRANCH=${GITHUB_REF#refs/heads/}" \
-                analogdevices/scopy-build:android /bin/bash -xe $GITHUB_WORKSPACE/CI/appveyor/build_scopy_apk.sh
+                ioanachelaruu/scopy-android:debug /bin/bash -xe $GITHUB_WORKSPACE/CI/appveyor/build_scopy_apk.sh
     - uses: actions/upload-artifact@v2
       with:
         name: scopy-android


### PR DESCRIPTION
Building the APK and deps in release mode implies signing the package.
For now we can use debug mode, in order to test the release candidate.

https://github.com/analogdevicesinc/scopy-android-deps/commit/b16d52d1b7b2d7f5a76a41d282fe576c0a47f456

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>