### PR TITLE
CI/inside_mingw_docker.sh: Export .iss file to scopy archive artifact.

### DIFF
--- a/CI/appveyor/inside_mingw_docker.sh
+++ b/CI/appveyor/inside_mingw_docker.sh
@@ -44,7 +44,7 @@ cp -r -n $DLL_DEPS $DEST_FOLDER/
 cd $STAGING/$MINGW_VERSION/bin 
 cp -r $DLL_DEPS $DEST_FOLDER/
 cp -r $PYTHON_FILES $DEST_FOLDER
-
+cp $BUILD_FOLDER/scopy-$ARCH_BIT.iss $DEST_FOLDER
 
 echo "### Extracting debug symbols ..."
 mkdir -p $DEST_FOLDER/.debug


### PR DESCRIPTION
The ISS file is needed when creating the release installer.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>