### PR TITLE
network_analyzer: do not clear graph when changing number of samples

### DIFF
--- a/src/nyquistGraph.cpp
+++ b/src/nyquistGraph.cpp
@@ -183,9 +183,11 @@ int NyquistGraph::getNumSamples() const
 
 void NyquistGraph::setNumSamples(int num)
 {
-	numSamples = (unsigned int) num;
 
-	reset();
+	if (numSamples == num) {
+		return;
+	}
+	numSamples = (unsigned int) num;
 	samples->reserve(numSamples + 1);
 
 	replot();


### PR DESCRIPTION
Graph gets cleared anyways on next run

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>