### PR TITLE
Implement a busy retry when setting kernel buffers.

### DIFF
--- a/src/gui/measure.cpp
+++ b/src/gui/measure.cpp
@@ -24,6 +24,8 @@
 #include <qmath.h>
 #include <QDebug>
 #include <QObject>
+#include <string>
+#include <fstream>
 
 using namespace adiscope;
 

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1829,14 +1829,11 @@ void LogicAnalyzer::startStop(bool start)
 			m_plot.setMaxBufferSizeErrorLabel(false);
 
 			if (oneShotOrStream) { // oneshot
-				do {
-					try {
-						m_m2kDigital->setKernelBuffersCountIn(1);
-						break;
-					} catch (libm2k::m2k_exception &e) {
-						qDebug() << e.what();
-					}
-				} while (true);
+				try {
+					m_m2kDigital->setKernelBuffersCountIn(1);
+				} catch (libm2k::m2k_exception &e) {
+					qDebug() << e.what();
+				}
 
 				chunk_size = bufferSizeAdjusted;
 
@@ -1894,14 +1891,11 @@ void LogicAnalyzer::startStop(bool start)
 					}
 				}
 
-				do {
-					try {
-						m_m2kDigital->setKernelBuffersCountIn(m_currentKernelBuffers);
-						break;
-					} catch (libm2k::m2k_exception &e) {
-						qDebug() << e.what();
-					}
-				} while (true);
+				try {
+					m_m2kDigital->setKernelBuffersCountIn(m_currentKernelBuffers);
+				} catch (libm2k::m2k_exception &e) {
+					qDebug() << e.what();
+				}
 
 				// time for one kernel buffer + 100ms for the transfer
 				oneBufferTimeout = ((oneBufferTimeout - 100) / m_currentKernelBuffers) + 100;

--- a/src/network_analyzer.cpp
+++ b/src/network_analyzer.cpp
@@ -1753,15 +1753,11 @@ void NetworkAnalyzer::startStop(bool pressed)
 		m_dBgraph.sweepDone();
 		m_phaseGraph.sweepDone();
 		ui->statusLabel->setText(tr("Stopped"));
-		do {
-			try {
-				m_m2k_analogin->setKernelBuffersCount(KERNEL_BUFFERS_DEFAULT);
-				break;
-			} catch (libm2k::m2k_exception &e) {
-				qDebug() << e.what();
-			}
-
-		} while (true);
+		try {
+			m_m2k_analogin->setKernelBuffersCount(KERNEL_BUFFERS_DEFAULT);
+		} catch (libm2k::m2k_exception &e) {
+			qDebug() << e.what();
+		}
 	}
 }
 

--- a/src/oscilloscope.cpp
+++ b/src/oscilloscope.cpp
@@ -3658,11 +3658,12 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 	hist_plot.replot();
 
 	ch_ui->cmbMemoryDepth->setCurrentIndex(0);
+	int m_currentKernelBuffers;
 	if (timeBase->value() >= TIMEBASE_THRESHOLD) {
 		plot_samples_sequentially = true;	// streaming
 		const int minKernelBuffers = 4;
 		const int oneBufferMaxSize = 2 * 1024 * 1024; // 2M
-		int m_currentKernelBuffers = minKernelBuffers;
+		m_currentKernelBuffers = minKernelBuffers;
 		if (active_trig_sample_count < 0) {
 			active_sample_count = -active_trig_sample_count;
 			m_currentKernelBuffers = (active_plot_sample_count / active_sample_count) + 1;
@@ -3702,9 +3703,7 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 		setSinksDisplayOneBuffer(false);
 		plot.setXAxisNumPoints(active_plot_sample_count);
 		resetStreamingFlag(true);
-		iio->set_kernel_buffer_count(m_currentKernelBuffers);
 	} else {
-		iio->set_kernel_buffer_count();
 		plot_samples_sequentially = false;
 		setSinksDisplayOneBuffer(true);
 		plot.setXAxisNumPoints(0);
@@ -3720,6 +3719,12 @@ void adiscope::Oscilloscope::onHorizScaleValueChanged(double value)
 	if (started)
 		iio->lock();
 	setAllSinksSampleCount(active_plot_sample_count);
+
+	if (timeBase->value() >= TIMEBASE_THRESHOLD) {
+		iio->set_kernel_buffer_count(m_currentKernelBuffers);
+	} else {
+		iio->set_kernel_buffer_count();
+	}
 
 	if (started) {
 		plot.setSampleRate(active_sample_rate, 1, "");


### PR DESCRIPTION
Calling set_kernel_buffers_count() right after destroying a buffer might
return EBUSY because the file descriptor is still in use.
Also, kernel buffers count should not be changed while acquisition is
in progress.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>