### PR TITLE
oscilloscope: update plot axis after setting v/div

### DIFF
--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3473,6 +3473,7 @@ void adiscope::Oscilloscope::onVertScaleValueChanged(double value)
 	cancelZoom();
 	if (value != plot.VertUnitsPerDiv(current_ch_widget)) {
 		plot.setVertUnitsPerDiv(value, current_ch_widget);
+		plot.replot();
 	}
 	voltsPosition->setStep(value / 10);
 


### PR DESCRIPTION
This is v/div is used to compute the gain of the m2k. If it is not updated
immediately, the gain setting lags behind. Alternatively a different way
of computing the gain setting could be implemented.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>