### PR TITLE
pluto-devices: Clean up the device compatibility list for ADALM-Pluto.

### DIFF
--- a/resources/filter.json
+++ b/resources/filter.json
@@ -4,7 +4,7 @@
 	},
 
 	"FMComms2-4": {
-		"compatible": [ "siggen", "dmm", "osc" ],
+		"compatible": [ "debugger" ],
 		"compatible-devices": [ "cf-ad9361-lpc", "cf-ad9361-dds-core-lpc", "ad9361-phy" ],
 		"osc-devices": [ "cf-ad9361-lpc" ],
 		"dmm-devices": [ "cf-ad9361-lpc" ],


### PR DESCRIPTION
For now, DMM, OSC, Spectrum and Signal Gen all work using gr-m2k.
In the future we'll enable back all these tools.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>