### PR TITLE
Fix generic device issues

### DIFF
--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1750,7 +1750,9 @@ bool adiscope::ToolLauncher::switchContext(const QString& uri)
 
 	m_m2k = m2kOpen(ctx, "");
 #ifdef LIBM2K_ENABLE_LOG
-	m_m2k->logAllAttributes();
+	if (m_m2k) {
+		m_m2k->logAllAttributes();
+	}
 #endif
 
 	filter = new Filter(ctx);

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1426,6 +1426,7 @@ void adiscope::ToolLauncher::destroyContext()
 			libm2k::context::contextCloseAll();
 		}
 		iio_context_destroy(ctx);
+
 		ctx = nullptr;
 	}
 
@@ -1754,8 +1755,8 @@ bool adiscope::ToolLauncher::switchContext(const QString& uri)
 		m_m2k->logAllAttributes();
 	}
 #endif
-
 	filter = new Filter(ctx);
+	menu->loadToolsFromFilter(filter);
 	if (filter->hw_name().compare("M2K") != 0) {
 		menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(false);
 	} else {

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1423,8 +1423,9 @@ void adiscope::ToolLauncher::destroyContext()
 			}
 			m_m2k = nullptr;
 		} else {
-			iio_context_destroy(ctx);
+			libm2k::context::contextCloseAll();
 		}
+		iio_context_destroy(ctx);
 		ctx = nullptr;
 	}
 

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -404,11 +404,6 @@ void ToolLauncher::_setupToolMenu()
 	menu = new ToolMenu(prefPanel, ui->menuContainer);
 	ui->menuContainerLayout->addWidget(menu);
 
-	// handle debugger tool and manual calibration
-	// TODO: move to preferences ??
-	if (!debugger_enabled) {
-		menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(true);
-	}
 	if (!manual_calibration_enabled) {
 		menu->getToolMenuItemFor(TOOL_CALIBRATION)->setToolDisabled(true);
 	}
@@ -1188,6 +1183,13 @@ void adiscope::ToolLauncher::deviceBtn_clicked(bool pressed)
 			if (tempCtx) {
 				auto tempFilter = new Filter(tempCtx);
 				menu->loadToolsFromFilter(tempFilter);
+				if (tempFilter->hw_name().compare("M2K") != 0) {
+					menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(false);
+				} else {
+					if (!debugger_enabled) {
+						menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(true);
+					}
+				}
 				delete tempFilter;
 				iio_context_destroy(tempCtx);
 			}
@@ -1656,14 +1658,6 @@ void adiscope::ToolLauncher::enableAdcBasedTools()
 			});
 		}
 
-		if (filter->compatible(TOOL_DEBUGGER)) {
-			debugger = new Debugger(ctx, filter,menu->getToolMenuItemFor(TOOL_DEBUGGER),
-						&js_engine, this);
-			adc_users_group.addButton(menu->getToolMenuItemFor(TOOL_DEBUGGER)->getToolStopBtn());
-			QObject::connect(debugger, &Debugger::newDebuggerInstance, this,
-					 &ToolLauncher::addDebugWindow);
-		}
-
 		if (filter->compatible(TOOL_CALIBRATION)) {
 			manual_calibration = new ManualCalibration(ctx, filter,menu->getToolMenuItemFor(TOOL_CALIBRATION),
 								   &js_engine, this, calib);
@@ -1759,6 +1753,13 @@ bool adiscope::ToolLauncher::switchContext(const QString& uri)
 #endif
 
 	filter = new Filter(ctx);
+	if (filter->hw_name().compare("M2K") != 0) {
+		menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(false);
+	} else {
+		if (!debugger_enabled) {
+			menu->getToolMenuItemFor(TOOL_DEBUGGER)->setToolDisabled(true);
+		}
+	}
 
 	calib = new Calibration(ctx, &js_engine);
 	calib->initialize();
@@ -1804,6 +1805,12 @@ bool adiscope::ToolLauncher::switchContext(const QString& uri)
 			});
 		}
 
+		if (filter->compatible(TOOL_DEBUGGER)) {
+			debugger = new Debugger(ctx, filter,menu->getToolMenuItemFor(TOOL_DEBUGGER),
+						&js_engine, this);
+			QObject::connect(debugger, &Debugger::newDebuggerInstance, this,
+					 &ToolLauncher::addDebugWindow);
+		}
 
 		if (filter->compatible(TOOL_POWER_CONTROLLER)) {
 			power_control = new PowerController(ctx, menu->getToolMenuItemFor(TOOL_POWER_CONTROLLER),

--- a/src/toolmenu.cpp
+++ b/src/toolmenu.cpp
@@ -98,9 +98,8 @@ void ToolMenu::loadToolsFromFilter(Filter *filter)
 	}
 	if (notCompatibleTools.size() && d_items) {
 		removeMenuItem(notCompatibleTools);
-	} else {
-		insertMenuItem(d_compatibleTools, compatiblePositions);
 	}
+	insertMenuItem(d_compatibleTools, compatiblePositions);
 }
 
 ToolMenuItem *ToolMenu::getToolMenuItemFor(enum tool tool)


### PR DESCRIPTION
- [x] Make the debugger always available for generic devices. For M2K we can control whether we want to make the debugger active using the entry from Scopy.ini
- [x] Make sure the tool menu list is correctly updating the items when changing between 2 different devices.
- [x] When disconnecting from a device, the iio_context should always be destroyed by its owner. This is linked to a libm2k fix - https://github.com/analogdevicesinc/libm2k/pull/308 - related to libm2k::Context objects not being properly destroyed in some scenarios.
- [x] Fix connection to generic devices when libm2k logging is enabled.