### PR TITLE
general: Migrate Scopy to Qt6 - still work in progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,22 +102,32 @@ if(ANDROID)
     set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
 endif()
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5 COMPONENTS LinguistTools REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
-find_package(Qt5Network REQUIRED)
-if(ANDROID)
-	find_package(Qt5AndroidExtras REQUIRED)
-endif()
-
 FILE(GLOB TS_FILES ${CMAKE_SOURCE_DIR}/resources/translations/*.ts)
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR})
 
-# Creates translation .ts files from ${CMAKE_SOURCE_DIR}
-#qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
+set(QT_MAJOR_VERSION 6)
+#See if the environment var is set
+if(DEFINED ENV{Qt${QT_MAJOR_VERSION}_HOME})
+    message(STATUS "Looking for Qt in: " $ENV{Qt${QT_MAJOR_VERSION}_HOME})
+else()
+    message(STATUS "Qt${QT_MAJOR_VERSION}_HOME environment variable not set. Checking default paths.")
+endif()
 
-# Generate .qm files from the .ts files
-qt5_add_translation(QM_FILES ${TS_FILES})
+find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core Widgets Gui Concurrent Network Qml Svg UiTools Xml LinguistTools OpenGL REQUIRED PATHS $ENV{Qt${QT_MAJOR_VERSION}_HOME})
+if(ANDROID)
+	find_package(Qt${QT_MAJOR_VERSION} COMPONENTS AndroidExtras REQUIRED PATHS $ENV{Qt${QT_MAJOR_VERSION}_HOME})
+endif()
+if ("${QT_MAJOR_VERSION}" STREQUAL "6")
+	find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS StateMachine)
+	# Generate .qm files from the .ts files
+	qt6_add_translation(QM_FILES ${TS_FILES})
+else()
+	# Creates translation .ts files from ${CMAKE_SOURCE_DIR}
+	qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
+
+	# Generate .qm files from the .ts files
+	qt5_add_translation(QM_FILES ${TS_FILES})
+endif()
 
 set(TRANSLATIONS)
 foreach(file ${TS_FILES})
@@ -129,7 +139,7 @@ configure_file(${CMAKE_SOURCE_DIR}/resources/translations.qrc
 	${CMAKE_BINARY_DIR}/translations.qrc
 	@ONLY)
 
-qt5_add_resources(TRANSLATION_RESOURCES ${CMAKE_BINARY_DIR}/translations.qrc)
+qt_add_resources(TRANSLATION_RESOURCES ${CMAKE_BINARY_DIR}/translations.qrc)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -171,11 +181,6 @@ else()
 
 endif()
 
-find_package(Qt5Qml REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5UiTools REQUIRED)
-find_package(Qt5Xml REQUIRED)
-
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 find_package(Gnuradio "3.8" REQUIRED COMPONENTS runtime analog blocks fft filter volk pmt )
 
@@ -213,14 +218,7 @@ pkg_get_variable(LIBSIGROK_DECODERS_DIR libsigrokdecode decodersdir)
 
 include_directories(
 	${Boost_INCLUDE_DIRS}
-	${Qt5Widgets_INCLUDE_DIRS}
-	${Qt5Concurrent_INCLUDE_DIRS}
-	${Qt5AndroidExtras_INCLUDE_DIRS}
-	${Qt5Qml_INCLUDE_DIRS}
-	${Qt5UiTools_INCLUDE_DIRS}
 	${QWT_INCLUDE_DIRS}
-	${Qt5Svg_INCLUDE_DIRS}
-	${Qt5Xml_INCLUDE_DIRS}
 	${SCOPY_INCLUDE_DIRS}
 	${LIBSIGROK_DECODE_INCLUDE_DIRS}
 	${GLIB_INCLUDE_DIRS}
@@ -251,10 +249,10 @@ FILE(GLOB SRC_LIST  src/*.cpp src/*.cc
 )
 
 FILE(GLOB M2KSCOPE_UIS ui/patterns/*.ui ui/*.ui)
-qt5_wrap_ui (m2kscope_FORMS_HEADERS ${M2KSCOPE_UIS})
+qt_wrap_ui (m2kscope_FORMS_HEADERS ${M2KSCOPE_UIS})
 
 FILE(GLOB M2KSCOPE_RESOURCES resources/resources.qrc)
-qt5_add_resources(m2kscope_RESOURCES ${M2KSCOPE_RESOURCES})
+qt_add_resources(m2kscope_RESOURCES ${M2KSCOPE_RESOURCES})
 
 if (WIN32)
         set(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/resources/properties.rc)
@@ -302,7 +300,7 @@ if (ENABLE_APPLICATION_BUNDLE)
 
 	set(CMAKE_EXE_LINKER_FLAGS "-Wl,-headerpad_max_install_names -Wl,-search_paths_first ${CMAKE_EXE_LINKER_FLAGS}")
 
-	foreach(plugin ${Qt5Gui_PLUGINS} ${Qt5Svg_PLUGINS})
+	foreach(plugin ${Qt${QT_MAJOR_VERSION}Gui_PLUGINS} ${Qt${QT_MAJOR_VERSION}Svg_PLUGINS})
 		get_target_property(_loc ${plugin} LOCATION)
 		get_filename_component(_name ${_loc} NAME)
 		get_filename_component(_dir ${_loc} DIRECTORY)
@@ -400,7 +398,7 @@ configure_file(${CMAKE_SOURCE_DIR}/resources/aboutpage.qrc
 	${CMAKE_BINARY_DIR}/aboutpage.qrc
 	@ONLY)
 
-qt5_add_resources(ABOUT_PAGE_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/aboutpage.qrc)
+qt_add_resources(ABOUT_PAGE_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/aboutpage.qrc)
 
 option(CLONE_IIO_EMU "Clone iio-emu" ON)
 if (CLONE_IIO_EMU)
@@ -444,12 +442,15 @@ endif()
 target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 		${BREAKPAD_LIBRARIES}
 		${BREAKPADCLIENT_LIBRARIES}
-		${Qt5Widgets_LIBRARIES}
-		${Qt5Concurrent_LIBRARIES}
-		${Qt5Qml_LIBRARIES}
-		${Qt5UiTools_LIBRARIES}
-		${Qt5Network_LIBRARIES}
-		${Qt5AndroidExtras_LIBRARIES}
+		Qt${QT_MAJOR_VERSION}::Widgets
+		Qt${QT_MAJOR_VERSION}::Gui
+		Qt${QT_MAJOR_VERSION}::Concurrent
+		Qt${QT_MAJOR_VERSION}::Qml
+		Qt${QT_MAJOR_VERSION}::UiTools
+		Qt${QT_MAJOR_VERSION}::Network
+		Qt${QT_MAJOR_VERSION}::Svg
+		Qt${QT_MAJOR_VERSION}::Xml
+		Qt${QT_MAJOR_VERSION}::OpenGL
 		${LIBUSB_LIBRARIES}
 		gnuradio::gnuradio-runtime
 		gnuradio::gnuradio-analog
@@ -462,8 +463,6 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 		gnuradio::gnuradio-m2k
 		${Boost_LIBRARIES}
 		${QWT_LIBRARIES}
-		${Qt5Svg_LIBRARIES}
-		${Qt5Xml_LIBRARIES}
 		${MATIO_LIBRARIES}
 		${LIBSIGROK_DECODE_LIBRARIES}
 		${GLIBMM_LIBRARIES}
@@ -471,6 +470,13 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 		${GLIB_LIBRARIES}
 		libm2k::libm2k
 )
+
+if ("${QT_MAJOR_VERSION}" STREQUAL "6")
+	target_link_libraries(${PROJECT_NAME} LINK_PRIVATE Qt${QT_MAJOR_VERSION}::StateMachine)
+endif()
+if (ANDROID)
+	target_link_libraries(${PROJECT_NAME} LINK_PRIVATE Qt${QT_MAJOR_VERSION}::AndroidExtras)
+endif()
 
 if (NOT WIN32)
 	find_library(PTHREAD_LIBRARIES pthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ if(ANDROID)
 	find_package(Qt${QT_MAJOR_VERSION} COMPONENTS AndroidExtras REQUIRED PATHS $ENV{Qt${QT_MAJOR_VERSION}_HOME})
 endif()
 if ("${QT_MAJOR_VERSION}" STREQUAL "6")
-	find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS StateMachine)
 	# Generate .qm files from the .ts files
 	qt6_add_translation(QM_FILES ${TS_FILES})
 else()
@@ -210,8 +209,6 @@ endif()
 find_package(PkgConfig)
 set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
-pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 pkg_check_modules(LIBSIGROK_DECODE REQUIRED libsigrokdecode)
 
 pkg_get_variable(LIBSIGROK_DECODERS_DIR libsigrokdecode decodersdir)
@@ -471,9 +468,6 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 		libm2k::libm2k
 )
 
-if ("${QT_MAJOR_VERSION}" STREQUAL "6")
-	target_link_libraries(${PROJECT_NAME} LINK_PRIVATE Qt${QT_MAJOR_VERSION}::StateMachine)
-endif()
 if (ANDROID)
 	target_link_libraries(${PROJECT_NAME} LINK_PRIVATE Qt${QT_MAJOR_VERSION}::AndroidExtras)
 endif()

--- a/resources/buildinfo.html.cmakein
+++ b/resources/buildinfo.html.cmakein
@@ -11,7 +11,7 @@ ${BUILD_INFO}
 
 This Scopy version uses the following library/tools versions:
 libboost: ${Boost_VERSION}
-libqt5: ${Qt5_VERSION}
+libqt${QT_MAJOR_VERSION}: ${Qt${QT_MAJOR_VERSION}_VERSION}
 volk: ${Volk_VERSION}
 cmake: ${CMAKE_VERSION}
 gnuradio: ${Gnuradio_VERSION}

--- a/resources/stylesheets/bigCustomSwitch.qss
+++ b/resources/stylesheets/bigCustomSwitch.qss
@@ -27,7 +27,7 @@ background-color: #aaaaaa;
 QLabel {
 margin-top: 6px;
 background-color: transparent;
-font: 16px;
+font: 14px;
 }
 
 QLabel#on {

--- a/src/BasicPlot.cpp
+++ b/src/BasicPlot.cpp
@@ -1,6 +1,6 @@
 #include "BasicPlot.h"
 
-#include <QwtPlotOpenGLCanvas>
+#include <qwt_plot_opengl_canvas.h>
 #include <QwtPainter>
 #include <QDebug>
 #include <tool_launcher.hpp>

--- a/src/DisplayPlot.cc
+++ b/src/DisplayPlot.cc
@@ -52,6 +52,7 @@
 #include <QStack>
 #include <QPainter>
 #include <QColor>
+#include <QLocale>
 #include <cmath>
 #include <iostream>
 #include <stdexcept>
@@ -417,7 +418,7 @@ PlotAxisConfiguration::PlotAxisConfiguration(int axisPos, int axisIdx, DisplayPl
 	if (axisPos == QwtAxis::YLeft) {
 		const QFontMetrics fm(d_plot->axisWidget(d_axis)->font());
 		QwtScaleDraw *scaleDraw = d_plot->axisScaleDraw(d_axis);
-		scaleDraw->setMinimumExtent( fm.width("100.00") );
+		scaleDraw->setMinimumExtent( fm.horizontalAdvance("100.00") );
 	}
 
 	// TO DO: Move this to a stylesheet file.
@@ -560,7 +561,7 @@ DisplayPlot::DisplayPlot(int nplots, QWidget* parent,  bool isdBgraph,
 
 	d_panner = new QwtPlotPanner(canvas());
 	d_panner->setAxisEnabled(QwtAxis::YRight, false);
-	d_panner->setMouseButton(Qt::MidButton, Qt::ControlModifier);
+	d_panner->setMouseButton(Qt::MiddleButton, Qt::ControlModifier);
 
 	// emit the position of clicks on widget
 	d_picker = new QwtDblClickPlotPicker(canvas());
@@ -667,7 +668,7 @@ void DisplayPlot::setupDisplayPlotDiv(bool isdBgraph) {
 		  scaleItem->setFont(this->axisWidget(QwtAxis::YLeft)->font());
 
           QPalette palette = scaleItem->palette();
-          palette.setBrush(QPalette::Foreground, QColor("#6E6E6F"));
+	  palette.setBrush(QPalette::WindowText, QColor("#6E6E6F"));
           palette.setBrush(QPalette::Text, QColor("#6E6E6F"));
           scaleItem->setPalette(palette);
           scaleItem->setBorderDistance(0);

--- a/src/FftDisplayPlot.cc
+++ b/src/FftDisplayPlot.cc
@@ -430,7 +430,7 @@ void FftDisplayPlot::setZoomerEnabled()
 
                 QFont font;
                 font.setPointSize(10);
-                font.setWeight(75);
+		font.setWeight(QFont::Bold);
 		d_zoomer[0]->setTrackerFont(font);
 
 #if QWT_VERSION < 0x060000

--- a/src/HistogramDisplayPlot.cc
+++ b/src/HistogramDisplayPlot.cc
@@ -259,7 +259,7 @@ HistogramDisplayPlot::HistogramDisplayPlot(int nplots, QWidget* parent)
 	  osd->setUnitType("V");
 	  osd->setFloatPrecision(2);
 	  osd->setColor(d_CurveColors[i]);
-	  const int fmw = QFontMetrics(scaleWidget->font()).width("-XX.XX XX");
+	  const int fmw = QFontMetrics(scaleWidget->font()).horizontalAdvance("-XX.XX XX");
 	  scaleWidget->setMinBorderDist(fmw / 2, fmw / 2);
   }
   for (int i = 0; i < 2; ++i) {

--- a/src/TimeDomainDisplayPlot.cc
+++ b/src/TimeDomainDisplayPlot.cc
@@ -199,7 +199,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(QWidget* parent, bool isdBgraph, un
 
   QFont font;
   font.setPointSize(10);
-  font.setWeight(75);
+  font.setWeight(QFont::Bold);
   //d_zoomer->setTrackerFont(font);
 
 #if QWT_VERSION < 0x060000
@@ -604,7 +604,7 @@ TimeDomainDisplayPlot::addZoomer(unsigned int zoomerIdx)
 {
     QFont font;
     font.setPointSize(10);
-    font.setWeight(75);
+    font.setWeight(QFont::Bold);
 	d_zoomer[zoomerIdx]->setTrackerFont(font);
 
 	#if QWT_VERSION < 0x060000

--- a/src/datalogger/datalogger.cpp
+++ b/src/datalogger/datalogger.cpp
@@ -223,7 +223,7 @@ void DataLogger::readChannelValues()
 {
 	if (!m_activeChannels.empty()) {
 		for (auto ch : m_activeChannels.keys()) {
-			QtConcurrent::run(this,&DataLogger::updateChannelWidget,ch);
+			QtConcurrent::run(std::bind(&DataLogger::updateChannelWidget, this, ch));
 		}
 	}
 }

--- a/src/dataloggermodel.cpp
+++ b/src/dataloggermodel.cpp
@@ -7,7 +7,7 @@ DataLoggerModel::DataLoggerModel():
 	m_timer(new QTimer())
 {
 	QObject::connect(m_timer, &QTimer::timeout , this, [=](){
-		QtConcurrent::run(this, &DataLoggerModel::logData);
+		QtConcurrent::run(std::bind(&DataLoggerModel::logData, this));
 	});
 }
 
@@ -135,7 +135,7 @@ double DataLoggerModel::computeAvg(QVector<QString> values)
 bool DataLoggerModel::isNumber(const QString& str)
 {
 	for (QChar const &c : str) {
-		if (!( c.isDigit() || c == ".")) return false;
+		if (!( c.isDigit() || c == '.')) return false;
 	}
 	return true;
 }

--- a/src/dbgraph.cpp
+++ b/src/dbgraph.cpp
@@ -173,7 +173,7 @@ dBgraph::dBgraph(QWidget *parent, bool isdBgraph)
 					QwtAbstractScaleDraw::Labels, false);
 
 		QPalette palette = scaleItem->palette();
-		palette.setBrush(QPalette::Foreground, QColor(plotColor));
+		palette.setBrush(QPalette::WindowText, QColor(plotColor));
 		palette.setBrush(QPalette::Text, QColor(plotColor));
 		scaleItem->setPalette(palette);
 		scaleItem->setBorderDistance(0);
@@ -198,7 +198,7 @@ dBgraph::dBgraph(QWidget *parent, bool isdBgraph)
 	setAxisVisible(QwtAxis::XTop, false);
 
 	QwtScaleWidget *scaleWidget = axisWidget(QwtAxis::XTop);
-	const int fmw = QFontMetrics(scaleWidget->font()).width("-XXXX.XX XX");
+	const int fmw = QFontMetrics(scaleWidget->font()).horizontalAdvance("-XXXX.XX XX");
 	scaleWidget->setMinBorderDist(fmw / 2, fmw / 2);
 
 	setupVerticalBars();

--- a/src/device_widget.cpp
+++ b/src/device_widget.cpp
@@ -40,6 +40,9 @@ DeviceWidget::DeviceWidget(QString uri, QString name,
 	m_ui->description->setText(uri);
 	m_ui->name->setText(name);
 
+	m_ui->description->setAlignment(Qt::AlignCenter);
+	m_ui->name->setAlignment(Qt::AlignCenter);
+
 	if (name.compare("M2K") != 0) {
 		m_infoPage = InfoPageBuilder::newPage(InfoPageBuilder::GENERIC,
 						      m_uri,

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -87,7 +87,7 @@ void FileManager::open(QString fileName,
 		while (!in.atEnd()) {
 			QVector<QString> line_data;
 			QString line = in.readLine();
-			QStringList list = line.split(separator, QString::SkipEmptyParts);
+			QStringList list = line.split(separator, Qt::SkipEmptyParts);
 			for (const QString &list_item : qAsConst(list)) {
 				line_data.push_back(list_item);
 			}

--- a/src/graticule.cpp
+++ b/src/graticule.cpp
@@ -32,7 +32,7 @@ Graticule::Graticule(QwtPlot *plot):
 	horizScale2 = new GraticulePlotScaleItem(QwtScaleDraw::TopScale,-1);
 
 	QPalette palette = vertScale->palette();
-	palette.setBrush(QPalette::Foreground, QColor("#6E6E6F"));
+	palette.setBrush(QPalette::WindowText, QColor("#6E6E6F"));
 	palette.setBrush(QPalette::Text, QColor("#6E6E6F"));
 
 	double minTick = vertScale->scaleDraw()->tickLength(QwtScaleDiv::MinorTick);

--- a/src/gui/ComboBoxLineEdit.cpp
+++ b/src/gui/ComboBoxLineEdit.cpp
@@ -36,7 +36,7 @@ void ComboBoxLineEdit::mousePressEvent(QMouseEvent *event)
 	QWidget::mousePressEvent(event);
 }
 
-void ComboBoxLineEdit::enterEvent(QEvent *event)
+void ComboBoxLineEdit::enterEvent(QEnterEvent *event)
 {
 	QWidget::enterEvent(event);
 }

--- a/src/gui/ComboBoxLineEdit.h
+++ b/src/gui/ComboBoxLineEdit.h
@@ -21,6 +21,7 @@
 #define ComboBoxLineEdit_H
 
 #include <QLineEdit>
+#include <QEnterEvent>
 #include <QMouseEvent>
 
 namespace adiscope {
@@ -33,7 +34,7 @@ public:
 protected Q_SLOTS:
 	void mouseReleaseEvent(QMouseEvent *event);
 	void mousePressEvent(QMouseEvent *event);
-	void enterEvent(QEvent *event);
+	void enterEvent(QEnterEvent *event);
 	void leaveEvent(QEvent *event);
 };
 }

--- a/src/gui/channel_manager.cpp
+++ b/src/gui/channel_manager.cpp
@@ -27,7 +27,7 @@ ChannelManager::ChannelManager(ChannelsPositionEnum position, QWidget* parent)
 		auto header = new QWidget();
 		auto headerLayout = new QHBoxLayout(header);
 		header->setSizePolicy(QSizePolicy::Preferred,QSizePolicy::Maximum);
-		headerLayout->setMargin(10);
+		headerLayout->setContentsMargins(10, 10, 10, 10);
 		headerLayout->setSpacing(15);
 
 		toolStatus = new QLabel("");
@@ -62,7 +62,6 @@ ChannelManager::ChannelManager(ChannelsPositionEnum position, QWidget* parent)
 	}
 
 	m_channelsWidget->layout()->setSpacing(0);
-	m_channelsWidget->layout()->setMargin(0);
 	m_channelsWidget->layout()->setContentsMargins(QMargins(0,0,0,0));
 	m_channelsWidget->layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
 	m_channelsWidget->setStyleSheet("border: 0px;");
@@ -89,15 +88,15 @@ ChannelWidget* ChannelManager::buildNewChannel(int chId, bool deletable, bool si
 					       const QString& fullName, const QString& shortName)
 {
 	ChannelWidget* ch = new ChannelWidget(chId, deletable, simplefied, color);
-	m_channelsWidget->layout()->setMargin(0);
-    m_channelsWidget->layout()->addWidget(ch);
+	m_channelsWidget->layout()->setContentsMargins(0, 0, 0, 0);
+	m_channelsWidget->layout()->addWidget(ch);
 	if (m_channelIdVisible) {
-        ch->setFullName(fullName + QString(" %1").arg(chId + 1));
-        ch->setShortName(shortName + QString(" %1").arg(chId + 1));
+		ch->setFullName(fullName + QString(" %1").arg(chId + 1));
+		ch->setShortName(shortName + QString(" %1").arg(chId + 1));
 	} else {
-        ch->setFullName(fullName);
-        ch->setShortName(shortName);
-    }
+		ch->setFullName(fullName);
+		ch->setShortName(shortName);
+	}
 	ch->nameButton()->setText(ch->shortName());
 
 	m_channelsList.append(ch);
@@ -165,7 +164,7 @@ void ChannelManager::changeParent(QWidget* newParent)
 
 	m_channelsWidget->layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
 	m_channelsWidget->layout()->setSpacing(0);
-	m_channelsWidget->layout()->setMargin(0);
+//	m_channelsWidget->layout()->setContentsMargins(0, 0, 0, 0);
 
 	for (ChannelWidget* channel : m_channelsList) {
 		m_channelsWidget->layout()->addWidget(channel);

--- a/src/gui/customSwitch.cpp
+++ b/src/gui/customSwitch.cpp
@@ -21,6 +21,7 @@
 #include "customSwitch.hpp"
 
 #include <QDebug>
+#include <QFile>
 #include <QResizeEvent>
 
 using namespace adiscope;

--- a/src/gui/customSwitch.cpp
+++ b/src/gui/customSwitch.cpp
@@ -49,6 +49,9 @@ CustomSwitch::CustomSwitch(QWidget *parent) : QPushButton(parent),
 	on.setText(tr("on"));
 	off.setText(tr("off"));
 	updateOnOffLabels();
+
+	on.setAlignment(Qt::AlignCenter);
+	off.setAlignment(Qt::AlignCenter);
 }
 
 void CustomSwitch::updateOnOffLabels()

--- a/src/gui/customcolqgridlayout.cpp
+++ b/src/gui/customcolqgridlayout.cpp
@@ -25,7 +25,7 @@ CustomColQGridLayout::CustomColQGridLayout(int maxCols,QWidget *parent) :
 	m_gridLayout->setVerticalSpacing(0);
 	m_gridLayout->setContentsMargins(0, 0, 0, 0);
 	m_gridLayout->setSpacing(0);
-	m_gridLayout->setMargin(0);
+	m_gridLayout->setContentsMargins(0, 0, 0, 0);
 	m_mainWidget->setLayout(m_gridLayout);
 
 	m_hspacer = new QSpacerItem(1,1, QSizePolicy::Expanding, QSizePolicy::Fixed);

--- a/src/gui/measure.cpp
+++ b/src/gui/measure.cpp
@@ -1115,10 +1115,10 @@ void Measure::measureTimeDomain()
 			if ((p1.m_bufIdx == p0.m_bufIdx) && (p1.m_onRising == p0.m_onRising)) {
 				if ((p0.m_name == "MR" && p1.m_name == "LR") ||
 						(p0.m_name == "HR" && p1.m_name == "MR"))
-					crossSequence.swap(i, i - 1);
+					crossSequence.swapItemsAt(i, i - 1);
 				else if ((p0.m_name == "MF" && p1.m_name == "HF") ||
 						(p0.m_name == "LF" && p1.m_name == "MF"))
-					crossSequence.swap(i, i - 1);
+					crossSequence.swapItemsAt(i, i - 1);
 			}
 		}
 

--- a/src/gui/menu_anim.cpp
+++ b/src/gui/menu_anim.cpp
@@ -20,7 +20,6 @@
 
 #include "menu_anim.hpp"
 
-#include <QSignalTransition>
 #include <QSizePolicy>
 
 using namespace adiscope;

--- a/src/gui/osc_export_settings.cpp
+++ b/src/gui/osc_export_settings.cpp
@@ -173,7 +173,7 @@ void ExportSettings::enableExportButton(bool on)
 
 void ExportSettings::disableUIMargins()
 {
-	ui->verticalLayout_3->setMargin(0);
+	ui->verticalLayout_3->setContentsMargins(0, 0, 0, 0);
 }
 
 void ExportSettings::setTitleLabelVisible(bool enabled)

--- a/src/gui/registerwidget.cpp
+++ b/src/gui/registerwidget.cpp
@@ -149,7 +149,7 @@ void RegisterWidget::checkRegisterMap(void)
 	int bit = 0;
 
 	/*sort vector using bit number*/
-	qSort(bitfieldsVector.begin(), bitfieldsVector.end(), lessThan);
+	std::sort(bitfieldsVector.begin(), bitfieldsVector.end(), lessThan);
 
 	for (auto iterator = bitfieldsVector.begin(); iterator != bitfieldsVector.end();
 	     ++iterator) {

--- a/src/gui/smallOnOffSwitch.cpp
+++ b/src/gui/smallOnOffSwitch.cpp
@@ -21,6 +21,7 @@
 #include "smallOnOffSwitch.hpp"
 #include "gui/dynamicWidget.hpp"
 
+#include <QFile>
 #include <QDebug>
 #include <QResizeEvent>
 #include <QStylePainter>

--- a/src/gui/spinbox_a.cpp
+++ b/src/gui/spinbox_a.cpp
@@ -34,7 +34,7 @@
 #include <QComboBox>
 #include <QFile>
 #include <qmath.h>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <QKeyEvent>
 
 #include <QDebug>
@@ -51,7 +51,7 @@ unsigned int SpinBoxA::current_id(0);
 SpinBoxA::SpinBoxA(QWidget *parent) : QWidget(parent),
 	ui(new Ui::SpinBoxA), m_value(0.0), m_min_value(0.0), m_max_value(0.0),
 	m_decimal_count(3),
-	m_validator(new QRegExpValidator(this)),
+	m_validator(new QRegularExpressionValidator(this)),
 	m_sba_api(new SpinBoxA_API(this))
 {
 	ui->setupUi(this);
@@ -178,19 +178,20 @@ void SpinBoxA::onLineEditTextEdited()
 {
 	QLineEdit *lineEdit = static_cast<QLineEdit *>(QObject::sender());
 	QString text = lineEdit->text();
-	QRegExp rx(m_validator->regExp());
+	QRegularExpression rx(m_validator->regularExpression());
 	double value;
 	QString unit;
 	bool ok;
 
-	rx.indexIn(text);
-	value = rx.cap(1).toDouble(&ok);
+	auto regExpMatch = rx.match(text);
+//	rx.indexIn(text);
+	value = regExpMatch.captured(1).toDouble(&ok);
 
 	if (!ok) {
 		return;
 	}
 
-	unit = rx.cap(6);
+	unit = regExpMatch.captured(6);
 
 	if (unit.isEmpty()) {
 		unit = m_units[ui->SBA_Combobox->currentIndex()].first;
@@ -587,7 +588,7 @@ void SpinBoxA::setUnits(const QStringList& list)
 		regex += "([" + sufixes + "]?)";
 	}
 
-	m_validator->setRegExp(QRegExp(regex));
+	m_validator->setRegularExpression(QRegularExpression(regex));
 
 	m_units_list = list;
 }

--- a/src/gui/spinbox_a.hpp
+++ b/src/gui/spinbox_a.hpp
@@ -36,7 +36,7 @@ class QLabel;
 class QLineEdit;
 class QFrame;
 class QComboBox;
-class QRegExpValidator;
+class QRegularExpressionValidator;
 
 namespace Ui {
 class SpinBoxA;
@@ -150,7 +150,7 @@ protected:
 	double m_max_value;
 	int m_decimal_count;
 	std::vector<std::pair<QString, double> > m_units;
-	QRegExpValidator *m_validator;
+	QRegularExpressionValidator *m_validator;
 	double m_displayScale;
 	SpinBoxA_API *m_sba_api;
 	unsigned int m_id;

--- a/src/gui/tool_view.cpp
+++ b/src/gui/tool_view.cpp
@@ -145,7 +145,7 @@ void ToolView::buildChannelsContainer(ChannelManager* cm, ChannelsPositionEnum p
 			}
 
 			m_ui->widgetHorizontalChannels->layout()->setSpacing(0);
-			m_ui->widgetHorizontalChannels->layout()->setMargin(0);
+			m_ui->widgetHorizontalChannels->layout()->setContentsMargins(0, 0, 0, 0);
 
 			Q_EMIT changeParent(m_ui->widgetVerticalChannelsContainer);
 		} else {

--- a/src/gui/user_notes.cpp
+++ b/src/gui/user_notes.cpp
@@ -274,17 +274,18 @@ void UserNotes::clearAllNotes()
  */
 
 Note::Note(QString name, QString path, QWidget *parent) :
-        QWidget(parent),
-        ui(new Ui::Note),
-        m_selected(false),
-        m_name(name),
-        m_path(path),
-        m_page(nullptr)
+	QWidget(parent),
+	ui(new Ui::Note),
+	m_selected(false),
+	m_name(name),
+	m_path(path),
+	m_page(nullptr)
 {
-        ui->setupUi(this);
-        ui->name->setText(name);
-        connect(ui->btn, SIGNAL(toggled(bool)),
-                this, SLOT(setSelected(bool)));
+	ui->setupUi(this);
+	ui->name->setText(name);
+	ui->name->setAlignment(Qt::AlignCenter);
+	connect(ui->btn, SIGNAL(toggled(bool)),
+		this, SLOT(setSelected(bool)));
 
 	pageUi = new Ui::UserNotePage();
 	m_page = new QWidget(this);

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -506,7 +506,7 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 		stackDecoderComboBox->setVisible(shouldBeVisible);
 	};
 
-	connect(decoderComboBox, QOverload<const QString &>::of(&QComboBox::currentIndexChanged), [=](const QString &decoder) {
+	connect(decoderComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
 		decoderComboBox->clearFocus();
 		if (!decoderComboBox->currentIndex()) {
 			return;
@@ -514,6 +514,7 @@ std::vector<QWidget *> LogicAnalyzer::enableMixedSignalView(CapturePlot *osc, in
 
 		std::shared_ptr<logic::Decoder> initialDecoder = nullptr;
 
+		QString decoder = decoderComboBox->itemText(index);
 		GSList *decoderList = g_slist_copy((GSList *)srd_decoder_list());
 		for (const GSList *sl = decoderList; sl; sl = sl->next) {
 		    srd_decoder *dec = (struct srd_decoder *)sl->data;
@@ -2075,14 +2076,14 @@ void LogicAnalyzer::setupDecoders()
 
 	g_slist_free(decoderList);
 
-	connect(ui->addDecoderComboBox, QOverload<const QString &>::of(&QComboBox::currentIndexChanged), [=](const QString &decoder) {
+	connect(ui->addDecoderComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
 		ui->addDecoderComboBox->clearFocus();
 		if (!ui->addDecoderComboBox->currentIndex()) {
 			return;
 		}
 
 		std::shared_ptr<logic::Decoder> initialDecoder = nullptr;
-
+		QString decoder = ui->addDecoderComboBox->itemText(index);
 		GSList *decoderList = g_slist_copy((GSList *)srd_decoder_list());
 		for (const GSList *sl = decoderList; sl; sl = sl->next) {
 		    srd_decoder *dec = (struct srd_decoder *)sl->data;

--- a/src/logicanalyzer/logicanalyzer_api.h
+++ b/src/logicanalyzer/logicanalyzer_api.h
@@ -24,6 +24,7 @@
 
 #include "logic_analyzer.h"
 #include "apiObject.hpp"
+#include <QtGlobal>
 
 namespace adiscope {
 namespace logic {
@@ -71,19 +72,21 @@ public:
 		// Register type. TODO: maybe a cleaner way of doing this
 		// QVariant needs qRegisterMetaTypeStreamOperators for serialization/deserialization
 		qRegisterMetaType<QPair<int, int>>("pair");
-		qRegisterMetaTypeStreamOperators<QPair<int, int>>("pair");
 		qRegisterMetaType<QList<QPair<int, int>>>("list(pair)");
-		qRegisterMetaTypeStreamOperators<QList<QPair<int, int>>>("list(pair)");
 		qRegisterMetaType<QList<QList<QPair<int, int>>>>("list(list(pair))");
-		qRegisterMetaTypeStreamOperators<QList<QList<QPair<int, int>>>>("list(list(pair))");
-
 		qRegisterMetaType<QList<QStringList>>("list(stringlist)");
-		qRegisterMetaTypeStreamOperators<QList<QStringList>>("list(stringlist)");
-
 		qRegisterMetaType<QVector<int>>("vector(int)");
-		qRegisterMetaTypeStreamOperators<QVector<int>>("vector(int)");
 		qRegisterMetaType<QVector<QVector<int>>>("vector(vector(int))");
+#if QT_VERSION < 0x060000
+		// RegisterMetaTypeStreamOperators was removed in Qt6;
+		// The metatype system will instead know about those automatically;
+		qRegisterMetaTypeStreamOperators<QPair<int, int>>("pair");
+		qRegisterMetaTypeStreamOperators<QList<QPair<int, int>>>("list(pair)");
+		qRegisterMetaTypeStreamOperators<QList<QList<QPair<int, int>>>>("list(list(pair))");
+		qRegisterMetaTypeStreamOperators<QList<QStringList>>("list(stringlist)");
+		qRegisterMetaTypeStreamOperators<QVector<int>>("vector(int)");
 		qRegisterMetaTypeStreamOperators<QVector<QVector<int>>>("vector(vector(int))");
+#endif
 	}
 	~LogicAnalyzer_API() {}
 

--- a/src/logicanalyzer/logicgroupitem.cpp
+++ b/src/logicanalyzer/logicgroupitem.cpp
@@ -105,8 +105,8 @@ void LogicGroupItem::buildUi()
 
 	m_nameLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
-	layout->insertWidget(1, m_nameLabel);
 	layout->insertWidget(0, deleteBtn);
+	layout->insertWidget(1, m_nameLabel);
 	layout->insertSpacerItem(2, spacer);
 	layout->insertWidget(3, dragWidget);
 

--- a/src/logicanalyzer/prop/enum.cpp
+++ b/src/logicanalyzer/prop/enum.cpp
@@ -172,7 +172,7 @@ QWidget* Enum::get_widget(QWidget *parent, bool auto_commit)
 		selector_ = new QComboBox(parent);
 		for (unsigned int i = 0; i < values_.size(); i++) {
 			const pair<Glib::VariantBase, QString> &v = values_[i];
-			selector_->addItem(v.second, qVariantFromValue(v.first));
+			selector_->addItem(v.second, QVariant::fromValue(v.first));
 		}
 
 		update_widget();

--- a/src/manualcalibration.cpp
+++ b/src/manualcalibration.cpp
@@ -574,11 +574,11 @@ void ManualCalibration::on_saveButton_clicked()
 		       << QTime::currentTime().toString()
 		       << "\n#ad9963 temperature: " << temp_ad9963
 		       << tr(" °C") << "\n#FPGA temperature: "<< temp_fpga
-		       << tr(" °C") << endl;
+		       << tr(" °C") << Qt::endl;
 
 		for (int i = 0; i < paramTable->rowCount(); i++)
 			stream << "cal," << paramTable->item(i,0)->text() << "="
-			       << paramTable->item(i,1)->text() << endl;
+			       << paramTable->item(i,1)->text() << Qt::endl;
 	}
 
 	file.close();

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -238,7 +238,7 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt,
 	connect(this, &NetworkAnalyzer::sweepDone,
 	[=]() {
 		if (ui->runSingleWidget->runButtonChecked()) {
-			thd = QtConcurrent::run(this, &NetworkAnalyzer::goertzel);
+			thd = QtConcurrent::run(std::bind(&NetworkAnalyzer::goertzel, this));
 			return;
 		}
 
@@ -1734,7 +1734,7 @@ void NetworkAnalyzer::startStop(bool pressed)
 		bufferPreviewer->clear();
 		configHwForNetworkAnalyzing();
 		m_stop = false;
-		thd = QtConcurrent::run(this, &NetworkAnalyzer::goertzel);
+		thd = QtConcurrent::run(std::bind(&NetworkAnalyzer::goertzel, this));
 		ui->statusLabel->setText(tr("Running"));
 	} else {
 		ui->statusLabel->setText(tr("Stopping..."));

--- a/src/nyquistGraph.cpp
+++ b/src/nyquistGraph.cpp
@@ -280,7 +280,7 @@ void NyquistGraph::mouseReleaseEvent(QMouseEvent *event)
 	QwtPolarPlot::mouseReleaseEvent(event);
 }
 
-void NyquistGraph::enterEvent(QEvent *event)
+void NyquistGraph::enterEvent(QEnterEvent *event)
 {
 	if (zoomer->isZoomed())
 		QApplication::setOverrideCursor(Qt::OpenHandCursor);

--- a/src/nyquistGraph.hpp
+++ b/src/nyquistGraph.hpp
@@ -85,7 +85,7 @@ namespace adiscope {
 
 		void mousePressEvent(QMouseEvent *event);
 		void mouseReleaseEvent(QMouseEvent *event);
-		void enterEvent(QEvent *event);
+		void enterEvent(QEnterEvent *event);
 		void leaveEvent(QEvent *event);
 
 	private:

--- a/src/osc_adc.cpp
+++ b/src/osc_adc.cpp
@@ -42,7 +42,7 @@ QStringList IioUtils::available_options_list(struct iio_device *dev,
 	ret = iio_device_attr_read(dev, attr_name, buffer, sizeof(buffer));
 	if (ret >= 0) {
 		QString s(buffer);
-		list = s.split(" ", QString::SkipEmptyParts);
+		list = s.split(" ", Qt::SkipEmptyParts);
 	}
 
 	return list;

--- a/src/osc_scale_zoomer.cpp
+++ b/src/osc_scale_zoomer.cpp
@@ -36,7 +36,7 @@ OscScaleZoomer::OscScaleZoomer(QWidget *parent) :
 
 	QFont font;
 	font.setPointSize(10);
-	font.setWeight(75);
+	font.setWeight(QFont::Bold);
 
 	setTrackerFont(font);
 	setZoomBase();

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -117,7 +117,7 @@ CapturePlot::CapturePlot(QWidget *parent,  bool isdBgraph, unsigned int xNumDivs
 	// stylesheet will be ignored when calculating width using FontMetrics
 	int width = d_timeBaseLabel->minimumSizeHint().width();
 	QFontMetrics fm = d_timeBaseLabel->fontMetrics();
-	width = fm.width("999.999 ms/div");
+	width = fm.horizontalAdvance("999.999 ms/div");
 	d_timeBaseLabel->setMinimumWidth(width);
 
 	// Sample Rate and Buffer Size
@@ -362,7 +362,7 @@ CapturePlot::CapturePlot(QWidget *parent,  bool isdBgraph, unsigned int xNumDivs
 
 	installEventFilter(this);
 	QwtScaleWidget *scaleWidget = axisWidget(QwtAxis::XBottom);
-	const int fmw = QFontMetrics(scaleWidget->font()).width("-XXX.XXX XX");
+	const int fmw = QFontMetrics(scaleWidget->font()).horizontalAdvance("-XXX.XXX XX");
 	scaleWidget->setMinBorderDist(fmw / 2 + 30, fmw / 2 + 30);
 
 	displayGraticule = false;
@@ -999,7 +999,7 @@ void CapturePlot::updateHandleAreaPadding(bool enabled)
 		d_bottomHandlesArea->setLeftPadding(50 + axisWidget(QwtAxisId(QwtAxis::YLeft, d_activeVertAxis))->width());
 		d_topGateHandlesArea->setLeftPadding(90 + axisWidget(QwtAxisId(QwtAxis::YLeft, d_activeVertAxis))->width());
 		QwtScaleWidget *scaleWidget = axisWidget(QwtAxis::XBottom);
-		const int fmw = QFontMetrics(scaleWidget->font()).width("-XX.XX XX");
+		const int fmw = QFontMetrics(scaleWidget->font()).horizontalAdvance("-XX.XX XX");
 		const int fmh = QFontMetrics(scaleWidget->font()).height();
 		d_bottomHandlesArea->setRightPadding(50 + fmw/2 + d_bonusWidth);
 		d_topGateHandlesArea->setRightPadding(50 + fmw/2 + d_bonusWidth);

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -1368,6 +1368,7 @@ bool CapturePlot::endGroupSelection(bool moveAnnotationCurvesLast)
 		}
 	}
 
+	group.first()->selected(false);
 	group.first()->setSelected(true);
 	group.first()->selected(true);
 

--- a/src/patterngenerator/pattern_generator_api.h
+++ b/src/patterngenerator/pattern_generator_api.h
@@ -54,15 +54,17 @@ public:
 	        : ApiObject()
 		, m_pattern(pattern) {
 		qRegisterMetaType<QVector<int>>("vector(int)");
-		qRegisterMetaTypeStreamOperators<QVector<int>>("vector(int)");
 		qRegisterMetaType<QVector<QVector<int>>>("vector(vector(int))");
-		qRegisterMetaTypeStreamOperators<QVector<QVector<int>>>("vector(vector(int))");
-
 		qRegisterMetaType<QPair<QVector<int>, QString>>("pair(vector(int), string)");
-		qRegisterMetaTypeStreamOperators<QPair<QVector<int>, QString>>("pair(vector(int), string)");
 		qRegisterMetaType<QVector<QPair<QVector<int>, QString>>>("vector(pair(vector(int), string))");
+#if QT_VERSION < 0x060000
+		// RegisterMetaTypeStreamOperators was removed in Qt6;
+		// The metatype system will instead know about those automatically;
+		qRegisterMetaTypeStreamOperators<QVector<int>>("vector(int)");
+		qRegisterMetaTypeStreamOperators<QVector<QVector<int>>>("vector(vector(int))");
+		qRegisterMetaTypeStreamOperators<QPair<QVector<int>, QString>>("pair(vector(int), string)");
 		qRegisterMetaTypeStreamOperators<QVector<QPair<QVector<int>, QString>>>("vector(pair(vector(int), string))");
-
+#endif
 	}
 	~PatternGenerator_API() {}
 

--- a/src/patterngenerator/patterns/patterns.cpp
+++ b/src/patterngenerator/patterns/patterns.cpp
@@ -184,10 +184,10 @@ Pattern *Pattern_API::fromString(QString str)
 		if (doc.isObject()) {
 			obj = doc.object();
 		} else {
-			qDebug() << "Document is not an object" << endl;
+			qDebug() << "Document is not an object" << Qt::endl;
 		}
 	} else {
-		qDebug() << "Invalid JSON...\n" << str << endl;
+		qDebug() << "Invalid JSON...\n" << str << Qt::endl;
 	}
 
 	return fromJson(obj);
@@ -2004,7 +2004,7 @@ void I2CPatternUI::parse_ui()
 
 	pattern->setMsbFirst(ui->PB_MSB->isChecked());
 	pattern->setWrite(ui->PB_readWrite->isChecked());
-	QStringList strList = ui->LE_toSend->text().split(' ',QString::SkipEmptyParts);
+	QStringList strList = ui->LE_toSend->text().split(' ', Qt::SkipEmptyParts);
 	pattern->v.clear();
 
 	bool fail = false;
@@ -2407,7 +2407,7 @@ void SPIPatternUI::parse_ui()
 	pattern->setCPOL(ui->PB_CPOL->isChecked());
 	pattern->setCSPol(ui->PB_CS->isChecked());
 	pattern->setMsbFirst(ui->PB_MSB->isChecked());
-	QStringList strList = ui->LE_toSend->text().split(' ',QString::SkipEmptyParts);
+	QStringList strList = ui->LE_toSend->text().split(' ', Qt::SkipEmptyParts);
 	pattern->v.clear();
 	bool fail = false;
 

--- a/src/phonehome.h
+++ b/src/phonehome.h
@@ -24,7 +24,6 @@
 #include "preferences.h"
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-#include <QTextCodec>
 #include <QJsonDocument>
 #include <QJsonObject>
 

--- a/src/plot_line_handle.cpp
+++ b/src/plot_line_handle.cpp
@@ -63,7 +63,7 @@ const QPen& PlotLineHandle::pen()
 	return m_pen;
 }
 
-void PlotLineHandle::enterEvent(QEvent *event)
+void PlotLineHandle::enterEvent(QEnterEvent *event)
 {
 	setCursor(Qt::OpenHandCursor);
 	QWidget::enterEvent(event);
@@ -247,7 +247,7 @@ void PlotGateHandle::paintEvent(QPaintEvent *event)
 	QString handleText = d_timeFormatter.format(m_timeValue,"",2);
 
 	QFontMetrics fm = p.fontMetrics();
-	int textWidth = fm.width(handleText);
+	int textWidth = fm.horizontalAdvance(handleText);
 	int textHeight = fm.height();
 
 	p.drawText(QPoint((width()-textWidth)/2,height()-textHeight/2),handleText);

--- a/src/plot_line_handle.h
+++ b/src/plot_line_handle.h
@@ -23,6 +23,7 @@
 
 #include <QWidget>
 #include <QPen>
+#include <QEnterEvent>
 #include <plot_utils.hpp>
 
 class HandlesArea;
@@ -51,7 +52,7 @@ Q_SIGNALS:
 	void reset();
 
 protected:
-	void enterEvent(QEvent *event);
+	void enterEvent(QEnterEvent *event);
 	void mousePressEvent(QMouseEvent *event);
 	void mouseReleaseEvent(QMouseEvent *event);
 

--- a/src/power_controller.cpp
+++ b/src/power_controller.cpp
@@ -95,6 +95,8 @@ PowerController::PowerController(struct iio_context *ctx,
 			SLOT(dac2_set_value(double)));
 	connect(ui->trackingRatio, SIGNAL(valueChanged(int)), this,
 			SLOT(ratioChanged(int)));
+	connect(ui->trackingRatio, SIGNAL(valueChanged(int)),
+		ui->trackingRatioLbl, SLOT(setNum(int)));
 
 	connect(runButton(), SIGNAL(clicked(bool)), this, SLOT(startStop(bool)));
 

--- a/src/qtgui_util.cc
+++ b/src/qtgui_util.cc
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <QDebug>
 #include <QSizePolicy>
+#include <QFile>
 
 QwtPickerDblClickPointMachine::QwtPickerDblClickPointMachine()
 #if QWT_VERSION < 0x060000
@@ -118,11 +119,11 @@ void Util::setWidgetNrOfChars(QWidget *w,
 {
 	QFontMetrics labelm(w->font());
 
-	auto label_min_width = labelm.width(QString(minNrOfChars,'X'));
+	auto label_min_width = labelm.horizontalAdvance(QString(minNrOfChars,'X'));
 	w->setMinimumWidth(label_min_width);
 
 	if (maxNrOfChars!=0) {
-		auto label_max_width = labelm.width(QString(maxNrOfChars,'X'));
+		auto label_max_width = labelm.horizontalAdvance(QString(maxNrOfChars,'X'));
 		w->setMaximumWidth(label_max_width);
 	}
 }

--- a/src/qtjs.cpp
+++ b/src/qtjs.cpp
@@ -100,7 +100,7 @@ QString QtJs::readFromConsole(const QString& request)
 		input = watcher.result();
 		done = true;
 	});
-	future = QtConcurrent::run(this, &QtJs::readInput);
+	future = QtConcurrent::run(std::bind(&QtJs::readInput, this));
 	watcher.setFuture(future);
 
 	do {

--- a/src/scopy_color_editor.cpp
+++ b/src/scopy_color_editor.cpp
@@ -253,7 +253,7 @@ bool ScopyColorEditor::handleRgbaColor(const QString &key, const QString &line, 
 {
 	int endIndex = -1;
 	for (int i = index; i < line.size(); ++i) {
-		if (line[i] == ")") {
+		if (line[i] == ')') {
 			endIndex = i;
 		}
 	}
@@ -313,7 +313,7 @@ bool ScopyColorEditor::handleHexColor(const QString &key, const QString &line, i
 {
 	int endIndex = -1;
 	for (int i = index; i < line.size(); ++i) {
-		if (line[i] == " " || line[i] == ";") {
+		if (line[i] == ' ' || line[i] == ';') {
 			endIndex = i;
 		}
 	}
@@ -396,9 +396,9 @@ void ScopyColorEditor::changeColor()
 	int index = btn->property("index").toInt();
 
 	bool changed = false;
-	if (line[index] == "r") {
+	if (line[index] == 'r') {
 		changed = handleRgbaColor(key, line, index, btn);
-	} else if (line[index] == "#") {
+	} else if (line[index] == '#') {
 		changed = handleHexColor(key, line, index, btn);
 	}
 

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -438,7 +438,7 @@ SignalGenerator::SignalGenerator(struct iio_context *_ctx, Filter *filt,
 		cw->setProperty("signal_generator_data",
 		                QVariant::fromValue(ptr));
 		cw->setProperty("channel",
-				qVariantFromValue(i));
+				QVariant::fromValue(i));
 		channels.append(cw);
 
 		ui->channelsList->addWidget(cw);
@@ -2174,7 +2174,7 @@ double SignalGenerator::get_best_sample_rate(unsigned int chnIdx)
 	}
 
 	if (use_oversampling(chnIdx)) {
-		qSort(values.begin(), values.end(), qLess<double>());
+		std::sort(values.begin(), values.end(), std::less<double>());
 	}
 
 	/* Return the best sample rate that we can create a buffer for */
@@ -2190,7 +2190,7 @@ double SignalGenerator::get_best_sample_rate(unsigned int chnIdx)
 
 	/* If we can't find a perfect sample rate, use the highest one */
 	if (use_oversampling(chnIdx)) {
-		qSort(values.begin(), values.end(), qGreater<double>());
+		std::sort(values.begin(), values.end(), std::greater<double>());
 	}
 
 

--- a/src/signal_generator.cpp
+++ b/src/signal_generator.cpp
@@ -306,6 +306,8 @@ SignalGenerator::SignalGenerator(struct iio_context *_ctx, Filter *filt,
 	ui->gridLayout_2->addWidget(fallTime, 1, 0, 1, 1);
 	ui->gridLayout_2->addWidget(holdLowTime, 1, 1, 1, 1);
 
+	ui->gridLayout_2->setAlignment(Qt::AlignBottom | Qt::AlignLeft);
+
 	ui->waveformGrid->addWidget(stepsUp,2,0,1,1);
 	ui->waveformGrid->addWidget(stepsDown,2,1,1,1);
 	ui->waveformGrid->addWidget(stairPhase,1,1,1,1);
@@ -619,6 +621,8 @@ SignalGenerator::SignalGenerator(struct iio_context *_ctx, Filter *filt,
 	gridLayout->addWidget(m_plot->topArea(), 0, 0);
 	gridLayout->addWidget(m_plot->topHandlesArea(), 1, 0);
 	gridLayout->addWidget(m_plot, 2, 0);
+
+	gridLayout->setAlignment(Qt::AlignBottom | Qt::AlignLeft);
 
 	centralWidget->setLayout(gridLayout);
 

--- a/src/spectrum_analyzer.cpp
+++ b/src/spectrum_analyzer.cpp
@@ -1569,8 +1569,8 @@ QString SpectrumAnalyzer::getReferenceChannelName() const
 	for (; current <= MAX_REF_CHANNELS; ++current) {
 		bool isOk = true;
 		for (const auto &ref_channel : referenceChannels) {
-			QString shortName = ref_channel->shortName();
-			int channel_counter = shortName.midRef(shortName.size() - 1).toInt();
+			std::string shortName = ref_channel->shortName().toStdString();
+			int channel_counter = QString::fromStdString(shortName.substr(shortName.size() - 1)).toInt();
 			if (current == channel_counter) {
 				isOk = false;
 				break;

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -52,7 +52,7 @@
 #include <QFileDialog>
 #include <QFile>
 #include <QDir>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QJsonDocument>
 #include <QDesktopServices>
 #include <QSpacerItem>
@@ -344,7 +344,7 @@ void ToolLauncher::createPhoneHomeMessageBox() {
 	QMessageBox* msgBox = new QMessageBox(this);
 
 	QSize mSize = msgBox->sizeHint(); // here's what you want, not m.width()/height()
-	QRect screenRect = QDesktopWidget().screenGeometry();
+	QRect screenRect = QGuiApplication::screens()[0]->geometry();
 
 	msgBox->setText("Do you want to automatically check for newer Scopy and m2k-firmware versions?");
 	msgBox->setInformativeText("You can change this anytime from the Preferences menu.");
@@ -374,7 +374,7 @@ void ToolLauncher::createLicenseMessageBox() {
 	QMessageBox* msgBox = new QMessageBox(this);
 
 	QSize mSize = msgBox->sizeHint(); // here's what you want, not m.width()/height()
-	QRect screenRect = QDesktopWidget().screenGeometry();
+	QRect screenRect = QGuiApplication::screens()[0]->geometry();
 
 	msgBox->setTextFormat(Qt::RichText);
 	msgBox->setText("Scopy is distributed under the GNU <a href='https://github.com/analogdevicesinc/scopy/blob/master/LICENSE'>GPLv3</a>, and is copyright Analog Devices. Inc and others. There are no restrictions or obligations on its use, except that you (the user) agree there is no warranty (per the GPLv3). If you don't agree to this - do not use this software.");
@@ -690,7 +690,7 @@ void ToolLauncher::runProgram(const QString& program, const QString& fn)
 void ToolLauncher::search()
 {
 	search_timer->stop();
-	future = QtConcurrent::run(this, &ToolLauncher::searchDevices);
+	future = QtConcurrent::run(std::bind(&ToolLauncher::searchDevices, this));
 	watcher.setFuture(future);
 }
 
@@ -1313,7 +1313,7 @@ void adiscope::ToolLauncher::connectBtn_clicked(bool pressed)
 				fileBuildInfo.open(QIODevice::ReadOnly | QIODevice::Text);
 				auto buildInfo = QString(fileBuildInfo.readAll());
 				fileBuildInfo.close();
-				buildInfo = buildInfo.remove(QRegExp("<(/?)(body|pre)>"));
+				buildInfo = buildInfo.remove(QRegularExpression("<(/?)(body|pre)>"));
 				LOG(INFO) << buildInfo.toLocal8Bit().toStdString();
 			} else {
 				// logging disabled
@@ -1974,9 +1974,9 @@ void ToolLauncher::hasText()
 		QJSValue val = js_engine.evaluate(js_cmd);
 
 		if (val.isError()) {
-			out << "Exception:" << val.toString() << endl;
+			out << "Exception:" << val.toString() << Qt::endl;
 		} else if (!val.isUndefined()) {
-			out << val.toString() << endl;
+			out << val.toString() << Qt::endl;
 		}
 
 		js_cmd.clear();

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -87,6 +87,10 @@ using namespace adiscope;
 using namespace libm2k::context;
 using namespace libm2k::digital;
 
+Q_DECLARE_OPAQUE_POINTER(struct iio_context *);
+Q_DECLARE_METATYPE(struct iio_context * )
+
+
 ToolLauncher* adiscope::tl_ptr;
 ToolLauncher* adiscope::getToolLauncherInstance() {
 	return tl_ptr;
@@ -1056,6 +1060,7 @@ void ToolLauncher::setupHomepage()
 
 void ToolLauncher::setupAddPage()
 {
+	qRegisterMetaType<struct iio_context*>("struct iio_context*");
 	connectWidget = new ConnectDialog(ui->stackedWidget);
 	connect(connectWidget, &ConnectDialog::newContext,
 		[=](const QString& uri) {

--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -44,7 +44,6 @@
 
 #include <QDebug>
 #include <QtConcurrentRun>
-#include <QSignalTransition>
 #include <QMessageBox>
 #include <QTimer>
 #include <QSettings>

--- a/ui/cursors_settings.ui
+++ b/ui/cursors_settings.ui
@@ -168,73 +168,9 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>238</width>
-                <height>30</height>
+                <width>0</width>
+                <height>0</height>
                </size>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 238px;
-max-width: 238px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 119px;
-max-width: 119px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:119px;
-max-width:119px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:119px;
-max-width:119px;
-margin-left: 119px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
               </property>
               <property name="text">
                <string/>
@@ -255,7 +191,13 @@ color: rgba(255,255,255,51);
                <string>Track</string>
               </property>
               <property name="duration_ms" stdset="0">
-               <string>0</string>
+               <string notr="true">0</string>
+              </property>
+              <property name="duration" stdset="0">
+               <number>100</number>
+              </property>
+              <property name="bigBtn" stdset="0">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -776,7 +718,7 @@ color: rgba(255,255,255,51);
   <customwidget>
    <class>adiscope::CustomSwitch</class>
    <extends>QPushButton</extends>
-   <header>gui/customSwitch.hpp</header>
+   <header location="global">gui/customSwitch.hpp</header>
   </customwidget>
   <customwidget>
    <class>adiscope::SmallOnOffSwitch</class>

--- a/ui/device.ui
+++ b/ui/device.ui
@@ -105,9 +105,6 @@ qproperty-alignment: AlignCenter;
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="styleSheet">
-         <string notr="true"/>
-        </property>
         <property name="text">
          <string/>
         </property>
@@ -134,7 +131,7 @@ qproperty-alignment: AlignCenter;
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../resources/resources.qrc">
+         <iconset resource="../../scopy/resources/resources.qrc">
           <normaloff>:/icons/adalm.svg</normaloff>:/icons/adalm.svg</iconset>
         </property>
         <property name="iconSize">
@@ -293,8 +290,6 @@ QFrame#line[failed=true] {
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/ui/digital_trigger_settings.ui
+++ b/ui/digital_trigger_settings.ui
@@ -868,11 +868,9 @@
   <customwidget>
    <class>adiscope::CustomSwitch</class>
    <extends>QPushButton</extends>
-   <header>customSwitch.hpp</header>
+   <header location="global">gui/customSwitch.hpp</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -1036,70 +1036,6 @@ border-color: grey;
                  </item>
                  <item>
                   <widget class="adiscope::CustomSwitch" name="btnTriggerMode">
-                   <property name="styleSheet">
-                    <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                   </property>
                    <property name="text">
                     <string/>
                    </property>
@@ -1117,6 +1053,9 @@ color: rgba(255,255,255,51);
                    </property>
                    <property name="duration" stdset="0">
                     <number>100</number>
+                   </property>
+                   <property name="bigBtn" stdset="0">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
@@ -1480,70 +1419,6 @@ color: rgba(255,255,255,51);
                        <property name="layoutDirection">
                         <enum>Qt::LeftToRight</enum>
                        </property>
-                       <property name="styleSheet">
-                        <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 300px;
-max-width: 300px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 150px;
-max-width: 150px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:150px;
-max-width:150px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:150px;
-max-width:150px;
-margin-left: 150px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1561,6 +1436,9 @@ color: rgba(255,255,255,51);
                        </property>
                        <property name="duration" stdset="0">
                         <number>100</number>
+                       </property>
+                       <property name="bigBtn" stdset="0">
+                        <bool>true</bool>
                        </property>
                       </widget>
                      </item>
@@ -1963,6 +1841,9 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
               <string/>
              </property>
              <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="bigBtn" stdset="0">
               <bool>true</bool>
              </property>
              <attribute name="buttonGroup">

--- a/ui/network_analyzer.ui
+++ b/ui/network_analyzer.ui
@@ -979,70 +979,6 @@ border: 5px solid white;
                      </item>
                      <item>
                       <widget class="adiscope::CustomSwitch" name="btnRefChn">
-                       <property name="styleSheet">
-                        <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1059,7 +995,13 @@ color: rgba(255,255,255,51);
                         <string>Channel 2</string>
                        </property>
                        <property name="duration_ms" stdset="0">
-                        <string>0</string>
+                        <string notr="true">0</string>
+                       </property>
+                       <property name="duration" stdset="0">
+                        <number>100</number>
+                       </property>
+                       <property name="bigBtn" stdset="0">
+                        <bool>true</bool>
                        </property>
                       </widget>
                      </item>
@@ -1364,70 +1306,6 @@ color: rgba(255,255,255,51);
                        </item>
                        <item row="1" column="0" colspan="2">
                         <widget class="adiscope::CustomSwitch" name="btnIsLog">
-                         <property name="styleSheet">
-                          <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                         </property>
                          <property name="text">
                           <string/>
                          </property>
@@ -1445,6 +1323,9 @@ color: rgba(255,255,255,51);
                          </property>
                          <property name="duration_ms" stdset="0">
                           <number>0</number>
+                         </property>
+                         <property name="duration" stdset="0">
+                          <number>100</number>
                          </property>
                         </widget>
                        </item>

--- a/ui/osc_general_settings.ui
+++ b/ui/osc_general_settings.ui
@@ -504,7 +504,7 @@
   <customwidget>
    <class>adiscope::CustomSwitch</class>
    <extends>QPushButton</extends>
-   <header>gui/customSwitch.hpp</header>
+   <header location="global">gui/customSwitch.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/ui/pattern_generator.ui
+++ b/ui/pattern_generator.ui
@@ -663,70 +663,6 @@ border-color: grey;
                         </item>
                         <item row="2" column="0" colspan="2">
                          <widget class="adiscope::CustomSwitch" name="btnOutputMode">
-                          <property name="styleSheet">
-                           <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                          </property>
                           <property name="text">
                            <string/>
                           </property>
@@ -744,6 +680,9 @@ color: rgba(255,255,255,51);
                           </property>
                           <property name="duration" stdset="0">
                            <number>100</number>
+                          </property>
+                          <property name="bigBtn" stdset="0">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -1046,70 +985,6 @@ color: rgba(255,255,255,51);
                  </item>
                  <item>
                   <widget class="adiscope::CustomSwitch" name="btnTriggerMode">
-                   <property name="styleSheet">
-                    <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                   </property>
                    <property name="text">
                     <string/>
                    </property>
@@ -1127,6 +1002,9 @@ color: rgba(255,255,255,51);
                    </property>
                    <property name="duration" stdset="0">
                     <number>100</number>
+                   </property>
+                   <property name="bigBtn" stdset="0">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>

--- a/ui/powercontrol.ui
+++ b/ui/powercontrol.ui
@@ -156,7 +156,6 @@
             <property name="font">
              <font>
               <pointsize>30</pointsize>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -276,7 +275,6 @@ color: #ff7200;
             <property name="font">
              <font>
               <pointsize>30</pointsize>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -360,7 +358,6 @@ color: #ff7200;
             <property name="font">
              <font>
               <pointsize>30</pointsize>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -426,7 +423,6 @@ color: #9013fe;
             <property name="font">
              <font>
               <pointsize>30</pointsize>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -1126,10 +1122,6 @@ QPushButton:disabled {
  </customwidgets>
  <resources>
   <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -1145,22 +1137,6 @@ QPushButton:disabled {
     <hint type="destinationlabel">
      <x>947</x>
      <y>158</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>trackingRatio</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>trackingRatioLbl</receiver>
-   <slot>setNum(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>844</x>
-     <y>151</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>903</x>
-     <y>115</y>
     </hint>
    </hints>
   </connection>

--- a/ui/powercontrol.ui
+++ b/ui/powercontrol.ui
@@ -649,68 +649,14 @@ color: #9013fe;
             </item>
             <item>
              <widget class="adiscope::CustomSwitch" name="btnSync">
-              <property name="styleSheet">
-               <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 200px;
-max-width: 200px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 102px;
-max-width: 102px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:100px;
-max-width:100px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:100px;
-max-width:100px;
-margin-left: 100px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
               </property>
               <property name="text">
                <string/>
@@ -723,6 +669,12 @@ color: rgba(255,255,255,51);
               </property>
               <property name="duration_ms" stdset="0">
                <number>0</number>
+              </property>
+              <property name="duration" stdset="0">
+               <number>100</number>
+              </property>
+              <property name="bigBtn" stdset="0">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -1120,9 +1072,7 @@ QPushButton:disabled {
    <header>lcdNumber.hpp</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>btnSync</sender>

--- a/ui/spectrum_analyzer.ui
+++ b/ui/spectrum_analyzer.ui
@@ -1108,70 +1108,6 @@ min-width: 64px;
                    </item>
                    <item>
                     <widget class="adiscope::CustomSwitch" name="logBtn">
-                     <property name="styleSheet">
-                      <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 280px;
-max-width: 280px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 142px;
-max-width: 142px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:140px;
-max-width:140px;
-margin-left: 140px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-                     </property>
                      <property name="text">
                       <string/>
                      </property>
@@ -1183,6 +1119,12 @@ color: rgba(255,255,255,51);
                      </property>
                      <property name="duration_ms" stdset="0">
                       <number>0</number>
+                     </property>
+                     <property name="duration" stdset="0">
+                      <number>100</number>
+                     </property>
+                     <property name="bigBtn" stdset="0">
+                      <bool>true</bool>
                      </property>
                     </widget>
                    </item>

--- a/ui/trigger_settings.ui
+++ b/ui/trigger_settings.ui
@@ -159,70 +159,6 @@
            </property>
            <item>
             <widget class="adiscope::CustomSwitch" name="btnTrigger">
-             <property name="styleSheet">
-              <string notr="true">QPushButton {
-min-height: 30px;
-max-height: 30px;
-min-width: 225px;
-max-width: 225px;
-background-color: black;
-border-radius: 4px;
-}
-
-QPushButton:disabled {
-background-color: qlineargradient(spread:pad, x1:0.5, y1:0, x2:0.501, y2:0, stop:0 #727273, stop:1 #141416);
-}
-
-QWidget#handle {
-min-height: 30px;
-max-height: 30px;
-min-width: 115px;
-max-width: 115px;
-background-color: #4a64ff;
-border-radius: 2px;
-}
-
-QWidget#handle:disabled {
-background-color: #aaaaaa;
-}
-
-QLabel {
-margin-top: 6px;
-background-color: transparent;
-line-height: 19px;
-}
-
-QLabel#on {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:112px;
-max-width:112px;
-qproperty-alignment: AlignCenter AlignCenter;
-margin-left: 0px;
-color: white;
-}
-
-QLabel#on:disabled {
-color: rgba(255,255,255,102);
-}
-
-QLabel#off {
-margin-top: 0px;
-min-height:30px;
-max-height:30px;
-min-width:113px;
-max-width:113px;
-margin-left: 112px;
-color: white;
-qproperty-alignment: AlignCenter AlignCenter;
-}
-
-QLabel#off:disabled {
-color: rgba(255,255,255,51);
-}
-</string>
-             </property>
              <property name="text">
               <string/>
              </property>
@@ -236,6 +172,12 @@ color: rgba(255,255,255,51);
               <number>0</number>
              </property>
              <property name="polarity" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="duration" stdset="0">
+              <number>100</number>
+             </property>
+             <property name="bigBtn" stdset="0">
               <bool>true</bool>
              </property>
             </widget>
@@ -958,7 +900,7 @@ color: rgba(255,255,255,51);
   <customwidget>
    <class>adiscope::CustomSwitch</class>
    <extends>QPushButton</extends>
-   <header>gui/customSwitch.hpp</header>
+   <header location="global">gui/customSwitch.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
These changes would allow builds using both Qt5.15.2 and Qt6.
QT_MAJOR_VERSION in CMakeLists.txt needs to be updated accordingly.

To get it working on your local machine:
-  Qwt needs to be recompiled using Qt6.

- [ ] Qt 5.15.2 version still needs testing for all the changes.

Known issues until now on Qt6:

- [x] Investigate     - Flatpak Qt org.kde.Sdk/Platform version 6.2 does not supply the new module : QtStateMachine
- [x] Investigate - setMargin does not exist -> we used setContentsMargins() -> but some buttons/labels still look weird
- [ ] Investigate - QT_NO_CREATE_VERSIONLESS_TARGETS for CMakeLists.txt (in order to have a find_package call independent of QT_MAJOR_VERSION)
- [ ] Investigate - High DPI politics Qt6 versus Qt5 - Qt High DPI scaling is now activated by default; the default rounding policy is PassThrough
- [x] Warning - Make sure 'iio_context*' is registered using qRegisterMetaType()
- [x] Fix     - CIs should be compatible with Qt6
- [x] Fix         - iio-emulator issue when creating a device
- [ ] Fix     - Overflow error on Parallel decoder in Logic Analyzer
- [x] Fix     - Custom big switch button looks bad ( probably some stylesheet issues)
- [x] Fix     - TL Device button looks weird
- [x] Fix     - LA and PG channel manager crashes when creating groups or loading .ini

- Review doc  - https://doc.qt.io/qt-6/portingguide.html
- Review doc  - https://doc.qt.io/qt-6/porting-to-qt6-using-clazy.html
- Review doc  - https://doc.qt.io/qt-6/modulechanges.html
- Review doc  - https://doc.qt.io/qt-6/qt6-buildsystem.html

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>