### PR TITLE
general : dmm menu arrows style fix

### DIFF
--- a/resources/stylesheets/templates/default.qss.c
+++ b/resources/stylesheets/templates/default.qss.c
@@ -339,15 +339,17 @@ QLabel[subsection_label=true]{
 QFrame[subsection_line=true]{ border: 1px solid rgba(255, 255, 255, 70); }
 
 QPushButton[subsection_arrow_button=true]{
-	max-height: 6px;
-	max-width: 10px;
-	border-image: url(:/icons/scopy-default/icons/sba_cmb_box_arrow.svg);
+	max-height: 12px;
+	max-width: 12px;
+	border: none;
+	image: url(:/icons/scopy-default/icons/sba_cmb_box_arrow.svg);
 }
 
 QPushButton[subsection_arrow_button=true]:checked{
-	max-height: 10px;
-	max-width:  6px;
-	border-image: url(:/icons/scopy-default/icons/sba_cmb_box_arrow_right.svg);
+	max-height: 12px;
+	max-width:  12px;
+	border: none;
+	image: url(:/icons/scopy-default/icons/sba_cmb_box_arrow_right.svg);
 }
 
 

--- a/resources/stylesheets/templates/light.qss.c
+++ b/resources/stylesheets/templates/light.qss.c
@@ -339,15 +339,17 @@ QLabel[subsection_label=true]{
 QFrame[subsection_line=true]{ border: 1px solid rgba(0, 0, 0, 50); }
 
 QPushButton[subsection_arrow_button=true]{
-	max-height: 6px;
-	max-width: 10px;
-	border-image: url(:/icons/scopy-light/icons/sba_cmb_box_arrow.svg);
+	max-height: 12px;
+	max-width: 12px;
+	border: none;
+	image: url(:/icons/scopy-light/icons/sba_cmb_box_arrow.svg);
 }
 
 QPushButton[subsection_arrow_button=true]:checked{
-	max-height: 10px;
-	max-width:  6px;
-	border-image: url(:/icons/scopy-light/icons/sba_cmb_box_arrow_right.svg);
+	max-height: 12px;
+	max-width:  12px;
+	border: none;
+	image: url(:/icons/scopy-light/icons/sba_cmb_box_arrow_right.svg);
 }
 
 


### PR DESCRIPTION
Since Qt does not support HiDPI SVG assets on border-image and background-image having different size images on the same position will cause the image to look bad the solution is to replace "border-image" or "backgroud-image" with "image" or "icon" and set "border: none;"


Signed-off-by: Ionut Muthi <ionut.muthi@analog.com>