### PR TITLE
gui: removed frames for QScrollArea and QTabBar

### DIFF
--- a/resources/stylesheets/templates/default.qss.c
+++ b/resources/stylesheets/templates/default.qss.c
@@ -101,6 +101,8 @@ QTabWidget::tab-bar { left: 0; }
 
 QTabWidget::pane { border-top: 0px; }
 
+QTabBar { qproperty-drawBase: 0; }
+
 QTabBar::tab {
 	min-width: 100px;
 	min-height: 32px;
@@ -258,6 +260,8 @@ QGroupBox::title {
 	subcontrol-origin: margin;
 	subcontrol-position: top left; /* position at the top center */
 }
+
+QScrollArea { border: 0px;}
 
 QScrollBar:vertical {
   background: #262628;

--- a/resources/stylesheets/templates/light.qss.c
+++ b/resources/stylesheets/templates/light.qss.c
@@ -102,6 +102,8 @@ QTabWidget::tab-bar { left: 0; }
 
 QTabWidget::pane { border-top: 0px; }
 
+QTabBar { qproperty-drawBase: 0; }
+
 QTabBar::tab {
 	min-width: 100px;
 	min-height: 32px;
@@ -258,6 +260,8 @@ QGroupBox::title {
 	subcontrol-origin: margin;
 	subcontrol-position: top left; /* position at the top center */
 }
+
+QScrollArea { border: 0px;}
 
 QScrollBar:vertical {
   background: #F7F7F7;


### PR DESCRIPTION
these were visible on Windows, in osc -> mixed signal menu and the tabs of the dock widgets

Signed-off-by: ioanachelaru <Ioana.Chelaru@analog.com>