### PR TITLE
logic_analyzer: fix drawing of last sample

### DIFF
--- a/src/logicanalyzer/logicdatacurve.cpp
+++ b/src/logicanalyzer/logicdatacurve.cpp
@@ -164,11 +164,7 @@ void LogicDataCurve::drawLines(QPainter *painter, const QwtScaleMap &xMap,
 	displayedData += QPointF(t2, y2);
     }
 
-    if (edges.back().first + 1 < m_endSample - 1) {
-	displayedData += QPointF(fromSampleToTime(m_endSample - 1), (!edges.back().second) * heightInPoints + m_pixelOffset);
-    }
-
-    if (edges.back().first + 1 == m_endSample - 1) {
+    if (edges.back().first + 1 < m_endSample) {
 	    displayedData += QPointF(plot()->axisInterval(QwtAxis::XBottom).maxValue(), displayedData.back().y());
     }
 


### PR DESCRIPTION
Draw straight line from the last sample to the end of the plot
From last edge in the list to the end of the plot->axisInterval,
with height of the last sample.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>