### PR TITLE
Implemented decoder table for logic analyzer

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -339,6 +339,64 @@ void FileManager::performWrite()
 	exportFile.close();
 }
 
+void FileManager::performDecoderWrite(bool skip_empty_lines)
+{
+	// write decoder data
+	if (openedFor == IMPORT) {
+		qDebug() << "Can't write when opened for import!";
+		return;
+	}
+
+	QFile exportFile(filename);
+	exportFile.open(QIODevice::WriteOnly);
+	QTextStream exportStream(&exportFile);
+
+	//column names row
+	bool skipFirstSeparator=true;
+
+	for (auto column: columnNames) {
+		if (!skipFirstSeparator) {
+			exportStream << separator;
+		}
+		skipFirstSeparator = false;
+		exportStream << column;
+	}
+
+	if (!columnNames.empty()) {
+		exportStream << "\n";
+	}
+
+	QString line;
+	bool empty_line;
+	if (!decoder_data.isEmpty()) {
+		for (int i = 0; i < decoder_data.size(); ++i) {
+			skipFirstSeparator = true;
+			line = QString();
+			empty_line = true;
+
+			for (int j = 0; j < decoder_data[i].size(); ++j) {
+				if (!skipFirstSeparator)
+					line += separator;
+				if (!decoder_data[i][j].isEmpty()) {
+					line += decoder_data[i][j].replace(separator, " ");
+				}
+				skipFirstSeparator = false;
+
+
+				if (j != 0 && decoder_data[i][j] != "") {
+					empty_line = false;
+				}
+			}
+
+			line += '\n';
+			if (skip_empty_lines && empty_line) continue;
+			exportStream << line;
+		}
+	}
+
+	exportFile.close();
+}
+
 QStringList FileManager::getAdditionalInformation() const
 {
 	return additionalInformation;

--- a/src/filemanager.h
+++ b/src/filemanager.h
@@ -71,6 +71,7 @@ public:
 	int getNrOfChannels() const;
 
 	void performWrite();
+	void performDecoderWrite(bool skip_empty_lines = false);
 
 	QStringList getAdditionalInformation() const;
 	void setAdditionalInformation(const QString& value);

--- a/src/gui/dropdown_switch_list.cpp
+++ b/src/gui/dropdown_switch_list.cpp
@@ -87,7 +87,7 @@ DropdownSwitchList::DropdownSwitchList(int switchColCount, QWidget *parent):
 	m_treeView->setAllColumnsShowFocus(false);
 	m_treeView->setRootIsDecorated(false);
 	m_treeView->setUniformRowHeights(true);
-	m_treeView->header()->setSectionResizeMode(0, QHeaderView::Fixed);
+	m_treeView->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 	m_treeView->header()->setDefaultAlignment(Qt::AlignCenter);
 }
 

--- a/src/logicanalyzer/annotationcurve.cpp
+++ b/src/logicanalyzer/annotationcurve.cpp
@@ -544,7 +544,7 @@ void AnnotationCurve::drawAnnotationInfo(int row, uint64_t start, uint64_t end, 
 	if (start != end) {
 		rect = QRectF(QPointF(xMap.transform(fromSampleToTime(start)), yMap.transform(offset)), QSizeF(width, m_infoHeight));
 	} else {
-		rect = QRectF(QPointF(canvasRect.x() + canvasRect.width() * infoWidthRatio, yMap.transform(offset)), QSizeF(canvasRect.width() * (1 - infoWidthRatio), m_infoHeight));
+		rect = QRectF(QPointF(canvasRect.x() + canvasRect.width() * infoWidthRatio, yMap.transform(offset)), QSizeF(canvasRect.width() * (1 - infoWidthRatio * 2), m_infoHeight));
 	}
 
 	painter->save();

--- a/src/logicanalyzer/annotationcurve.cpp
+++ b/src/logicanalyzer/annotationcurve.cpp
@@ -531,7 +531,7 @@ QString AnnotationCurve::formatSeconds(double sec) const
 
 void AnnotationCurve::drawAnnotationInfo(int row, uint64_t start, uint64_t end, QPainter *painter,
 					 const QwtScaleMap &xMap, const QwtScaleMap &yMap,
-					 const QRectF &canvasRect, const QwtPointMapper &mapper) const {
+					 const QRectF &canvasRect) const {
 
 	const double infoHeightInPoints = yMap.invTransform(m_infoHeight) - yMap.invTransform(0);
 	const double infoWidthRatio = 0.09;

--- a/src/logicanalyzer/annotationcurve.cpp
+++ b/src/logicanalyzer/annotationcurve.cpp
@@ -176,7 +176,7 @@ void AnnotationCurve::sort_rows()
 void AnnotationCurve::newAnnotations()
 {
     QMetaObject::invokeMethod(plot(), "replot");
-    Q_EMIT annotationsChanged();
+    state = 1;
 }
 
 void AnnotationCurve::reset()
@@ -187,7 +187,7 @@ void AnnotationCurve::reset()
     m_annotationRows.clear();
 	m_annotationDecoder->reset();
 	m_visibleRows = 0;
-    Q_EMIT annotationsChanged();
+	state = 0;
 }
 
 QWidget *AnnotationCurve::getCurrentDecoderStackMenu()
@@ -450,6 +450,9 @@ void AnnotationCurve::drawLines(QPainter *painter, const QwtScaleMap &xMap, cons
         // if no annotations are generated for it
         currentRowOnPlot++;
     }
+    if (state == 1) {
+	    state = 2;
+    }
 
     m_visibleRows = currentRowOnPlot;
 
@@ -570,6 +573,27 @@ void AnnotationCurve::drawAnnotationInfo(int row, uint64_t start, uint64_t end, 
 	painter->setPen(QPen(QBrush(Qt::black), 1));
 
 	painter->restore();
+}
+
+void  AnnotationCurve::setState(int st)
+{
+	state = st;
+}
+
+int AnnotationCurve::getState()
+{
+	// -2: decoding failed
+	// -1: empty curve
+	//  0: started decoding
+	//  1: finished decoding
+	//  2: finished painting
+	return state;
+}
+
+QString AnnotationCurve::fromTitleToRowType(QString title) const
+{
+	return (title.indexOf(':')) ? title.mid(title.indexOf(':') + 1)
+				    : title;
 }
 
 void AnnotationCurve::drawAnnotation(int row, const Annotation &ann, QPainter *painter,

--- a/src/logicanalyzer/annotationcurve.h
+++ b/src/logicanalyzer/annotationcurve.h
@@ -116,6 +116,12 @@ public:
                    const QwtScaleMap &xMap, const QwtScaleMap &yMap,
                    const QRectF &canvasRect, const QwtPointMapper &mapper) const;
 
+    void drawAnnotationInfo(int row, uint64_t start, uint64_t end, QPainter *painter,
+		   const QwtScaleMap &xMap, const QwtScaleMap &yMap,
+		   const QRectF &canvasRect, const QwtPointMapper &mapper) const;
+
+    const double m_infoHeight = 17 * 2;
+
 protected:
     void drawLines( QPainter *painter,
         const QwtScaleMap &xMap, const QwtScaleMap &yMap,
@@ -139,6 +145,8 @@ private:
                                  const QwtScaleMap &xMap, const QwtScaleMap &yMap,
 				 const QRectF &canvasRect, const QwtPointMapper &mapper,
 				 const QwtInterval &interval, const QSizeF &titleSize) const;
+
+    QString formatSeconds(double time) const;
 
 
 

--- a/src/logicanalyzer/annotationcurve.h
+++ b/src/logicanalyzer/annotationcurve.h
@@ -118,7 +118,7 @@ public:
 
     void drawAnnotationInfo(int row, uint64_t start, uint64_t end, QPainter *painter,
 		   const QwtScaleMap &xMap, const QwtScaleMap &yMap,
-		   const QRectF &canvasRect, const QwtPointMapper &mapper) const;
+		   const QRectF &canvasRect) const;
 
     const double m_infoHeight = 17 * 2;
 

--- a/src/logicanalyzer/annotationcurve.h
+++ b/src/logicanalyzer/annotationcurve.h
@@ -150,10 +150,9 @@ private:
     std::map<std::pair<const srd_decoder*, int>, Row> m_classRows;
     std::map<Row, RowData> m_annotationRows;
 
-	std::vector<std::shared_ptr<adiscope::bind::Decoder>> m_bindings;
+    std::vector<std::shared_ptr<adiscope::bind::Decoder>> m_bindings;
 
-	mutable int m_visibleRows;
-
+    mutable int m_visibleRows;
 };
 }
 

--- a/src/logicanalyzer/annotationcurve.h
+++ b/src/logicanalyzer/annotationcurve.h
@@ -71,9 +71,6 @@ public:
 Q_SIGNALS:
 	void decoderMenuChanged();
 
-    // Emitted when new annotations are decoded from the decoder thread
-    void annotationsChanged();
-
     // Emitted when an annotation is clicked
     void annotationClicked(AnnotationQueryResult result);
 
@@ -122,6 +119,12 @@ public:
 
     const double m_infoHeight = 17 * 2;
 
+    int getState();
+
+    QString fromTitleToRowType(QString title) const;
+
+    void setState(int st);
+
 protected:
     void drawLines( QPainter *painter,
         const QwtScaleMap &xMap, const QwtScaleMap &yMap,
@@ -161,6 +164,7 @@ private:
     std::vector<std::shared_ptr<adiscope::bind::Decoder>> m_bindings;
 
     mutable int m_visibleRows;
+    mutable int state = -1;
 };
 }
 

--- a/src/logicanalyzer/annotationdecoder.cpp
+++ b/src/logicanalyzer/annotationdecoder.cpp
@@ -476,6 +476,8 @@ void AnnotationDecoder::decodeProc()
             if (!dec->have_required_channels()) {
 //                qDebug() << "not having required channels!";
                 // TODO: SET ERROR MESSAGE
+		m_annotationCurve->setState(-2);
+
                 return;
             }
         }

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -20,8 +20,13 @@
 #include "decoder_table.hpp"
 #include "decoder_table_model.hpp"
 #include "decoder_table_item.hpp"
+#include <QFileDialog>
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QHeaderView>
 #include "logic_analyzer.h"
+#include "filemanager.h"
+#include "qtconcurrentrun.h"
 
 namespace adiscope {
 
@@ -82,6 +87,200 @@ QVector<GenericLogicPlotCurve *> DecoderTable::getDecoderCruves()
 DecoderTableModel* DecoderTable::decoderModel() const
 {
 	return dynamic_cast<DecoderTableModel*>(model());
+}
+
+void DecoderTable::exportData()
+{
+	QString selectedFilter;
+	QStringList filter;
+	QString fileType = "";
+
+	filter += QString(tr("Comma-separated row per sample (*.csv)"));
+	filter += QString(tr("Tab-delimited row per annotation (*.txt)"));
+	QString fileName = QFileDialog::getSaveFileName(this,
+							tr("Export"), "", filter.join(";;"),
+							&selectedFilter, QFileDialog::DontUseNativeDialog);
+
+	if (fileName.isEmpty()) {
+		return;
+	}
+
+	// Check the selected file type
+	if (selectedFilter != "") {
+		if(selectedFilter.contains("comma", Qt::CaseInsensitive)) {
+			fileType = "csv";
+		}
+		if(selectedFilter.contains("tab", Qt::CaseInsensitive)) {
+			fileType = "txt";
+		}
+	}
+
+	if (fileName.split(".").size() <= 1) {
+		// file name w/o extension. Let's append it
+		QString ext = selectedFilter.split(".")[1].split(")")[0];
+		fileName += "." + ext;
+	}
+
+	m_logicAnalyzer->setStatusLabel("Exporting ...");
+
+	QFuture<void> future;
+	if (fileType == "csv") {
+		future = QtConcurrent::run(this, &DecoderTable::exportCsv, fileName);
+	} else if (fileType == "txt") {
+		future = QtConcurrent::run(this, &DecoderTable::exportTxt, fileName);
+	}
+	QFutureWatcher<void> *watcher = new QFutureWatcher<void>(this);
+
+	connect(watcher, &QFutureWatcher<void>::finished, this, [=](){
+		m_logicAnalyzer->setStatusLabel("");
+	});
+	connect(watcher, SIGNAL(finished()), watcher, SLOT(deleteLater()));
+	watcher->setFuture(future);
+}
+
+QVector<QPair<uint64_t, uint64_t>> DecoderTable::getSearchSampleMask()
+{
+	// convert the table row search mask to a sample area mask
+
+	auto curve = dynamic_cast<AnnotationCurve *>(getDecoderCruves().at(tableModel->getCurrentColumn()));
+	std::map<Row, RowData> decoder(curve->getAnnotationRows());
+	vector<Annotation> row;
+	QVector<QPair<uint64_t, uint64_t>> sampleMask;
+
+	for (auto row_map: decoder) {
+		if (row_map.first.index() == tableModel->getPrimaryAnnotationIndex()) {
+			row = row_map.second.get_annotations();
+			break;
+		}
+	}
+
+	for (auto index: tableModel->getSearchMask()) {
+		int size = m_logicAnalyzer->getGroupSize();
+		int off = (m_logicAnalyzer->getGroupOffset() == 0) ? size : m_logicAnalyzer->getGroupOffset();
+
+		int start_ann = (index == 0) ? 0 : off + size * (index - 1);
+		int end_ann = std::min(uint64_t(off + size * (index)) - 1, uint64_t(row.size() - 1));
+
+		if (off == 0) {
+			start_ann--;
+			end_ann--;
+		}
+
+		sampleMask.append(QPair<uint64_t, uint64_t>(row[start_ann].start_sample(), row[end_ann].end_sample()));
+	}
+
+	return sampleMask;
+}
+
+bool DecoderTable::exportTxt(QString fileName)
+{
+	FileManager fm("Logic Analyzer");
+	fm.open(fileName, FileManager::EXPORT);
+	QVector<QVector<QString>> decoder_data;
+	auto curve = dynamic_cast<AnnotationCurve *>(getDecoderCruves().at(tableModel->getCurrentColumn()));
+	std::map<Row, RowData> decoder(curve->getAnnotationRows());
+	auto sampleMask = getSearchSampleMask();
+
+	// set decoder data
+	std::map<Row, RowData>::iterator it;
+	for (it = decoder.begin(); it != decoder.end(); it++) {
+		auto annotations = it->second.get_annotations();
+		QString title = curve->fromTitleToRowType(it->first.title());
+		if (tableModel->getFiltered().value(tableModel->getCurrentColumn()).contains(title)) continue;
+
+		for (auto ann: annotations) {
+			QVector<QString> str = {QString::number(ann.start_sample()) + "-" + QString::number(ann.end_sample()), ann.row()->title(), ann.annotations()[0]};
+			decoder_data.append(str);
+		}
+	}
+
+	fm.save(QVector<QVector<double>>(), decoder_data, QStringList());
+
+	fm.performDecoderWrite(true);
+
+	return true;
+}
+
+bool DecoderTable::exportCsv(QString fileName)
+{
+	FileManager fm("Logic Analyzer");
+	fm.open(fileName, FileManager::EXPORT);
+
+	QStringList columnNames;
+	std::map<Row, RowData>::iterator it;
+	int col = tableModel->getCurrentColumn();
+	uint64_t last_sample = 0;
+
+	QVector<QVector<QString>> decoder_data;
+	AnnotationCurve *curve = dynamic_cast<AnnotationCurve *>(getDecoderCruves().at(col));
+	std::map<Row, RowData> decoder(curve->getAnnotationRows());
+	QRegExp rx =  QRegExp(tableModel->getsearchString(), Qt::CaseInsensitive);
+	int row_count = 0;
+	int primaryCol = 0;
+
+	auto sampleMask = getSearchSampleMask();
+
+	// set column names
+	columnNames += "Time";
+	for (it = decoder.begin(); it != decoder.end(); it++) {
+		last_sample = std::max(last_sample, it->second.get_max_sample());
+
+		auto title = curve->fromTitleToRowType(it->first.title());
+		if (!it->second.get_annotations().empty() && !tableModel->getFiltered()[col].contains(title)) {
+			if (it->first.index() == tableModel->getPrimaryAnnotationIndex()) {
+				primaryCol = columnNames.size();
+			}
+			columnNames += it->first.title();
+		}
+	}
+
+	// initialize decoder_data
+	QVector<QString> aux;
+	for (uint64_t i = 0; i < last_sample; i++) {
+		aux = QVector<QString>();
+		for (uint64_t j = 0; j < columnNames.count(); j++) {
+			aux.append("");
+		}
+		decoder_data.append(aux);
+	}
+
+	// set time
+	for (int i = 0; i < last_sample; i++) {
+		decoder_data[i][0] = QString::fromStdString(std::to_string(curve->fromSampleToTime(i))).replace(",", ".");
+	}
+
+	// populate decoder_data
+	for (it = decoder.begin(); it != decoder.end(); it++) {
+		auto row = it->second.get_annotations();
+		auto title = curve->fromTitleToRowType(it->first.title());
+		if (tableModel->getFiltered()[col].contains(title) || row.empty()) continue;
+		row_count++;
+
+		for (unsigned int ann_index = 0; ann_index < row.size(); ann_index++) {
+			for (uint64_t i = row[ann_index].start_sample(); i < row[ann_index].end_sample(); i++) {
+				decoder_data[i][row_count] = row[ann_index].annotations()[0];
+			}
+		}
+	}
+
+	// apply search
+	for (uint64_t i = 0; i < last_sample; i++) {
+		if (decoder_data[i][primaryCol] == "") {
+			decoder_data[i] = QVector<QString>();
+		}
+	}
+	for (auto sample_range: sampleMask) {
+		for (uint64_t i = sample_range.first; i <= sample_range.second; i++) {
+			if (i < last_sample)
+			decoder_data[i] = QVector<QString>();
+		}
+	}
+
+	fm.save(QVector<QVector<double>>(), decoder_data, columnNames);
+
+	fm.performDecoderWrite(true);
+
+	return true;
 }
 
 void DecoderTable::activate(bool logic)

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "decoder_table.hpp"
+#include "decoder_table_model.hpp"
+#include "decoder_table_item.hpp"
+#include <QHeaderView>
+#include "logic_analyzer.h"
+
+namespace adiscope {
+
+
+namespace logic {
+
+
+DecoderTable::DecoderTable(QWidget *parent) : QTableView(parent)
+{
+    horizontalHeader()->setStretchLastSection(true);
+    verticalHeader()->hide();
+    setItemDelegate(new DecoderTableItemDelegate);
+    setMinimumWidth(500);
+    horizontalHeader()->setMinimumSectionSize(500);
+    horizontalHeader()->sectionResizeMode(QHeaderView::Interactive);
+}
+
+void DecoderTable::setLogicAnalyzer(LogicAnalyzer *logicAnalyzer)
+{
+    if (logicAnalyzer != nullptr) {
+        if (const auto oldDecoderModel = dynamic_cast<DecoderTableModel*>(model())) {
+            if (oldDecoderModel != nullptr) {
+                delete oldDecoderModel;
+            }
+        }
+	tableModel = new DecoderTableModel(this, logicAnalyzer);
+	setModel(tableModel);
+    }
+
+    m_logicAnalyzer = logicAnalyzer;
+}
+
+QVector<GenericLogicPlotCurve *> DecoderTable::getDecoderCruves()
+{
+	QVector<GenericLogicPlotCurve *> temp_curves = m_logicAnalyzer->getPlotCurves(true);
+	temp_curves.remove(0, DIGITAL_NR_CHANNELS);
+	return temp_curves;
+}
+
+DecoderTableModel* DecoderTable::decoderModel() const
+{
+    return dynamic_cast<DecoderTableModel*>(model());
+}
+
+void DecoderTable::activate(bool logic)
+{
+    setLogicAnalyzer(m_logicAnalyzer);
+    if (const auto m = decoderModel()) {
+        m->reloadDecoders(logic);
+        m_active = true;
+    }
+}
+
+void DecoderTable::deactivate()
+{
+    if (const auto m = decoderModel()) {
+        m->deactivate();
+    }
+    m_active = false;
+}
+
+} // namespace logic
+} // namespace adiscope
+

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -31,27 +31,27 @@ namespace logic {
 
 DecoderTable::DecoderTable(QWidget *parent) : QTableView(parent)
 {
-    horizontalHeader()->setStretchLastSection(true);
-    verticalHeader()->hide();
-    setItemDelegate(new DecoderTableItemDelegate);
-    setMinimumWidth(500);
-    horizontalHeader()->setMinimumSectionSize(500);
-    horizontalHeader()->sectionResizeMode(QHeaderView::Interactive);
+	horizontalHeader()->setStretchLastSection(true);
+	verticalHeader()->hide();
+	setItemDelegate(new DecoderTableItemDelegate);
+	setMinimumWidth(500);
+	horizontalHeader()->setMinimumSectionSize(500);
+	horizontalHeader()->sectionResizeMode(QHeaderView::Interactive);
 }
 
 void DecoderTable::setLogicAnalyzer(LogicAnalyzer *logicAnalyzer)
 {
-    if (logicAnalyzer != nullptr) {
-        if (const auto oldDecoderModel = dynamic_cast<DecoderTableModel*>(model())) {
-            if (oldDecoderModel != nullptr) {
-                delete oldDecoderModel;
-            }
-        }
-	tableModel = new DecoderTableModel(this, logicAnalyzer);
-	setModel(tableModel);
-    }
+	if (logicAnalyzer != nullptr) {
+		if (const auto oldDecoderModel = dynamic_cast<DecoderTableModel*>(model())) {
+			if (oldDecoderModel != nullptr) {
+				delete oldDecoderModel;
+			}
+		}
+		tableModel = new DecoderTableModel(this, logicAnalyzer);
+		setModel(tableModel);
+	}
 
-    m_logicAnalyzer = logicAnalyzer;
+	m_logicAnalyzer = logicAnalyzer;
 }
 
 QVector<GenericLogicPlotCurve *> DecoderTable::getDecoderCruves()
@@ -63,29 +63,24 @@ QVector<GenericLogicPlotCurve *> DecoderTable::getDecoderCruves()
 
 DecoderTableModel* DecoderTable::decoderModel() const
 {
-    return dynamic_cast<DecoderTableModel*>(model());
-}
-
-void DecoderTable::setPrimaryAnnotation(int index)
-{
-	decoderModel()->setPrimaryAnnotation(index);
+	return dynamic_cast<DecoderTableModel*>(model());
 }
 
 void DecoderTable::activate(bool logic)
 {
-    setLogicAnalyzer(m_logicAnalyzer);
-    if (const auto m = decoderModel()) {
-        m->reloadDecoders(logic);
-        m_active = true;
-    }
+	setLogicAnalyzer(m_logicAnalyzer);
+	if (const auto m = decoderModel()) {
+		m->reloadDecoders(logic);
+		m_active = true;
+	}
 }
 
 void DecoderTable::deactivate()
 {
-    if (const auto m = decoderModel()) {
-        m->deactivate();
-    }
-    m_active = false;
+	if (const auto m = decoderModel()) {
+		m->deactivate();
+	}
+	m_active = false;
 }
 
 } // namespace logic

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -83,6 +83,11 @@ void DecoderTable::deactivate()
 	m_active = false;
 }
 
+void DecoderTable::showEvent(QShowEvent *event)
+{
+    tableModel->to_be_refreshed = true;
+}
+
 } // namespace logic
 } // namespace adiscope
 

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -106,6 +106,11 @@ void DecoderTable::showEvent(QShowEvent *event)
     tableModel->to_be_refreshed = true;
 }
 
+void DecoderTable::groupValuesChanged(int value)
+{
+	reset();
+	tableModel->to_be_refreshed = true;
+}
 } // namespace logic
 } // namespace adiscope
 

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -66,6 +66,11 @@ DecoderTableModel* DecoderTable::decoderModel() const
     return dynamic_cast<DecoderTableModel*>(model());
 }
 
+void DecoderTable::setPrimaryAnnotation(int index)
+{
+	decoderModel()->setPrimaryAnnotation(index);
+}
+
 void DecoderTable::activate(bool logic)
 {
     setLogicAnalyzer(m_logicAnalyzer);

--- a/src/logicanalyzer/decoder_table.cpp
+++ b/src/logicanalyzer/decoder_table.cpp
@@ -31,12 +31,30 @@ namespace logic {
 
 DecoderTable::DecoderTable(QWidget *parent) : QTableView(parent)
 {
-	horizontalHeader()->setStretchLastSection(true);
-	verticalHeader()->hide();
 	setItemDelegate(new DecoderTableItemDelegate);
-	setMinimumWidth(500);
+
+	horizontalHeader()->setStretchLastSection(true);
 	horizontalHeader()->setMinimumSectionSize(500);
 	horizontalHeader()->sectionResizeMode(QHeaderView::Interactive);
+	horizontalScrollBar()->setEnabled(false);
+	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+	verticalHeader()->hide();
+	setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+
+	setAutoScroll(false);
+	installEventFilter(this);
+}
+
+bool DecoderTable::eventFilter(QObject* object, QEvent* event)
+{
+	// prevent user from swiping through columns using touchscreen
+
+	if (event->type() == QEvent::Paint && tableModel->getCurrentColumn() != horizontalScrollBar()->value()) {
+		horizontalScrollBar()->setValue(tableModel->getCurrentColumn());
+		return true;
+	}
+	return false;
 }
 
 void DecoderTable::setLogicAnalyzer(LogicAnalyzer *logicAnalyzer)

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -49,6 +49,8 @@ public:
     // Shortcut to get a reference to the model.
     DecoderTableModel* decoderModel() const;
 
+    void setPrimaryAnnotation(int index);
+
 private:
     bool m_active;
     DecoderTableModel* tableModel;

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -49,8 +49,6 @@ public:
     // Shortcut to get a reference to the model.
     DecoderTableModel* decoderModel() const;
 
-    void setPrimaryAnnotation(int index);
-
 private:
     bool m_active;
     DecoderTableModel* tableModel;

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -54,6 +54,9 @@ private:
     DecoderTableModel* tableModel;
     LogicAnalyzer* m_logicAnalyzer;
     QVector<GenericLogicPlotCurve *> *temp_curves;
+
+protected:
+    void showEvent(QShowEvent *event);
 };
 } // namespace logic
 } // namespace adiscope

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DECODER_TABLE_H
+#define DECODER_TABLE_H
+
+#include <QAbstractTableModel>
+#include <QTableView>
+#include "decoder.h"
+#include "decoder_table_item.hpp"
+#include "logic_analyzer.h"
+
+namespace adiscope {
+
+
+namespace logic {
+
+class DecoderTableModel;
+
+class DecoderTable : public QTableView {
+    Q_OBJECT
+
+public:
+    DecoderTable(QWidget *parent = nullptr);
+
+    void setLogicAnalyzer(LogicAnalyzer* logicAnalyzer);
+    void activate(bool logic);
+    void deactivate();
+    QVector<GenericLogicPlotCurve *> getDecoderCruves();
+    inline bool isActive() const { return m_active; }
+
+    // Shortcut to get a reference to the model.
+    DecoderTableModel* decoderModel() const;
+
+private:
+    bool m_active;
+    DecoderTableModel* tableModel;
+    LogicAnalyzer* m_logicAnalyzer;
+    QVector<GenericLogicPlotCurve *> *temp_curves;
+};
+} // namespace logic
+} // namespace adiscope
+
+#endif // DECODER_TABLE_H

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -48,6 +48,7 @@ public:
 
     // Shortcut to get a reference to the model.
     DecoderTableModel* decoderModel() const;
+    bool eventFilter(QObject *object, QEvent *event);
 
 private:
     bool m_active;

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -50,6 +50,9 @@ public:
     DecoderTableModel* decoderModel() const;
     bool eventFilter(QObject *object, QEvent *event);
 
+public Q_SLOTS:
+    void groupValuesChanged(int value);
+
 private:
     bool m_active;
     DecoderTableModel* tableModel;

--- a/src/logicanalyzer/decoder_table.hpp
+++ b/src/logicanalyzer/decoder_table.hpp
@@ -52,12 +52,16 @@ public:
 
 public Q_SLOTS:
     void groupValuesChanged(int value);
+    void exportData();
 
 private:
     bool m_active;
     DecoderTableModel* tableModel;
     LogicAnalyzer* m_logicAnalyzer;
     QVector<GenericLogicPlotCurve *> *temp_curves;
+    bool exportCsv(QString fileName);
+    bool exportTxt(QString fileName);
+    QVector<QPair<uint64_t, uint64_t> > getSearchSampleMask();
 
 protected:
     void showEvent(QShowEvent *event);

--- a/src/logicanalyzer/decoder_table_item.cpp
+++ b/src/logicanalyzer/decoder_table_item.cpp
@@ -99,7 +99,7 @@ void DecoderTableItem::paint(
 
 	QwtScaleMap xmap, ymap;
 	xmap.setPaintInterval(0, rect.width());
-	ymap.setPaintInterval(4, rect.height());
+	ymap.setPaintInterval(4 + curve->m_infoHeight, rect.height());
 	// qDebug() << "rect: " << rect << Qt::endl;
 
 	QwtPointMapper mapper;
@@ -135,6 +135,7 @@ void DecoderTableItem::paint(
 		return;
 	}
 
+	curve->drawAnnotationInfo(offset, startSample, endSample, painter, xmap, ymap, rect, mapper);
 	for (const auto &entry: curve->getAnnotationRows()) {
 		const RowData &data = entry.second;
 

--- a/src/logicanalyzer/decoder_table_item.cpp
+++ b/src/logicanalyzer/decoder_table_item.cpp
@@ -57,11 +57,12 @@ QSize DecoderTableItemDelegate::sizeHint(
 }
 
 
-DecoderTableItem::DecoderTableItem(AnnotationCurve *curve, uint64_t start, uint64_t end, QVector<QString> filter):
+DecoderTableItem::DecoderTableItem(AnnotationCurve *curve, uint64_t start, uint64_t end, QVector<QString> filter, bool flag):
 	curve(curve),
 	startSample(start),
 	endSample(end),
-	filteredMessages(filter)
+	filteredMessages(filter),
+	tableInfoFlag(flag)
 {
 
 }
@@ -99,7 +100,11 @@ void DecoderTableItem::paint(
 
 	QwtScaleMap xmap, ymap;
 	xmap.setPaintInterval(0, rect.width());
-	ymap.setPaintInterval(4 + curve->m_infoHeight, rect.height());
+	if (tableInfoFlag) {
+		ymap.setPaintInterval(4 + curve->m_infoHeight, rect.height());
+	} else {
+		ymap.setPaintInterval(4, rect.height());
+	}
 	// qDebug() << "rect: " << rect << Qt::endl;
 
 	QwtPointMapper mapper;
@@ -135,7 +140,9 @@ void DecoderTableItem::paint(
 		return;
 	}
 
-	curve->drawAnnotationInfo(offset, startSample, endSample, painter, xmap, ymap, rect, mapper);
+	if (tableInfoFlag) {
+		curve->drawAnnotationInfo(offset, startSample, endSample, painter, xmap, ymap, rect);
+	}
 	for (const auto &entry: curve->getAnnotationRows()) {
 		const RowData &data = entry.second;
 

--- a/src/logicanalyzer/decoder_table_item.cpp
+++ b/src/logicanalyzer/decoder_table_item.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "decoder_table_item.hpp"
+#include <qwt_painter.h>
+#include <qwt_point_mapper.h>
+#include <qwt_scale_map.h>
+#include <QDebug>
+#include <qwt_text.h>
+
+namespace adiscope {
+
+
+namespace logic {
+
+
+void DecoderTableItemDelegate::paint(
+    QPainter *painter,
+    const QStyleOptionViewItem &option,
+    const QModelIndex &index
+) const {
+    if (index.data().canConvert<DecoderTableItem>()) {
+        DecoderTableItem decoderItem = qvariant_cast<DecoderTableItem>(index.data());
+        decoderItem.paint(painter, option.rect, option.palette);
+    } else {
+        QStyledItemDelegate::paint(painter, option, index);
+    }
+}
+
+
+
+QSize DecoderTableItemDelegate::sizeHint(
+    const QStyleOptionViewItem &option,
+    const QModelIndex &index
+) const {
+    if (index.data().canConvert<DecoderTableItem>()) {
+        DecoderTableItem decoderItem = qvariant_cast<DecoderTableItem>(index.data());
+        return decoderItem.sizeHint();
+    }
+    return QStyledItemDelegate::sizeHint(option, index);
+}
+
+
+DecoderTableItem::DecoderTableItem(AnnotationCurve *curve, uint64_t start, uint64_t end):
+    curve(curve),
+    startSample(start),
+    endSample(end)
+{
+
+}
+
+double DecoderTableItem::startTime() const
+{
+    if (curve != nullptr)
+        return curve->fromSampleToTime(startSample);
+    return 0;
+}
+
+double DecoderTableItem::endTime() const
+{
+    if (curve != nullptr)
+        return curve->fromSampleToTime(endSample);
+    return 0;
+}
+
+void DecoderTableItem::paint(
+    QPainter *painter,
+    const QRect &rect,
+    const QPalette &palette
+) const {
+
+    if (curve == nullptr){
+	    return;
+    }
+    painter->save();
+
+    // Shift to start of table
+    painter->translate(rect.x(), rect.y());
+
+    // Set border color
+    painter->setPen(QPen(QBrush(Qt::black), 1));
+
+    QwtScaleMap xmap, ymap;
+    xmap.setPaintInterval(0, rect.width());
+    ymap.setPaintInterval(0, rect.height());
+    // qDebug() << "rect: " << rect << Qt::endl;
+
+    QwtPointMapper mapper;
+    mapper.setFlag( QwtPointMapper::RoundPoints, QwtPainter::roundingAlignment( painter ) );
+    // mapper.setBoundingRect(rect);  // Seems to have no effect?
+
+    // Scale the annotation to fit in the column
+    const double lower = startTime();
+    const double upper = endTime();
+    double padding = (upper - lower) * 0.05;
+    if (padding == 0) {
+	    padding = 0.0001;
+    }
+
+    const QwtInterval interval = QwtInterval(lower-padding, upper+padding);
+    xmap.setScaleInterval(interval.minValue(), interval.maxValue());
+
+    // Shift curve offset to 0 and block any signals while doing it since the
+    // changes are restored after drawing. Without this the rows are shifted out
+    // of place.
+    QSignalBlocker signalBlocker(curve);
+    const auto originalPixelOffset = curve->getPixelOffset();
+    curve->setPixelOffset(0);
+
+    // The title size is reserved for the titles in the normal plot
+    // this is unused here.
+    const QSize titleSize = QSize(0, 0);
+
+    // Draw all annotations in the sample range
+    int offset = 0; // TODO: This does not retain the original order
+
+    if (curve->getAnnotationRows().size() == 0) {
+	    return;
+    }
+
+    for (const auto &entry: curve->getAnnotationRows()) {
+	const RowData &data = entry.second;
+
+	if (data.size() == 0) continue;
+	const auto range = data.get_annotations();
+
+	for (auto ann: range) {
+		curve->drawAnnotation(
+		    offset, ann, painter, xmap, ymap, rect, mapper,
+		    interval, titleSize);
+	}
+	offset += 1;
+    }
+
+    // Restore
+    curve->setPixelOffset(originalPixelOffset);
+
+    painter->restore();
+}
+
+QSize DecoderTableItem::sizeHint() const
+{
+    return itemSize;
+}
+
+
+
+} // namespace logic
+} // namespace adiscope
+

--- a/src/logicanalyzer/decoder_table_item.cpp
+++ b/src/logicanalyzer/decoder_table_item.cpp
@@ -99,7 +99,7 @@ void DecoderTableItem::paint(
 
 	QwtScaleMap xmap, ymap;
 	xmap.setPaintInterval(0, rect.width());
-	ymap.setPaintInterval(0, rect.height());
+	ymap.setPaintInterval(4, rect.height());
 	// qDebug() << "rect: " << rect << Qt::endl;
 
 	QwtPointMapper mapper;

--- a/src/logicanalyzer/decoder_table_item.hpp
+++ b/src/logicanalyzer/decoder_table_item.hpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef DECODER_TABLE_ITEM_H
+#define DECODER_TABLE_ITEM_H
+
+#include "annotationcurve.h"
+#include <bitset>
+#include <QPainter>
+#include <QStyledItemDelegate>
+
+
+namespace adiscope {
+namespace logic {
+
+
+class DecoderTableItemDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+    virtual ~DecoderTableItemDelegate() {};
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option,
+                   const QModelIndex &index) const override;
+};
+
+
+
+class DecoderTableItem {
+
+public:
+
+    explicit DecoderTableItem(
+        AnnotationCurve* curve=nullptr,
+        uint64_t start=0,
+        uint64_t end=0
+    );
+
+    void paint(QPainter *painter, const QRect &rect, const QPalette &palette) const;
+    QSize sizeHint() const;
+
+    double startTime() const;
+    double endTime() const;
+
+    AnnotationCurve* curve;
+    uint64_t startSample;
+    uint64_t endSample;
+    QSize itemSize = QSize(300, 40);
+
+};
+
+} // namespace logic
+} // namespace adiscope
+
+
+// This is needed so it can be stored as a QVariant
+Q_DECLARE_METATYPE(adiscope::logic::DecoderTableItem)
+
+
+
+#endif // DECODER_TABLE_ITEM_H

--- a/src/logicanalyzer/decoder_table_item.hpp
+++ b/src/logicanalyzer/decoder_table_item.hpp
@@ -52,7 +52,8 @@ public:
     explicit DecoderTableItem(
         AnnotationCurve* curve=nullptr,
         uint64_t start=0,
-        uint64_t end=0
+	uint64_t end=0,
+	QVector<QString> filter= QVector<QString>()
     );
 
     void paint(QPainter *painter, const QRect &rect, const QPalette &palette) const;
@@ -65,6 +66,7 @@ public:
     uint64_t startSample;
     uint64_t endSample;
     QSize itemSize = QSize(300, 40);
+    QVector<QString> filteredMessages;
 
 };
 

--- a/src/logicanalyzer/decoder_table_item.hpp
+++ b/src/logicanalyzer/decoder_table_item.hpp
@@ -53,7 +53,8 @@ public:
         AnnotationCurve* curve=nullptr,
         uint64_t start=0,
 	uint64_t end=0,
-	QVector<QString> filter= QVector<QString>()
+	QVector<QString> filter= QVector<QString>(),
+	bool flag=true
     );
 
     void paint(QPainter *painter, const QRect &rect, const QPalette &palette) const;
@@ -67,6 +68,8 @@ public:
     uint64_t endSample;
     QSize itemSize = QSize(300, 40);
     QVector<QString> filteredMessages;
+
+    bool tableInfoFlag;
 
 };
 

--- a/src/logicanalyzer/decoder_table_model.cpp
+++ b/src/logicanalyzer/decoder_table_model.cpp
@@ -254,7 +254,12 @@ void DecoderTableModel::refreshColumn(double column) const
 	}
 
 	// resize rows
-	const int spacing = 10 + curve->m_infoHeight;
+	int spacing;
+	if (m_logic->getTableInfo()) {
+		spacing = 10 + curve->m_infoHeight;
+	} else {
+		spacing = 10;
+	}
 	int rowHeight = 25;
 
 	int row_count = 0;
@@ -358,7 +363,8 @@ QVariant DecoderTableModel::data(const QModelIndex &index, int role) const
 					   temp_curve,
 					   row[index.row()].start_sample(),
 				   row[index.row()].end_sample(),
-			m_filteredMessages.value(index.column())
+			m_filteredMessages.value(index.column()),
+			m_logic->getTableInfo()
 			));
 }
 

--- a/src/logicanalyzer/decoder_table_model.cpp
+++ b/src/logicanalyzer/decoder_table_model.cpp
@@ -254,7 +254,7 @@ void DecoderTableModel::refreshColumn(double column) const
 	}
 
 	// resize rows
-	const int spacing = 10;
+	const int spacing = 10 + curve->m_infoHeight;
 	int rowHeight = 25;
 
 	int row_count = 0;

--- a/src/logicanalyzer/decoder_table_model.cpp
+++ b/src/logicanalyzer/decoder_table_model.cpp
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "decoder_table_model.hpp"
+#include "logic_analyzer.h"
+#include <QDebug>
+#include <QHeaderView>
+
+namespace adiscope {
+
+
+namespace logic {
+
+DecoderTableModel::DecoderTableModel(DecoderTable *decoderTable, LogicAnalyzer *logicAnalyzer):
+    QAbstractTableModel(decoderTable),
+    m_decoderTable(decoderTable),
+    m_logic(logicAnalyzer)
+{
+	m_plotCurves = m_logic->getPlotCurves(true);
+	m_decoderTable->verticalHeader()->setMinimumSectionSize(1);
+	m_primary_annoations = new QMap<int, int>();
+}
+
+void DecoderTableModel::setDefaultPrimaryAnnotations()
+{
+	for (int i=DIGITAL_NR_CHANNELS; i<m_plotCurves.size(); i++) {
+		int count = 0;
+		std::map<Row, RowData>::iterator it;
+		AnnotationCurve *curve = dynamic_cast<AnnotationCurve *>(m_plotCurves[i]);
+		std::map<Row, RowData> decoder(curve->getAnnotationRows());
+
+		for (it = decoder.begin(); it != decoder.end(); it++) {
+			if (!it->second.get_annotations().empty()) {
+//				count = it->second.get_annotations().size();
+				count = it->first.index();
+				break;
+			}
+		}
+	m_primary_annoations->insert(i, count);
+	}
+}
+
+int DecoderTableModel::rowCount(const QModelIndex &parent) const
+{
+    // Return max of all packets
+	return 100;
+    size_t count = 0;
+    if (!m_active) {
+	    return 0;
+    }
+    std::map<Row, RowData> decoder;
+    for (const auto &entry: m_decoderTable->getDecoderCruves()) {
+	const auto &curve = dynamic_cast<AnnotationCurve *>(entry);
+	decoder = curve->getAnnotationRows();
+	std::map<Row, RowData>::iterator it;
+	for (it = decoder.begin(); it != decoder.end(); it++) {
+		count = std::max(count, it->second.get_annotations().size());
+	}
+
+    }
+    return count;
+}
+int DecoderTableModel::columnCount(const QModelIndex &parent) const
+{
+	// One column per curve
+	if (!m_active) {
+		return 0;
+	}
+	return m_decoderTable->getDecoderCruves().size();
+}
+
+int DecoderTableModel::indexOfCurve(const AnnotationCurve *curve) const
+{
+    for (size_t i=0; i < m_curves.size(); i++) {
+        if (m_curves[i] == curve) return i;
+    }
+    return -1;
+}
+
+void DecoderTableModel::activate()
+{
+    if (m_logic->runButton()->isChecked()) {
+	    m_logic->runButton()->click();
+    }
+    m_logic->enableRunButton(false);
+    m_logic->runButton()->setEnabled(false);
+    m_logic->enableSingleButton(false);
+
+    for (const auto &curve: m_curves) {
+        if (curve.isNull()) continue;
+        QObject::connect(
+            curve,
+            &AnnotationCurve::annotationsChanged,
+            this,
+            &DecoderTableModel::annotationsChanged
+        );
+    }
+    m_active = true;
+
+    setDefaultPrimaryAnnotations();
+    m_plotCurves.remove(0, DIGITAL_NR_CHANNELS);
+}
+
+void DecoderTableModel::deactivate()
+{
+    m_logic->enableRunButton(true);
+    m_logic->runButton()->setEnabled(true);
+    m_logic->enableSingleButton(true);
+
+    // Disconnect signals
+    for (const auto &curve: m_curves) {
+        if (curve.isNull()) continue;
+	QObject::disconnect(
+	    curve,
+	    &AnnotationCurve::annotationsChanged,
+	    this,
+	    &DecoderTableModel::annotationsChanged
+	);
+    }
+    m_active = false;
+}
+
+void DecoderTableModel::reloadDecoders(bool logic)
+{
+    // Disconnect signals
+    deactivate();
+
+    m_curves.clear();
+
+    // Reconnect signals for all the annotation curves
+    for (const auto &curve: m_plotCurves) {
+		if (const auto annCurve = dynamic_cast<AnnotationCurve *>(curve)) {
+            m_curves.emplace_back(annCurve);
+		}
+    }
+
+    // Reconnect signals
+    activate();
+
+    // Recompute samples
+    annotationsChanged();
+}
+
+void DecoderTableModel::refreshColumn(double column) const
+{
+	// hide/show rows
+	auto curve = dynamic_cast<AnnotationCurve *> (m_plotCurves.at(column));
+	const auto verticalHeader = m_decoderTable->verticalHeader();
+
+	if (curve->getMaxAnnotationCount() == 0) {
+		verticalHeader->setDefaultSectionSize(1);
+		return;
+	}
+
+	for (int row = 0; row < m_decoderTable->size().height(); row++) {
+		if (row < curve->getMaxAnnotationCount(m_primary_annoations->value((int) column))) {
+			m_decoderTable->showRow(row);
+		}
+		else {
+			m_decoderTable->hideRow(row);
+		}
+	}
+
+	// resize rows
+	const int spacing = 10;
+	int rowHeight = 20;
+	rowHeight = std::max(rowHeight, static_cast<int>(curve->getTraceHeight()));
+	verticalHeader->setDefaultSectionSize(rowHeight * curve->getVisibleRows() + spacing);
+}
+
+void DecoderTableModel::annotationsChanged()
+{
+    beginResetModel();
+
+//    int visibleRows = 0;
+//    int rowHeight = 20;
+//    for (const auto &entry: m_decoderTable->getDecoderCruves()) {
+//	const auto &curve = dynamic_cast<AnnotationCurve *>(entry);
+//	if (curve->isVisible()) continue;
+//	int n = curve->getVisibleRows();
+//	if (curve->getAnnotationRows().size() == 0) {
+//		return;
+//	}
+//        for (const auto &rowmap: curve->getAnnotationRows()) {
+//            const Row &row = rowmap.first;
+//            const RowData &data = rowmap.second;
+//	    const auto i = row.index();
+
+//        }
+
+//        visibleRows = std::max(visibleRows, n);
+//	rowHeight = std::max(rowHeight, static_cast<int>(curve->getTraceHeight()));
+//    }
+    endResetModel();
+	/*
+
+    const auto verticalHeader = m_decoderTable->verticalHeader();
+    const int spacing = 10;
+    verticalHeader->setDefaultSectionSize(rowHeight * visibleRows + spacing);
+    verticalHeader->sectionResizeMode(QHeaderView::Fixed);*/
+}
+
+QVariant DecoderTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole and orientation == Qt::Horizontal) {
+        if (section < 0 or static_cast<size_t>(section) >= m_curves.size()) {
+            return QVariant();
+        }
+	if (m_plotCurves.size() > section) {
+		AnnotationCurve *curve = dynamic_cast<AnnotationCurve *>(m_plotCurves[section]);
+		std::map<Row, RowData> decoder(curve->getAnnotationRows());
+		std::map<Row, RowData>::iterator it;
+
+		for (it = decoder.begin(); it != decoder.end(); it++) {
+			if (it->first.index() == m_primary_annoations->value(section)) {
+				return it->first.title();
+			}
+		}
+		return m_plotCurves.at(section)->getName();
+	}
+	return QVariant();
+   }
+    return QAbstractTableModel::headerData(section, orientation, role);
+}
+
+QVariant DecoderTableModel::data(const QModelIndex &index, int role) const
+{
+	if (!index.isValid()) return QVariant();
+
+	const size_t col = index.column();
+	if ( col >= m_curves.size() ) return QVariant();
+	const auto &curve = m_curves.at(col);
+	if (curve.isNull()) return QVariant();
+
+//	if (index.row() >= curve->getMaxAnnotationCount(m_primary_annoations->value(index.column()))) {
+//		return QVariant();
+//	}
+
+	const size_t row = index.row();
+	refreshColumn(index.column());
+
+	if (curve->getAnnotationRows().size() == 0) {
+		return QVariant();
+	}
+
+	auto temp_curve = dynamic_cast<AnnotationCurve *>(m_plotCurves.at(index.column()));
+	std::map<Row, RowData> decoder(temp_curve->getAnnotationRows());
+	std::map<Row, RowData>::iterator it;
+	vector<Annotation> roww;
+
+	for (auto row_map: decoder) {
+		roww = row_map.second.get_annotations();
+		if (!roww.empty() && row_map.first.index() == m_primary_annoations->value(index.column())) {
+			break;
+		}
+	}
+
+	if (roww.empty()) {
+		return QVariant();
+	}
+
+	return QVariant::fromValue(DecoderTableItem(
+					   temp_curve,
+					   roww[index.row()].start_sample(),
+				   roww[index.row()].end_sample()
+			));
+}
+
+} // namespace logic
+} // namespace adiscope

--- a/src/logicanalyzer/decoder_table_model.cpp
+++ b/src/logicanalyzer/decoder_table_model.cpp
@@ -29,14 +29,14 @@ namespace adiscope {
 namespace logic {
 
 DecoderTableModel::DecoderTableModel(DecoderTable *decoderTable, LogicAnalyzer *logicAnalyzer):
-    QAbstractTableModel(decoderTable),
-    m_decoderTable(decoderTable),
-    m_logic(logicAnalyzer)
+	QAbstractTableModel(decoderTable),
+	m_decoderTable(decoderTable),
+	m_logic(logicAnalyzer)
 {
 	m_plotCurves = m_logic->getPlotCurves(true);
 	m_decoderTable->verticalHeader()->setMinimumSectionSize(1);
 	m_primary_annoations = new QMap<int, int>();
-	m_current_column = 1;
+	m_current_column = 0;
 }
 
 void DecoderTableModel::setDefaultPrimaryAnnotations()
@@ -49,33 +49,33 @@ void DecoderTableModel::setDefaultPrimaryAnnotations()
 
 		for (it = decoder.begin(); it != decoder.end(); it++) {
 			if (!it->second.get_annotations().empty()) {
-//				count = it->second.get_annotations().size();
 				count = it->first.index();
 				break;
 			}
 		}
-	m_primary_annoations->insert(i, count);
+		m_primary_annoations->insert(i, count);
 	}
 }
 
 int DecoderTableModel::rowCount(const QModelIndex &parent) const
 {
-    // Return max of all packets
-    size_t count = 0;
-    if (!m_active) {
-	    return 0;
-    }
-    std::map<Row, RowData> decoder;
-    for (const auto &entry: m_decoderTable->getDecoderCruves()) {
-	const auto &curve = dynamic_cast<AnnotationCurve *>(entry);
-	decoder = curve->getAnnotationRows();
-	std::map<Row, RowData>::iterator it;
-	for (it = decoder.begin(); it != decoder.end(); it++) {
-		count = std::max(count, it->second.get_annotations().size());
+	// Return max of all packets
+	if (m_decoderTable->signalsBlocked()) {
+		return max_row_count;
+	}
+	size_t count = 0;
+	if (!m_active) {
+		max_row_count = 0;
+		return 0;
 	}
 
-    }
-    return count;
+	std::map<Row, RowData> decoder;
+	for (const auto &entry: m_decoderTable->getDecoderCruves()) {
+		const auto &curve = dynamic_cast<AnnotationCurve *>(entry);
+		count = std::max(count, curve->getMaxAnnotationCount());
+	}
+	max_row_count = count;
+	return count;
 }
 int DecoderTableModel::columnCount(const QModelIndex &parent) const
 {
@@ -88,10 +88,10 @@ int DecoderTableModel::columnCount(const QModelIndex &parent) const
 
 int DecoderTableModel::indexOfCurve(const AnnotationCurve *curve) const
 {
-    for (size_t i=0; i < m_curves.size(); i++) {
-        if (m_curves[i] == curve) return i;
-    }
-    return -1;
+	for (size_t i=0; i < m_curves.size(); i++) {
+		if (m_curves[i] == curve) return i;
+	}
+	return -1;
 }
 
 void DecoderTableModel::setPrimaryAnnotation(int index)
@@ -112,74 +112,92 @@ void DecoderTableModel::populateDecoderComboBox()
 
 	decoderComboBox->clear();
 	for (const auto &curve: m_curves) {
-	    decoderComboBox->addItem(curve->getName());
+		decoderComboBox->addItem(curve->getName());
 	}
+}
+
+
+int DecoderTableModel::getCurrentColumn()
+{
+	return m_current_column;
+}
+
+
+QMap<int, QVector<QString>>& DecoderTableModel::getFiltered()
+{
+	return m_filteredMessages;
 }
 
 void DecoderTableModel::activate()
 {
-    if (m_logic->runButton()->isChecked()) {
-	    m_logic->runButton()->click();
-    }
-    m_logic->enableRunButton(false);
-    m_logic->runButton()->setEnabled(false);
-    m_logic->enableSingleButton(false);
+	if (m_logic->runButton()->isChecked()) {
+		m_logic->runButton()->click();
+	}
+	m_logic->enableRunButton(false);
+	m_logic->runButton()->setEnabled(false);
+	//    m_logic->enableSingleButton(false);
 
-    for (const auto &curve: m_curves) {
-        if (curve.isNull()) continue;
-        QObject::connect(
-            curve,
-            &AnnotationCurve::annotationsChanged,
-            this,
-            &DecoderTableModel::annotationsChanged
-        );
-    }
-    m_active = true;
+	for (const auto &curve: m_curves) {
+		if (curve.isNull()) continue;
+		QObject::connect(
+					curve,
+					&AnnotationCurve::annotationsChanged,
+					this,
+					&DecoderTableModel::annotationsChanged
+					);
+	}
+	m_active = true;
 
-    m_plotCurves.remove(0, DIGITAL_NR_CHANNELS);
-    populateDecoderComboBox();
-//    setDefaultPrimaryAnnotations();
-    refreshColumn(0);
+	m_filteredMessages.clear();
+	for (int i=0; i<m_curves.size(); i++) {
+		m_filteredMessages.insert(i, QVector<QString>());
+	}
+
+	m_plotCurves.remove(0, DIGITAL_NR_CHANNELS);
+	populateDecoderComboBox();
+	populateFilter(0);
+	//    setDefaultPrimaryAnnotations();
+	refreshColumn(0);
 }
 
 void DecoderTableModel::deactivate()
 {
-    m_logic->enableRunButton(true);
-    m_logic->runButton()->setEnabled(true);
-    m_logic->enableSingleButton(true);
+	m_logic->enableRunButton(true);
+	m_logic->runButton()->setEnabled(true);
+	//    m_logic->enableSingleButton(true);
 
-    // Disconnect signals
-    for (const auto &curve: m_curves) {
-        if (curve.isNull()) continue;
-	QObject::disconnect(
-	    curve,
-	    &AnnotationCurve::annotationsChanged,
-	    this,
-	    &DecoderTableModel::annotationsChanged
-	);
-    }
-    m_active = false;
+	// Disconnect signals
+	for (const auto &curve: m_curves) {
+		if (curve.isNull()) continue;
+		QObject::disconnect(
+					curve,
+					&AnnotationCurve::annotationsChanged,
+					this,
+					&DecoderTableModel::annotationsChanged
+					);
+	}
+	m_active = false;
 }
 
 void DecoderTableModel::reloadDecoders(bool logic)
 {
-    // Disconnect signals
-    deactivate();
+	// Disconnect signals
+	deactivate();
 
-    m_curves.clear();
+	m_curves.clear();
 
-    // Reconnect signals for all the annotation curves
-    for (const auto &curve: m_plotCurves) {
+	// Reconnect signals for all the annotation curves
+	for (const auto &curve: m_plotCurves) {
 		if (const auto annCurve = dynamic_cast<AnnotationCurve *>(curve)) {
-            m_curves.emplace_back(annCurve);
+			m_curves.emplace_back(annCurve);
 		}
-    }
+	}
 
-    // Reconnect signals
-    activate();
+	// Reconnect signals
+	activate();
 
-    // Recompute samples
-    annotationsChanged();
+	// Recompute samples
+	annotationsChanged();
 }
 
 void DecoderTableModel::refreshColumn(double column) const
@@ -208,7 +226,7 @@ void DecoderTableModel::refreshColumn(double column) const
 
 	// resize rows
 	const int spacing = 10;
-	int rowHeight = 20;
+	int rowHeight = 25;
 
 	int row_count = 0;
 	std::map<Row, RowData>::iterator it;
@@ -220,42 +238,18 @@ void DecoderTableModel::refreshColumn(double column) const
 		}
 	}
 
-	if (verticalHeader->defaultSectionSize() != rowHeight * row_count + spacing) {
-		rowHeight = std::max(rowHeight, static_cast<int>(curve->getTraceHeight()));
-		verticalHeader->setDefaultSectionSize(rowHeight * row_count + spacing);
+	auto new_height = rowHeight * (row_count - m_filteredMessages.value(column).size()) + spacing;
+	if (verticalHeader->minimumSectionSize() != new_height || verticalHeader->maximumSectionSize() != new_height) {
+		verticalHeader->setMinimumSectionSize(new_height);
+		verticalHeader->setDefaultSectionSize(new_height);
+		verticalHeader->setMaximumSectionSize(new_height);
 	}
 }
 
 void DecoderTableModel::annotationsChanged()
 {
-    beginResetModel();
-
-//    int visibleRows = 0;
-//    int rowHeight = 20;
-//    for (const auto &entry: m_decoderTable->getDecoderCruves()) {
-//	const auto &curve = dynamic_cast<AnnotationCurve *>(entry);
-//	if (curve->isVisible()) continue;
-//	int n = curve->getVisibleRows();
-//	if (curve->getAnnotationRows().size() == 0) {
-//		return;
-//	}
-//        for (const auto &rowmap: curve->getAnnotationRows()) {
-//            const Row &row = rowmap.first;
-//            const RowData &data = rowmap.second;
-//	    const auto i = row.index();
-
-//        }
-
-//        visibleRows = std::max(visibleRows, n);
-//	rowHeight = std::max(rowHeight, static_cast<int>(curve->getTraceHeight()));
-//    }
-    endResetModel();
-	/*
-
-    const auto verticalHeader = m_decoderTable->verticalHeader();
-    const int spacing = 10;
-    verticalHeader->setDefaultSectionSize(rowHeight * visibleRows + spacing);
-    verticalHeader->sectionResizeMode(QHeaderView::Fixed);*/
+	beginResetModel();
+	endResetModel();
 }
 
 void DecoderTableModel::selectedDecoderChanged(int index)
@@ -263,28 +257,33 @@ void DecoderTableModel::selectedDecoderChanged(int index)
 	if (index >= 0) {
 		m_decoderTable->scrollTo(QAbstractTableModel::index(0, index));
 		m_current_column = index;
-		bool changed = m_logic->setPrimaryAnntations(index, m_primary_annoations->value(index));
+		m_logic->setPrimaryAnntations(index, m_primary_annoations->value(index));
 		if (m_decoderTable->isActive()) {
 			refreshColumn(index);
+			populateFilter(index);
 		}
 	}
 }
 
-QVariant DecoderTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+void DecoderTableModel::populateFilter(int index)
 {
-    if (role == Qt::DisplayRole and orientation == Qt::Horizontal) {
-        if (section < 0 or static_cast<size_t>(section) >= m_curves.size()) {
-            return QVariant();
-        }
-	if (m_plotCurves.size() > section) {
-		return m_plotCurves.at(section)->getName();
-	}
-	return QVariant();
-   }
-    m_current_column = section;
-    bool changed = m_logic->setPrimaryAnntations(section, m_primary_annoations->value(section));
+	auto temp_curve = dynamic_cast<AnnotationCurve *>(m_plotCurves.at(index));
+	std::map<Row, RowData> decoder(temp_curve->getAnnotationRows());
+	m_logic->clearFilter();
 
-    return QAbstractTableModel::headerData(section, orientation, role);
+	int count = 0;
+	for (auto row_map: decoder) {
+		if (!row_map.second.get_annotations().empty()) {
+			count ++;
+			auto title = row_map.first.title();
+			if (title.indexOf(':')) {
+				m_logic->addFilterRow(QIcon(), title.mid(title.indexOf(':') + 1));
+			}
+			else {
+				m_logic->addFilterRow(QIcon(), title);
+			}
+		}
+	}
 }
 
 QVariant DecoderTableModel::data(const QModelIndex &index, int role) const
@@ -296,11 +295,9 @@ QVariant DecoderTableModel::data(const QModelIndex &index, int role) const
 	const auto &curve = m_curves.at(col);
 	if (curve.isNull()) return QVariant();
 
-	if (index.row() >= curve->getMaxAnnotationCount(m_primary_annoations->value(index.column()))) {
-		return QVariant();
-	}
-
-	const size_t row = index.row();
+	//	if (index.row() >= curve->getMaxAnnotationCount(m_primary_annoations->value(index.column()))) {
+	//		return QVariant();
+	//	}
 
 	if (curve->getAnnotationRows().size() == 0) {
 		return QVariant();
@@ -308,24 +305,24 @@ QVariant DecoderTableModel::data(const QModelIndex &index, int role) const
 
 	auto temp_curve = dynamic_cast<AnnotationCurve *>(m_plotCurves.at(index.column()));
 	std::map<Row, RowData> decoder(temp_curve->getAnnotationRows());
-	std::map<Row, RowData>::iterator it;
-	vector<Annotation> roww;
+	vector<Annotation> row;
 
 	for (auto row_map: decoder) {
-		roww = row_map.second.get_annotations();
-		if (!roww.empty() && row_map.first.index() == m_primary_annoations->value(index.column())) {
+		row = row_map.second.get_annotations();
+		if (!row.empty() && row_map.first.index() == m_primary_annoations->value(index.column())) {
 			break;
 		}
 	}
 
-	if (roww.empty()) {
+	if (row.empty()) {
 		return QVariant();
 	}
 
 	return QVariant::fromValue(DecoderTableItem(
 					   temp_curve,
-					   roww[index.row()].start_sample(),
-				   roww[index.row()].end_sample()
+					   row[index.row()].start_sample(),
+				   row[index.row()].end_sample(),
+			m_filteredMessages.value(index.column())
 			));
 }
 

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -41,7 +41,6 @@ public:
     DecoderTableModel(DecoderTable *decoderTable, LogicAnalyzer *logicAnalyzer);
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     void setDefaultPrimaryAnnotations();
 
@@ -58,6 +57,10 @@ public:
 
     void setPrimaryAnnotation(int index);
     void selectedDecoderChanged(int index);
+
+    void populateFilter(int index);
+    QMap<int, QVector<QString>>& getFiltered();
+    int getCurrentColumn();
 
 public Q_SLOTS:
 
@@ -81,6 +84,8 @@ protected:
     QMap<int, int> *m_primary_annoations;
     void populateDecoderComboBox();
     mutable int m_current_column;
+    QMap<int, QVector<QString>> m_filteredMessages;
+    mutable int max_row_count = 0;
 };
 
 } // namespace logic

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -45,7 +45,7 @@ public:
     void setDefaultPrimaryAnnotations();
 
     // resize table cells and hide/show rows
-    void refreshColumn(double column) const;
+    void refreshColumn(double column = -1) const;
 
     // activate connects signals to listen for new decoded messages
     // deactivate disconnects them.
@@ -56,11 +56,15 @@ public:
     int indexOfCurve(const AnnotationCurve* curve) const;
 
     void setPrimaryAnnotation(int index);
-    void selectedDecoderChanged(int index);
+    void selectedDecoderChanged(int index) const;
 
-    void populateFilter(int index);
+    void populateFilter(int index) const;
     QMap<int, QVector<QString>>& getFiltered();
     int getCurrentColumn();
+    void setCurrentRow(int index);
+    void setMaxRowCount();
+    mutable bool to_be_refreshed;
+    void refreshSettings(int column = -1) const;
 
 public Q_SLOTS:
 
@@ -82,7 +86,7 @@ protected:
     QVector<GenericLogicPlotCurve*> m_plotCurves;
     bool m_active = false;
     QMap<int, int> *m_primary_annoations;
-    void populateDecoderComboBox();
+    void populateDecoderComboBox() const;
     mutable int m_current_column;
     QMap<int, QVector<QString>> m_filteredMessages;
     mutable int max_row_count = 0;

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -63,8 +63,9 @@ public:
     int getCurrentColumn();
     void setCurrentRow(int index);
     void setMaxRowCount();
-    mutable bool to_be_refreshed;
+    mutable int to_be_refreshed;
     void refreshSettings(int column = -1) const;
+    void setSearchString(QString str);
 
 public Q_SLOTS:
 
@@ -75,6 +76,8 @@ public Q_SLOTS:
 
     // Slot that should be invoked when new annotations are decoded
     void annotationsChanged();
+
+    void searchBoxSignal(QString text);
 
 protected:
 
@@ -90,6 +93,8 @@ protected:
     mutable int m_current_column;
     QMap<int, QVector<QString>> m_filteredMessages;
     mutable int max_row_count = 0;
+    mutable QString searchString;
+    QVector<int> searchMask;
 };
 
 } // namespace logic

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -60,12 +60,15 @@ public:
 
     void populateFilter(int index) const;
     QMap<int, QVector<QString>>& getFiltered();
-    int getCurrentColumn();
+    int getCurrentColumn() const;
     void setCurrentRow(int index);
     void setMaxRowCount();
     mutable int to_be_refreshed;
     void refreshSettings(int column = -1);
     void setSearchString(QString str) const;
+    QVector<int> getSearchMask();
+    QString getsearchString();
+    int getPrimaryAnnotationIndex() const;
 
 public Q_SLOTS:
 

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -64,8 +64,8 @@ public:
     void setCurrentRow(int index);
     void setMaxRowCount();
     mutable int to_be_refreshed;
-    void refreshSettings(int column = -1) const;
-    void setSearchString(QString str);
+    void refreshSettings(int column = -1);
+    void setSearchString(QString str) const;
 
 public Q_SLOTS:
 
@@ -74,10 +74,7 @@ public Q_SLOTS:
     // the curves vecotr reconnects up signals to watch for annotation changes.
     void reloadDecoders(bool logic);
 
-    // Slot that should be invoked when new annotations are decoded
-    void annotationsChanged();
-
-    void searchBoxSignal(QString text);
+    void searchBoxSlot(QString text);
 
 protected:
 
@@ -95,6 +92,8 @@ protected:
     mutable int max_row_count = 0;
     mutable QString searchString;
     QVector<int> searchMask;
+private:
+    void searchTable(QString text);
 };
 
 } // namespace logic

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DECODER_TABLE_MODEL_H
+#define DECODER_TABLE_MODEL_H
+
+#include <bitset>
+#include <QAbstractTableModel>
+#include <QMap>
+#include "annotationcurve.h"
+#include "decoder_table.hpp"
+#include "decoder_table_item.hpp"
+
+
+namespace adiscope {
+
+
+namespace logic {
+
+class DecoderTableModel : public QAbstractTableModel {
+    Q_OBJECT
+
+public:
+    DecoderTableModel(DecoderTable *decoderTable, LogicAnalyzer *logicAnalyzer);
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    void setDefaultPrimaryAnnotations();
+
+    // resize table cells and hide/show rows
+    void refreshColumn(double column) const;
+
+    // activate connects signals to listen for new decoded messages
+    // deactivate disconnects them.
+    void activate();
+    void deactivate();
+
+    // Get index of the curve
+    int indexOfCurve(const AnnotationCurve* curve) const;
+
+public Q_SLOTS:
+
+    // This slot should be used when any of the decoders / annotation curves
+    // have been modified (eg adding/removing decoders, etc..). This clears
+    // the curves vecotr reconnects up signals to watch for annotation changes.
+    void reloadDecoders(bool logic);
+
+    // Slot that should be invoked when new annotations are decoded
+    void annotationsChanged();
+
+protected:
+
+    // Set of curves to observe. Each should have an entry in the dataset
+    std::vector<QPointer<AnnotationCurve>> m_curves;
+
+    DecoderTable *m_decoderTable;
+    LogicAnalyzer *m_logic;
+    QVector<GenericLogicPlotCurve*> m_plotCurves;
+    bool m_active = false;
+    QMap<int, int> *m_primary_annoations;
+};
+
+} // namespace logic
+} // namespace adiscope
+
+#endif // DECODER_TABLE_MODEL_H
+

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -56,6 +56,8 @@ public:
     // Get index of the curve
     int indexOfCurve(const AnnotationCurve* curve) const;
 
+    void setPrimaryAnnotation(int index);
+
 public Q_SLOTS:
 
     // This slot should be used when any of the decoders / annotation curves
@@ -76,6 +78,7 @@ protected:
     QVector<GenericLogicPlotCurve*> m_plotCurves;
     bool m_active = false;
     QMap<int, int> *m_primary_annoations;
+    mutable int m_current_column;
 };
 
 } // namespace logic

--- a/src/logicanalyzer/decoder_table_model.hpp
+++ b/src/logicanalyzer/decoder_table_model.hpp
@@ -57,6 +57,7 @@ public:
     int indexOfCurve(const AnnotationCurve* curve) const;
 
     void setPrimaryAnnotation(int index);
+    void selectedDecoderChanged(int index);
 
 public Q_SLOTS:
 
@@ -78,6 +79,7 @@ protected:
     QVector<GenericLogicPlotCurve*> m_plotCurves;
     bool m_active = false;
     QMap<int, int> *m_primary_annoations;
+    void populateDecoderComboBox();
     mutable int m_current_column;
 };
 

--- a/src/logicanalyzer/genericlogicplotcurve.cpp
+++ b/src/logicanalyzer/genericlogicplotcurve.cpp
@@ -20,6 +20,8 @@
 
 
 #include "genericlogicplotcurve.h"
+#include <qwt_plot.h>
+#include <qwt_scale_map.h>
 
 
 GenericLogicPlotCurve::GenericLogicPlotCurve(const QString &name, const QString &id, LogicPlotCurveType type, double pixelOffset,
@@ -178,4 +180,14 @@ double GenericLogicPlotCurve::fromSampleToTime(uint64_t sample) const
 	}
 
 	return (sample - smin) / (smax - smin) * (tmax - tmin) + tmin;
+}
+
+QPointF GenericLogicPlotCurve::screenPosToCurvePoint(const QPoint& pos) const
+{
+    const auto plt = plot();
+    if (plt == nullptr) return QPointF();
+    // TODO: Is there another way to do this?
+    const auto xmap = plt->canvasMap(xAxis().pos);
+    const auto ymap = plt->canvasMap(yAxis().pos);
+    return QPointF(xmap.invTransform(pos.x()), ymap.invTransform(pos.y()));
 }

--- a/src/logicanalyzer/genericlogicplotcurve.h
+++ b/src/logicanalyzer/genericlogicplotcurve.h
@@ -65,13 +65,20 @@ public:
 	virtual void dataAvailable(uint64_t from, uint64_t to) {}
 	virtual void reset() {}
 
+	uint64_t fromTimeToSample(double time) const;
+	double fromSampleToTime(uint64_t sample) const;
+
+	// Check if the point is on the curve. When invoked by the CapturePlot
+	// this point is already mapped to the plot's bounds.
+	virtual bool testHit(const QPointF& p) const { return false; }
+
+	// Map screen point to curve point
+	QPointF screenPosToCurvePoint(const QPoint& pos) const;
+
 Q_SIGNALS:
 	void nameChanged(QString);
 	void pixelOffsetChanged(double);
-
-protected:
-	uint64_t fromTimeToSample(double time) const;
-	double fromSampleToTime(uint64_t sample) const;
+	void clicked(const QPointF& p);
 
 protected:
 	QString m_name;

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1620,6 +1620,14 @@ void LogicAnalyzer::connectSignalsAndSlots()
 		[=](bool checked){
 		if (!checked) {
 			ui->decoderTableView->blockSignals(false);
+			if (ui->decoderTableView->isActive()) {
+				ui->decoderTableView->decoderModel()->setMaxRowCount();
+				if (ui->PrimaryAnnotationComboBox->count() == 0) {
+					ui->decoderTableView->decoderModel()->refreshColumn();
+				} else {
+					ui->decoderTableView->decoderModel()->to_be_refreshed = true;
+				}
+			}
 		}
 	});
 
@@ -2425,6 +2433,15 @@ void LogicAnalyzer::setupDecoders()
 			const auto model = ui->decoderTableView->decoderModel();
 			const auto col = model->indexOfCurve(curve);
 			ui->DecoderComboBox->setCurrentIndex(col);
+
+			std::string title = result.ann->row()->title().toStdString();
+			title = title.erase(0, title.find(':') + 1);
+
+			int row_index = ui->PrimaryAnnotationComboBox->findText(QString::fromStdString(title));
+			if (row_index != -1) {
+				ui->PrimaryAnnotationComboBox->setCurrentIndex(row_index);
+				ui->decoderTableView->decoderModel()->setCurrentRow(result.index);
+			}
 		});
 	});
 

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1542,6 +1542,11 @@ void LogicAnalyzer::clearFilter()
 	filterCount = 0;
 }
 
+bool LogicAnalyzer::getTableInfo()
+{
+	return m_tableInfo;
+}
+
 bool LogicAnalyzer::setPrimaryAnntations(int column, int index)
 {
 	bool changed = false;
@@ -1605,6 +1610,8 @@ void LogicAnalyzer::connectSignalsAndSlots()
 {
 	// connect all the signals and slots here
 
+	connect(ui->decoderTableView, SIGNAL(show()), this, SLOT(PrimaryAnnotationChanged(int)));
+
 	connect(ui->primaryAnnotationComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(PrimaryAnnotationChanged(int)));
 
 	connect(ui->DecoderComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(selectedDecoderChanged(int)));
@@ -1622,7 +1629,7 @@ void LogicAnalyzer::connectSignalsAndSlots()
 			ui->decoderTableView->blockSignals(false);
 			if (ui->decoderTableView->isActive()) {
 				ui->decoderTableView->decoderModel()->setMaxRowCount();
-				if (ui->PrimaryAnnotationComboBox->count() == 0) {
+				if (ui->primaryAnnotationComboBox->count() == 0) {
 					ui->decoderTableView->decoderModel()->refreshColumn();
 				} else {
 					ui->decoderTableView->decoderModel()->to_be_refreshed = true;
@@ -2437,9 +2444,9 @@ void LogicAnalyzer::setupDecoders()
 			std::string title = result.ann->row()->title().toStdString();
 			title = title.erase(0, title.find(':') + 1);
 
-			int row_index = ui->PrimaryAnnotationComboBox->findText(QString::fromStdString(title));
+			int row_index = ui->primaryAnnotationComboBox->findText(QString::fromStdString(title));
 			if (row_index != -1) {
-				ui->PrimaryAnnotationComboBox->setCurrentIndex(row_index);
+				ui->primaryAnnotationComboBox->setCurrentIndex(row_index);
 				ui->decoderTableView->decoderModel()->setCurrentRow(result.index);
 			}
 		});
@@ -2718,6 +2725,7 @@ void LogicAnalyzer::restoreTriggerState()
 void LogicAnalyzer::readPreferences()
 {
 	bool showFps = prefPanel->getShow_plot_fps();
+	m_tableInfo = prefPanel->getTableInfo();
 	m_separateAnnotations = prefPanel->getSeparateAnnotations();
 	m_plot.setVisibleFpsLabel(showFps);
 

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -205,6 +205,7 @@ LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx, adiscope::Filter *filt,
 			ui->wDecoderSettings_2->setVisible(check);
 		});
 	ui->btnCollapseSettings->click();
+	ui->statusLabel->setStyleSheet("QLabel { color : #4A64FF; }");
 
 	// Add propper zoomer
 	m_plot.addZoomer(0);
@@ -1525,6 +1526,9 @@ void LogicAnalyzer::setupUi()
 			SLOT(onFilterChanged(QStandardItem*)));
 
 	ui->filterLayout->addWidget(filterMessages);
+
+	connect(ui->btnTableExport, &QPushButton::clicked,
+		ui->decoderTableView, &DecoderTable::exportData);
 }
 
 void LogicAnalyzer::onFilterChanged(QStandardItem *item)
@@ -1649,9 +1653,10 @@ void LogicAnalyzer::selectedDecoderChanged(int index)
 
 void LogicAnalyzer::waitForDecoders()
 {
-	// waits for LA to stop decoding
+	setStatusLabel("Waiting for plot ...");
 	ui->wDecoderSettings_2->setDisabled(true);
 
+	// waits for LA to stop decoding
 	bool all_finished;
 	while(this->isVisible()) {
 		usleep(100);
@@ -1669,6 +1674,7 @@ void LogicAnalyzer::waitForDecoders()
 	}
 
 	ui->wDecoderSettings_2->setDisabled(false);
+	setStatusLabel("");
 }
 
 int LogicAnalyzer::getGroupSize()
@@ -1688,6 +1694,11 @@ void LogicAnalyzer::setMaxGroupValues(int value)
 
 	ui->groupOffsetSpinBox->setMaximum(value);
 	ui->groupOffsetSpinBox->setMinimum(0);
+}
+
+void LogicAnalyzer::setStatusLabel(QString text)
+{
+	ui->statusLabel->setText(text);
 }
 
 void LogicAnalyzer::connectSignalsAndSlots()

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1430,6 +1430,8 @@ void LogicAnalyzer::setupUi()
 	// Decoder table
 
 	ui->decoderTableView->setLogicAnalyzer(this);
+	ui->decoderTableView->horizontalHeader()->hide();
+	ui->decoderTableView->horizontalScrollBar()->hide();
 
 	// Setup cursors menu
 
@@ -1508,9 +1510,9 @@ bool LogicAnalyzer::setPrimaryAnntations(int column, int index)
 	return changed;
 }
 
-void LogicAnalyzer::setSelectedPrimaryAnnotation(int index)
+QComboBox* LogicAnalyzer::getDecoderComboBox()
 {
-	ui->primaryAnnotationComboBox->setCurrentIndex(ui->primaryAnnotationComboBox->findData(index));
+	return ui->DecoderComboBox;
 }
 
 void LogicAnalyzer::enableRunButton(bool flag)
@@ -1524,7 +1526,16 @@ void LogicAnalyzer::enableSingleButton(bool flag)
 }
 
 void LogicAnalyzer::PrimaryAnnotationChanged(int index){
+	if (index == -1) {
+		index = 0;
+		ui->primaryAnnotationComboBox->setCurrentIndex(index);
+	}
 	ui->decoderTableView->setPrimaryAnnotation(ui->primaryAnnotationComboBox->currentData().toInt());
+}
+
+void LogicAnalyzer::selectedDecoderChanged(int index)
+{
+	ui->decoderTableView->decoderModel()->selectedDecoderChanged(index);
 }
 
 void LogicAnalyzer::connectSignalsAndSlots()
@@ -1532,6 +1543,8 @@ void LogicAnalyzer::connectSignalsAndSlots()
 	// connect all the signals and slots here
 
 	connect(ui->primaryAnnotationComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(PrimaryAnnotationChanged(int)));
+
+	connect(ui->DecoderComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(selectedDecoderChanged(int)));
 
 	connect(ui->runSingleWidget, &RunSingleWidget::toggled,
 		[=](bool checked){

--- a/src/logicanalyzer/logic_analyzer.cpp
+++ b/src/logicanalyzer/logic_analyzer.cpp
@@ -1671,6 +1671,25 @@ void LogicAnalyzer::waitForDecoders()
 	ui->wDecoderSettings_2->setDisabled(false);
 }
 
+int LogicAnalyzer::getGroupSize()
+{
+	return (ui->groupSizeSpinBox->value() != 0) ? ui->groupSizeSpinBox->value() : 1;
+}
+
+int LogicAnalyzer::getGroupOffset()
+{
+	return ui->groupOffsetSpinBox->value();
+}
+
+void LogicAnalyzer::setMaxGroupValues(int value)
+{
+	ui->groupSizeSpinBox->setMaximum(value);
+	ui->groupSizeSpinBox->setMinimum(1);
+
+	ui->groupOffsetSpinBox->setMaximum(value);
+	ui->groupOffsetSpinBox->setMinimum(0);
+}
+
 void LogicAnalyzer::connectSignalsAndSlots()
 {
 	// connect all the signals and slots here
@@ -1705,6 +1724,10 @@ void LogicAnalyzer::connectSignalsAndSlots()
 			}
 		}
 	});
+
+	connect(ui->groupSizeSpinBox, SIGNAL(valueChanged(int)), ui->decoderTableView, SLOT(groupValuesChanged(int)));
+
+	connect(ui->groupOffsetSpinBox, SIGNAL(valueChanged(int)), ui->decoderTableView, SLOT(groupValuesChanged(int)));
 
 	connect(ui->searchBox, &QLineEdit::returnPressed,
 		[=](){
@@ -2520,8 +2543,12 @@ void LogicAnalyzer::setupDecoders()
 
 			int row_index = ui->primaryAnnotationComboBox->findText(QString::fromStdString(title));
 			if (row_index != -1) {
+				int row = 0;
+				if (getGroupOffset() < result.index) {
+					row = result.index / getGroupSize();
+				}
 				ui->primaryAnnotationComboBox->setCurrentIndex(row_index);
-				ui->decoderTableView->decoderModel()->setCurrentRow(result.index);
+				ui->decoderTableView->decoderModel()->setCurrentRow(row);
 			}
 		});
 	});

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -103,8 +103,11 @@ public: // Mixed Signal View Interface
 
 	// Update the viewport to fit the min and max time
 	void fitViewport(double min, double max);
+	void resetViewport();
+	bool setPrimaryAnntations(int column, int index = -1);
 	void enableRunButton(bool flag);
 	void enableSingleButton(bool flag);
+	void setSelectedPrimaryAnnotation(int index);
 
 Q_SIGNALS:
 	void showTool();
@@ -139,6 +142,8 @@ private Q_SLOTS:
 	void exportData();
 	bool exportTabCsv(const QString &separator, const QString &fileName);
 	bool exportVcd(const QString &fileName, const QString &startSep, const QString &endSep);
+
+	void PrimaryAnnotationChanged(int index);
 
 private:
 	void setupUi();

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -45,6 +45,8 @@
 #include <libm2k/digital/m2kdigital.hpp>
 #include <libm2k/enums.hpp>
 
+constexpr int DIGITAL_NR_CHANNELS = 16;
+
 // TODO
 using namespace libm2k;
 using namespace libm2k::digital;
@@ -91,10 +93,19 @@ public: // Mixed Signal View Interface
 	// get the current plot in use (logic or osc)
 	QwtPlot *getCurrentPlot();
 
+	// get list of plot curves
+	QVector<GenericLogicPlotCurve*> getPlotCurves(bool logic) const;
+
 	// connect signals and slots for the plot (logic or osc)
 	void connectSignalsAndSlotsForPlot(CapturePlot *plot);
 
 	void setData(const uint16_t * const data, int size);
+
+	// Update the viewport to fit the min and max time
+	void fitViewport(double min, double max);
+	void enableRunButton(bool flag);
+	void enableSingleButton(bool flag);
+
 Q_SIGNALS:
 	void showTool();
 

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -114,7 +114,10 @@ public: // Mixed Signal View Interface
 	void clearFilter();
 	bool getTableInfo();
 	void clearSearch(int index = -1);
+	int getGroupSize();
+	void setMaxGroupValues(int value);
 
+	int getGroupOffset();
 Q_SIGNALS:
 	void showTool();
 

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -151,6 +151,8 @@ private Q_SLOTS:
 
 	void PrimaryAnnotationChanged(int index);
 	void selectedDecoderChanged(int index);
+	void emitSearchSignal(int index = -1);
+	void clearSearchSignal(int index = -1);
 
 	void onFilterChanged(QStandardItem *item);
 

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -116,6 +116,7 @@ public: // Mixed Signal View Interface
 	void clearSearch(int index = -1);
 	int getGroupSize();
 	void setMaxGroupValues(int value);
+	void setStatusLabel(QString text);
 
 	int getGroupOffset();
 Q_SIGNALS:

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -107,7 +107,7 @@ public: // Mixed Signal View Interface
 	bool setPrimaryAnntations(int column, int index = -1);
 	void enableRunButton(bool flag);
 	void enableSingleButton(bool flag);
-	void setSelectedPrimaryAnnotation(int index);
+	QComboBox *getDecoderComboBox();
 
 Q_SIGNALS:
 	void showTool();
@@ -144,6 +144,7 @@ private Q_SLOTS:
 	bool exportVcd(const QString &fileName, const QString &startSep, const QString &endSep);
 
 	void PrimaryAnnotationChanged(int index);
+	void selectedDecoderChanged(int index);
 
 private:
 	void setupUi();

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -29,6 +29,7 @@
 #include <QList>
 #include <QQueue>
 #include <QScrollBar>
+#include <QStandardItem>
 #include <QTimer>
 
 #include "logic_tool.h"
@@ -44,6 +45,7 @@
 #include <libm2k/contextbuilder.hpp>
 #include <libm2k/digital/m2kdigital.hpp>
 #include <libm2k/enums.hpp>
+#include <gui/dropdown_switch_list.h>
 
 constexpr int DIGITAL_NR_CHANNELS = 16;
 
@@ -108,6 +110,8 @@ public: // Mixed Signal View Interface
 	void enableRunButton(bool flag);
 	void enableSingleButton(bool flag);
 	QComboBox *getDecoderComboBox();
+	void addFilterRow(QIcon icon, QString name);
+	void clearFilter();
 
 Q_SIGNALS:
 	void showTool();
@@ -122,6 +126,7 @@ private Q_SLOTS:
 
 	void on_btnSettings_clicked(bool checked);
 	void on_btnGeneralSettings_toggled(bool);
+	void on_btnDecoderTable_toggled(bool);
 	void rightMenuFinished(bool opened);
 
 	void onTimeTriggerValueChanged(double value);
@@ -145,6 +150,8 @@ private Q_SLOTS:
 
 	void PrimaryAnnotationChanged(int index);
 	void selectedDecoderChanged(int index);
+
+	void onFilterChanged(QStandardItem *item);
 
 private:
 	void setupUi();
@@ -235,6 +242,9 @@ private:
 	int m_currentKernelBuffers;
 
 	StateUpdater *m_triggerUpdater;
+
+	DropdownSwitchList* filterMessages;
+	int filterCount = 0;
 
 
 };

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -113,6 +113,7 @@ public: // Mixed Signal View Interface
 	void addFilterRow(QIcon icon, QString name);
 	void clearFilter();
 	bool getTableInfo();
+	void clearSearch(int index = -1);
 
 Q_SIGNALS:
 	void showTool();
@@ -152,7 +153,6 @@ private Q_SLOTS:
 	void PrimaryAnnotationChanged(int index);
 	void selectedDecoderChanged(int index);
 	void emitSearchSignal(int index = -1);
-	void clearSearchSignal(int index = -1);
 
 	void onFilterChanged(QStandardItem *item);
 
@@ -174,6 +174,8 @@ private:
 	void setupTriggerMenu();
 
 	QVector<QVector<QString>> createDecoderData(bool separate_annotations);
+
+	void waitForDecoders();
 
 private:
 	// TODO: consisten naming (m_ui, m_crUi)

--- a/src/logicanalyzer/logic_analyzer.h
+++ b/src/logicanalyzer/logic_analyzer.h
@@ -112,6 +112,7 @@ public: // Mixed Signal View Interface
 	QComboBox *getDecoderComboBox();
 	void addFilterRow(QIcon icon, QString name);
 	void clearFilter();
+	bool getTableInfo();
 
 Q_SIGNALS:
 	void showTool();
@@ -202,6 +203,7 @@ private:
 	double m_timeTriggerOffset;
 	bool m_resetHorizAxisOffset;
 	bool m_separateAnnotations;
+	bool m_tableInfo;
 
 	// capture
 	std::thread *m_captureThread;

--- a/src/logicanalyzer/rowdata.cpp
+++ b/src/logicanalyzer/rowdata.cpp
@@ -102,8 +102,9 @@ std::pair<uint64_t, uint64_t> RowData::get_annotation_subset(uint64_t start_samp
         }
     }
 
-    if (!last && first > 0 && first < annotations_.size() - 1) {
-        last = first + 1;
+    if (!last && first > 0) {
+	    last = (first < annotations_.size() - 1) ? first + 1
+			    : first;
     }
 
     // let s adjust the edges a bit

--- a/src/logicanalyzer/rowdata.cpp
+++ b/src/logicanalyzer/rowdata.cpp
@@ -59,9 +59,18 @@ void RowData::get_annotation_subset(
             dest.push_back(annotation);
 }
 
+vector<Annotation> RowData::get_annotations() const {
+	return annotations_;
+}
+
 Annotation RowData::getAnnAt(uint64_t index) const {
 
     return annotations_[index];
+}
+
+const Annotation* RowData::annAt(uint64_t index) const
+{
+    return &annotations_[index];
 }
 
 void RowData::sort_annotations() {

--- a/src/logicanalyzer/rowdata.h
+++ b/src/logicanalyzer/rowdata.h
@@ -71,12 +71,15 @@ public:
         vector<Annotation> &dest,
         uint64_t start_sample, uint64_t end_sample) const;
 
+    vector<Annotation> get_annotations() const;
+
     void emplace_annotation(srd_proto_data *pdata, const Row *row);
 
     std::pair<uint64_t, uint64_t> get_annotation_subset(uint64_t start_sample,
                                                         uint64_t end_sample) const;
 
     Annotation getAnnAt(uint64_t index) const;
+    const Annotation* annAt(uint64_t index) const;
 
     void sort_annotations();
 

--- a/src/oscilloscope_plot.cpp
+++ b/src/oscilloscope_plot.cpp
@@ -79,7 +79,7 @@ CapturePlot::CapturePlot(QWidget *parent,  bool isdBgraph, unsigned int xNumDivs
 	d_maxBufferError(nullptr)
 {
 	setMinimumHeight(200);
-	setMinimumWidth(450);
+	setMinimumWidth(200);
 
 	/* Initial colors scheme */
 	d_trigAactiveLinePen = QPen(QColor(255, 255, 255), 2, Qt::SolidLine);

--- a/src/oscilloscope_plot.hpp
+++ b/src/oscilloscope_plot.hpp
@@ -131,6 +131,9 @@ namespace adiscope {
 
 		CursorReadouts * getCursorReadouts() const;
 
+		// Get the curve at the given point. May return nullptr.
+		GenericLogicPlotCurve* curveAt(const QPoint& pos) const;
+
 	Q_SIGNALS:
 		void timeTriggerValueChanged(double);
 		void channelOffsetChanged(unsigned int, double);
@@ -139,6 +142,11 @@ namespace adiscope {
 		void leftGateChanged(double);
 		void rightGateChanged(double);
 		void channelSelected(int, bool);
+
+		// These are only emitted if you set setMouseTracking(true) (not done by default)
+		void mouseButtonPress(const QMouseEvent *event);
+		void mouseButtonRelease(const QMouseEvent *event);
+		void mouseMove(const QMouseEvent *event);
 
 	public Q_SLOTS:
 		void setTriggerAEnabled(bool en);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -68,6 +68,7 @@ Preferences::Preferences(QWidget *parent) :
 	language("auto"),
 	m_displaySamplingPoints(false),
 	m_separateAnnotations(false),
+	m_tableInfo(true),
 	m_instrument_notes_active(false),
 	m_debug_messages_active(false),
 	m_attemptTempLutCalib(false),
@@ -293,6 +294,11 @@ Preferences::Preferences(QWidget *parent) :
 		Q_EMIT notify();
 	});
 
+	connect(ui->logicAnalyzerTableInfo, &QCheckBox::stateChanged, [=](int state){
+		m_tableInfo = (!state ? false : true);
+		Q_EMIT notify();
+	});
+
 	connect(ui->useOpenGl, &QCheckBox::stateChanged, [=](int state){
 		m_use_open_gl = state;
 		qputenv("SCOPY_USE_OPENGL",QByteArray::number(state));
@@ -393,6 +399,16 @@ void Preferences::setDisplaySamplingPoints(bool display)
 	m_displaySamplingPoints = display;
 }
 
+bool Preferences::getTableInfo() const
+{
+	return m_tableInfo;
+}
+
+void Preferences::setTableInfo(bool flag)
+{
+	m_tableInfo = flag;
+}
+
 bool Preferences::getSeparateAnnotations() const
 {
 	return m_separateAnnotations;
@@ -450,6 +466,7 @@ void Preferences::initializePreferences()
 	ui->languageCombo->setCurrentText(language);
 	ui->logicAnalyzerDisplaySamplingPoints->setChecked(m_displaySamplingPoints);
 	ui->logicAnalyzerSeparateAnnotations->setChecked(m_separateAnnotations);
+	ui->logicAnalyzerTableInfo->setChecked(m_tableInfo);
 	ui->instrumentNotesCheckbox->setChecked(m_instrument_notes_active);
 	ui->debugMessagesCheckbox->setChecked(m_debug_messages_active);
 	ui->debugInstrumentCheckbox->setChecked(debugger_enabled);
@@ -1025,6 +1042,16 @@ void Preferences_API::setSeparateAnnotations(bool val)
 {
 	preferencePanel->m_separateAnnotations = val;
 }
+
+bool Preferences_API::getTableInfo() const
+{
+	return preferencePanel->m_tableInfo;
+}
+void Preferences_API::setTableInfo(bool val)
+{
+	preferencePanel->m_tableInfo = val;
+}
+
 
 QString Preferences_API::getCurrentStylesheet() const
 {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -117,6 +117,9 @@ public:
 	bool getSeparateAnnotations() const;
 	void setSeparateAnnotations(bool display);
 
+	bool getTableInfo() const;
+	void setTableInfo(bool display);
+
 	bool getInstrumentNotesActive() const;
 	void setInstrumentNotesActive(bool display);
 
@@ -207,6 +210,7 @@ private:
 	bool m_instrument_notes_active;
 	bool m_displaySamplingPoints;
 	bool m_separateAnnotations;
+	bool m_tableInfo;
 	bool m_debug_messages_active;
 	bool m_attemptTempLutCalib;
 	bool m_skipCalIfCalibrated;
@@ -251,6 +255,7 @@ class Preferences_API : public ApiObject
 	Q_PROPERTY(bool attemptTempLutCalib READ getAttemptTempLutCalib WRITE setAttemptTempLutCalib)
 	Q_PROPERTY(bool skipCalIfCalibrated READ getSkipCalIfCalibrated WRITE setSkipCalIfCalibrated)
 	Q_PROPERTY(bool separateAnnotations READ getSeparateAnnotations WRITE setSeparateAnnotations)
+	Q_PROPERTY(bool TableInfo READ getTableInfo WRITE setTableInfo)
 	Q_PROPERTY(bool automatical_version_checking_enabled READ getAutomaticalVersionCheckingEnabled WRITE setAutomaticalVersionCheckingEnabled)
 	Q_PROPERTY(QString check_updates_url READ getCheckUpdatesUrl WRITE setCheckUpdatesUrl)
 	Q_PROPERTY(bool first_application_run READ getFirstApplicationRun WRITE setFirstApplicationRun)
@@ -336,6 +341,9 @@ public:
 
 	bool getSeparateAnnotations() const;
 	void setSeparateAnnotations(bool val);
+
+	bool getTableInfo() const;
+	void setTableInfo(bool val);
 
 	bool getAutomaticalVersionCheckingEnabled() const;
 	void setAutomaticalVersionCheckingEnabled(const bool& enabled);

--- a/src/tool.hpp
+++ b/src/tool.hpp
@@ -55,6 +55,7 @@ public:
 	~Tool();
 
 	QPushButton *runButton() { return toolMenuItem->getToolStopBtn(); }
+	QPushButton *singleButton() { return toolMenuItem->getToolBtn(); }
 	const QString& getName();
 	void setName(const QString& name);
 	virtual void settingsLoaded();

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -2003,6 +2003,12 @@ color: rgba(255,255,255,51);
                  </item>
                  <item>
                   <widget class="adiscope::logic::DecoderTable" name="decoderTableView">
+                   <property name="minimumSize">
+                    <size>
+                     <width>500</width>
+                     <height>0</height>
+                    </size>
+                   </property>
                    <property name="frameShadow">
                     <enum>QFrame::Plain</enum>
                    </property>
@@ -2416,6 +2422,22 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
     <hint type="destinationlabel">
      <x>1185</x>
      <y>427</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnDecoderTable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>btnSettings</receiver>
+   <slot>setChecked(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1243</x>
+     <y>677</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1233</x>
+     <y>35</y>
     </hint>
    </hints>
   </connection>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -526,7 +526,7 @@
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>358</width>
+                      <width>400</width>
                       <height>542</height>
                      </rect>
                     </property>
@@ -1392,8 +1392,8 @@ color: rgba(255,255,255,51);
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>320</width>
-                      <height>304</height>
+                      <width>472</width>
+                      <height>542</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1795,6 +1795,9 @@ color: rgba(255,255,255,51);
                  </property>
                  <item>
                   <layout class="QVBoxLayout" name="wDecoderSettingsContainer">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
@@ -1889,21 +1892,10 @@ color: rgba(255,255,255,51);
                       <property name="sizeConstraint">
                        <enum>QLayout::SetMinimumSize</enum>
                       </property>
-                      <item row="6" column="0">
-                       <widget class="QLabel" name="label_22">
-                        <property name="text">
-                         <string>Group offset</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="9" column="1">
-                       <layout class="QVBoxLayout" name="filterLayout">
-                        <property name="spacing">
-                         <number>0</number>
-                        </property>
-                       </layout>
-                      </item>
-                      <item row="3" column="1">
+                      <property name="bottomMargin">
+                       <number>2</number>
+                      </property>
+                      <item row="4" column="1">
                        <widget class="QComboBox" name="primaryAnnotationComboBox">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1919,86 +1911,14 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="0">
-                       <widget class="QLabel" name="label_18">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Decoder</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QComboBox" name="DecoderComboBox">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="8" column="0">
-                       <widget class="QLabel" name="label_20">
-                        <property name="text">
-                         <string>Regex search</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="5" column="0">
+                      <item row="6" column="0">
                        <widget class="QLabel" name="label_21">
                         <property name="text">
                          <string>Group size</string>
                         </property>
                        </widget>
                       </item>
-                      <item row="3" column="0">
-                       <widget class="QLabel" name="label_17">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Group by</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="8" column="1">
-                       <widget class="QLineEdit" name="searchBox">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="9" column="0">
-                       <widget class="QLabel" name="label_19">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Filter</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="7" column="0" colspan="2">
+                      <item row="8" column="0" colspan="2">
                        <widget class="Line" name="line_10">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -2026,7 +1946,20 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="5" column="1">
+                      <item row="2" column="0">
+                       <widget class="QLabel" name="label_18">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Decoder</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="6" column="1">
                        <widget class="QSpinBox" name="groupSizeSpinBox">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -2048,7 +1981,80 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="6" column="1">
+                      <item row="9" column="1">
+                       <widget class="QLineEdit" name="searchBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="9" column="0">
+                       <widget class="QLabel" name="label_20">
+                        <property name="text">
+                         <string>Regex search</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="10" column="0">
+                       <widget class="QLabel" name="label_19">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Filter</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="10" column="1">
+                       <layout class="QVBoxLayout" name="filterLayout">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
+                       </layout>
+                      </item>
+                      <item row="4" column="0">
+                       <widget class="QLabel" name="label_17">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Group by</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="1">
+                       <widget class="QComboBox" name="DecoderComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="7" column="0">
+                       <widget class="QLabel" name="label_22">
+                        <property name="text">
+                         <string>Group offset</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="7" column="1">
                        <widget class="QSpinBox" name="groupOffsetSpinBox">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -2064,6 +2070,28 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
+                      <item row="11" column="1">
+                       <widget class="QPushButton" name="btnTableExport">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>30</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>30</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>Export</string>
+                        </property>
+                        <property name="blue_button" stdset="0">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </widget>
                    </item>
@@ -2071,11 +2099,14 @@ color: rgba(255,255,255,51);
                  </item>
                  <item>
                   <layout class="QVBoxLayout" name="verticalLayout_15">
+                   <property name="spacing">
+                    <number>2</number>
+                   </property>
                    <property name="leftMargin">
                     <number>10</number>
                    </property>
                    <property name="topMargin">
-                    <number>6</number>
+                    <number>0</number>
                    </property>
                    <property name="rightMargin">
                     <number>10</number>
@@ -2083,6 +2114,16 @@ color: rgba(255,255,255,51);
                    <property name="bottomMargin">
                     <number>0</number>
                    </property>
+                   <item>
+                    <widget class="QLabel" name="statusLabel">
+                     <property name="text">
+                      <string/>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignCenter</set>
+                     </property>
+                    </widget>
+                   </item>
                    <item>
                     <widget class="Line" name="line_8">
                      <property name="maximumSize">
@@ -2105,17 +2146,36 @@ color: rgba(255,255,255,51);
                   </layout>
                  </item>
                  <item>
-                  <widget class="adiscope::logic::DecoderTable" name="decoderTableView">
-                   <property name="minimumSize">
-                    <size>
-                     <width>500</width>
-                     <height>0</height>
-                    </size>
+                  <layout class="QVBoxLayout" name="verticalLayout_13">
+                   <property name="spacing">
+                    <number>0</number>
                    </property>
-                   <property name="frameShadow">
-                    <enum>QFrame::Plain</enum>
+                   <property name="leftMargin">
+                    <number>6</number>
                    </property>
-                  </widget>
+                   <property name="rightMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="adiscope::logic::DecoderTable" name="decoderTableView">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="minimumSize">
+                      <size>
+                       <width>500</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Plain</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                 </layout>
                </widget>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -526,8 +526,8 @@
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>373</width>
-                      <height>522</height>
+                      <width>200</width>
+                      <height>360</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1392,8 +1392,8 @@ color: rgba(255,255,255,51);
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>363</width>
-                      <height>522</height>
+                      <width>320</width>
+                      <height>304</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1788,6 +1788,140 @@ color: rgba(255,255,255,51);
                   <number>0</number>
                  </property>
                  <item>
+                  <layout class="QVBoxLayout" name="wDecoderSettingsContainer">
+                   <property name="leftMargin">
+                    <number>10</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>10</number>
+                   </property>
+                   <item>
+                    <layout class="QHBoxLayout" name="wDecoderSettingsCollapse">
+                     <item>
+                      <widget class="QPushButton" name="btnCollapseSettings">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checkable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                       <property name="subsection_arrow_button" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_16">
+                       <property name="text">
+                        <string>SETTINGS</string>
+                       </property>
+                       <property name="subsection_label" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="Line" name="line_9">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>1</height>
+                        </size>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>1</height>
+                        </size>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="subsection_line" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QWidget" name="wDecoderSettings_2" native="true">
+                     <layout class="QVBoxLayout" name="wDecoderSettings">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_12">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>6</number>
+                        </property>
+                        <item>
+                         <widget class="QLabel" name="label_17">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Group by</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QComboBox" name="primaryAnnotationComboBox">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>16777215</height>
+                           </size>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
                   <layout class="QVBoxLayout" name="verticalLayout_15">
                    <property name="leftMargin">
                     <number>6</number>
@@ -1802,14 +1936,27 @@ color: rgba(255,255,255,51);
                     <number>6</number>
                    </property>
                    <item>
-                    <widget class="QLabel" name="decoderTableLabel">
-                     <property name="text">
-                      <string>Decode</string>
-                     </property>
-                     <property name="general_settings_label" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
+                    <layout class="QGridLayout" name="gridLayout_4">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="decoderTableLabel">
+                       <property name="enabled">
+                        <bool>true</bool>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>100</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Decode</string>
+                       </property>
+                       <property name="general_settings_label" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item>
                     <widget class="Line" name="line_8">
@@ -2145,10 +2292,6 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
-  <include location="../resources/resources.qrc"/>
   <include location="../resources/resources.qrc"/>
  </resources>
  <connections>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1280</width>
-    <height>694</height>
+    <height>704</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -115,7 +115,7 @@
            <string>Print</string>
           </property>
           <property name="icon">
-           <iconset>
+           <iconset resource="../resources/resources.qrc">
             <normaloff>:/icons/printer.svg</normaloff>:/icons/printer.svg</iconset>
           </property>
           <property name="iconSize">
@@ -456,7 +456,7 @@
               <number>0</number>
              </property>
              <property name="topMargin">
-              <number>20</number>
+              <number>0</number>
              </property>
              <property name="rightMargin">
               <number>0</number>
@@ -476,7 +476,7 @@
                 <string notr="true"/>
                </property>
                <property name="currentIndex">
-                <number>3</number>
+                <number>4</number>
                </property>
                <widget class="QWidget" name="channelSettings">
                 <property name="minimumSize">
@@ -526,8 +526,8 @@
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>358</width>
-                      <height>514</height>
+                      <width>373</width>
+                      <height>522</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1392,8 +1392,8 @@ color: rgba(255,255,255,51);
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>348</width>
-                      <height>514</height>
+                      <width>363</width>
+                      <height>522</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1437,10 +1437,10 @@ color: rgba(255,255,255,51);
                         </size>
                        </property>
                        <property name="frameShadow">
-                        <enum>QFrame::Plain</enum>
+                        <enum>QFrame::Sunken</enum>
                        </property>
                        <property name="lineWidth">
-                        <number>2</number>
+                        <number>1</number>
                        </property>
                        <property name="orientation">
                         <enum>Qt::Horizontal</enum>
@@ -1764,6 +1764,83 @@ color: rgba(255,255,255,51);
                  </item>
                 </layout>
                </widget>
+               <widget class="QWidget" name="decoderTablePage">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>100</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_15">
+                   <property name="leftMargin">
+                    <number>6</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>6</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>6</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="decoderTableLabel">
+                     <property name="text">
+                      <string>Decode</string>
+                     </property>
+                     <property name="general_settings_label" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line_8">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                     <property name="lineWidth">
+                      <number>1</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="blue_line" stdset="0">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="adiscope::logic::DecoderTable" name="decoderTableView">
+                   <property name="frameShadow">
+                    <enum>QFrame::Plain</enum>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
               </widget>
              </item>
             </layout>
@@ -1970,6 +2047,42 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
              </attribute>
             </widget>
            </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayoutDecoderTable">
+             <property name="leftMargin">
+              <number>6</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="rightMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>6</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblDecoderTable">
+               <property name="text">
+                <string>Decode</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="adiscope::CustomPushButton" name="btnDecoderTable">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
           </layout>
          </widget>
         </item>
@@ -2025,8 +2138,19 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
    <extends>QPushButton</extends>
    <header>gui/customSwitch.hpp</header>
   </customwidget>
+  <customwidget>
+   <class>adiscope::logic::DecoderTable</class>
+   <extends>QTableView</extends>
+   <header>logicanalyzer/decoder_table.hpp</header>
+  </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
+  <include location="../resources/resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>btnTrigger</sender>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -1797,6 +1797,9 @@ color: rgba(255,255,255,51);
                    </property>
                    <item>
                     <layout class="QHBoxLayout" name="wDecoderSettingsCollapse">
+                     <property name="spacing">
+                      <number>6</number>
+                     </property>
                      <item>
                       <widget class="QPushButton" name="btnCollapseSettings">
                        <property name="maximumSize">
@@ -1821,6 +1824,12 @@ color: rgba(255,255,255,51);
                      </item>
                      <item>
                       <widget class="QLabel" name="label_16">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
                        <property name="text">
                         <string>SETTINGS</string>
                        </property>
@@ -1861,60 +1870,61 @@ color: rgba(255,255,255,51);
                    </item>
                    <item>
                     <widget class="QWidget" name="wDecoderSettings_2" native="true">
-                     <layout class="QVBoxLayout" name="wDecoderSettings">
-                      <property name="leftMargin">
-                       <number>0</number>
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <layout class="QFormLayout" name="wDecoderSettings">
+                      <property name="formAlignment">
+                       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                       </property>
-                      <property name="topMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="bottomMargin">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_12">
-                        <property name="spacing">
-                         <number>0</number>
+                      <item row="1" column="0">
+                       <widget class="QLabel" name="label_17">
+                        <property name="text">
+                         <string>Group by</string>
                         </property>
-                        <property name="leftMargin">
-                         <number>0</number>
+                       </widget>
+                      </item>
+                      <item row="1" column="1">
+                       <widget class="QComboBox" name="primaryAnnotationComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
                         </property>
-                        <property name="rightMargin">
-                         <number>6</number>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>16777215</height>
+                         </size>
                         </property>
-                        <item>
-                         <widget class="QLabel" name="label_17">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Group by</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QComboBox" name="primaryAnnotationComboBox">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="maximumSize">
-                           <size>
-                            <width>16777215</width>
-                            <height>16777215</height>
-                           </size>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
+                       </widget>
+                      </item>
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_18">
+                        <property name="text">
+                         <string>Decoder</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="1">
+                       <widget class="QComboBox" name="DecoderComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                       </widget>
                       </item>
                      </layout>
                     </widget>
@@ -1935,29 +1945,6 @@ color: rgba(255,255,255,51);
                    <property name="bottomMargin">
                     <number>6</number>
                    </property>
-                   <item>
-                    <layout class="QGridLayout" name="gridLayout_4">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="decoderTableLabel">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>100</width>
-                         <height>16777215</height>
-                        </size>
-                       </property>
-                       <property name="text">
-                        <string>Decode</string>
-                       </property>
-                       <property name="general_settings_label" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
                    <item>
                     <widget class="Line" name="line_8">
                      <property name="maximumSize">

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -1877,7 +1877,7 @@ color: rgba(255,255,255,51);
                       <property name="sizeConstraint">
                        <enum>QLayout::SetMinimumSize</enum>
                       </property>
-                      <item row="0" column="1">
+                      <item row="2" column="1">
                        <widget class="QComboBox" name="DecoderComboBox">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1893,20 +1893,7 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_17">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Group by</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
+                      <item row="3" column="1">
                        <widget class="QComboBox" name="primaryAnnotationComboBox">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1922,10 +1909,7 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="1">
-                       <layout class="QVBoxLayout" name="filterLayout"/>
-                      </item>
-                      <item row="2" column="0">
+                      <item row="6" column="0">
                        <widget class="QLabel" name="label_19">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1938,7 +1922,10 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="0" column="0">
+                      <item row="6" column="1">
+                       <layout class="QVBoxLayout" name="filterLayout"/>
+                      </item>
+                      <item row="2" column="0">
                        <widget class="QLabel" name="label_18">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1950,6 +1937,29 @@ color: rgba(255,255,255,51);
                          <string>Decoder</string>
                         </property>
                        </widget>
+                      </item>
+                      <item row="3" column="0">
+                       <widget class="QLabel" name="label_17">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Group by</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="5" column="0">
+                       <widget class="QLabel" name="label_20">
+                        <property name="text">
+                         <string>Regex search</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="5" column="1">
+                       <widget class="QLineEdit" name="searchBox"/>
                       </item>
                      </layout>
                     </widget>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -526,8 +526,8 @@
                      <rect>
                       <x>0</x>
                       <y>0</y>
-                      <width>200</width>
-                      <height>360</height>
+                      <width>358</width>
+                      <height>542</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1778,8 +1778,14 @@ color: rgba(255,255,255,51);
                  </size>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
                  <property name="leftMargin">
                   <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>10</number>
                  </property>
                  <property name="rightMargin">
                   <number>0</number>
@@ -1790,10 +1796,10 @@ color: rgba(255,255,255,51);
                  <item>
                   <layout class="QVBoxLayout" name="wDecoderSettingsContainer">
                    <property name="leftMargin">
-                    <number>10</number>
+                    <number>0</number>
                    </property>
                    <property name="rightMargin">
-                    <number>10</number>
+                    <number>0</number>
                    </property>
                    <property name="bottomMargin">
                     <number>0</number>
@@ -1802,6 +1808,12 @@ color: rgba(255,255,255,51);
                     <layout class="QHBoxLayout" name="wDecoderSettingsCollapse">
                      <property name="spacing">
                       <number>6</number>
+                     </property>
+                     <property name="leftMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>10</number>
                      </property>
                      <item>
                       <widget class="QPushButton" name="btnCollapseSettings">
@@ -1873,25 +1885,23 @@ color: rgba(255,255,255,51);
                    </item>
                    <item>
                     <widget class="QWidget" name="wDecoderSettings_2" native="true">
-                     <layout class="QGridLayout" name="wDecoderSettings" columnstretch="0,0" columnminimumwidth="200,0">
+                     <layout class="QGridLayout" name="wDecoderSettings" columnstretch="0,0" columnminimumwidth="150,0">
                       <property name="sizeConstraint">
                        <enum>QLayout::SetMinimumSize</enum>
                       </property>
-                      <item row="2" column="1">
-                       <widget class="QComboBox" name="DecoderComboBox">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
+                      <item row="6" column="0">
+                       <widget class="QLabel" name="label_22">
+                        <property name="text">
+                         <string>Group offset</string>
                         </property>
                        </widget>
+                      </item>
+                      <item row="9" column="1">
+                       <layout class="QVBoxLayout" name="filterLayout">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
+                       </layout>
                       </item>
                       <item row="3" column="1">
                        <widget class="QComboBox" name="primaryAnnotationComboBox">
@@ -1909,22 +1919,6 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="6" column="0">
-                       <widget class="QLabel" name="label_19">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Filter</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="6" column="1">
-                       <layout class="QVBoxLayout" name="filterLayout"/>
-                      </item>
                       <item row="2" column="0">
                        <widget class="QLabel" name="label_18">
                         <property name="sizePolicy">
@@ -1935,6 +1929,36 @@ color: rgba(255,255,255,51);
                         </property>
                         <property name="text">
                          <string>Decoder</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="1">
+                       <widget class="QComboBox" name="DecoderComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="8" column="0">
+                       <widget class="QLabel" name="label_20">
+                        <property name="text">
+                         <string>Regex search</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="5" column="0">
+                       <widget class="QLabel" name="label_21">
+                        <property name="text">
+                         <string>Group size</string>
                         </property>
                        </widget>
                       </item>
@@ -1951,15 +1975,94 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="5" column="0">
-                       <widget class="QLabel" name="label_20">
+                      <item row="8" column="1">
+                       <widget class="QLineEdit" name="searchBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="9" column="0">
+                       <widget class="QLabel" name="label_19">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
                         <property name="text">
-                         <string>Regex search</string>
+                         <string>Filter</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="7" column="0" colspan="2">
+                       <widget class="Line" name="line_10">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>1</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>1</height>
+                         </size>
+                        </property>
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="blue_line" stdset="0">
+                         <bool>true</bool>
                         </property>
                        </widget>
                       </item>
                       <item row="5" column="1">
-                       <widget class="QLineEdit" name="searchBox"/>
+                       <widget class="QSpinBox" name="groupSizeSpinBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>40</height>
+                         </size>
+                        </property>
+                        <property name="minimum">
+                         <number>1</number>
+                        </property>
+                        <property name="value">
+                         <number>1</number>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="6" column="1">
+                       <widget class="QSpinBox" name="groupOffsetSpinBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>40</height>
+                         </size>
+                        </property>
+                       </widget>
                       </item>
                      </layout>
                     </widget>
@@ -1969,16 +2072,16 @@ color: rgba(255,255,255,51);
                  <item>
                   <layout class="QVBoxLayout" name="verticalLayout_15">
                    <property name="leftMargin">
-                    <number>6</number>
+                    <number>10</number>
                    </property>
                    <property name="topMargin">
                     <number>6</number>
                    </property>
                    <property name="rightMargin">
-                    <number>6</number>
+                    <number>10</number>
                    </property>
                    <property name="bottomMargin">
-                    <number>6</number>
+                    <number>0</number>
                    </property>
                    <item>
                     <widget class="Line" name="line_8">

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -2225,6 +2225,9 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
                <property name="text">
                 <string>Decode</string>
                </property>
+               <property name="general_settings_label" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item>

--- a/ui/logic_analyzer.ui
+++ b/ui/logic_analyzer.ui
@@ -1795,6 +1795,9 @@ color: rgba(255,255,255,51);
                    <property name="rightMargin">
                     <number>10</number>
                    </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
                    <item>
                     <layout class="QHBoxLayout" name="wDecoderSettingsCollapse">
                      <property name="spacing">
@@ -1870,18 +1873,34 @@ color: rgba(255,255,255,51);
                    </item>
                    <item>
                     <widget class="QWidget" name="wDecoderSettings_2" native="true">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <layout class="QFormLayout" name="wDecoderSettings">
-                      <property name="formAlignment">
-                       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                     <layout class="QGridLayout" name="wDecoderSettings" columnstretch="0,0" columnminimumwidth="200,0">
+                      <property name="sizeConstraint">
+                       <enum>QLayout::SetMinimumSize</enum>
                       </property>
+                      <item row="0" column="1">
+                       <widget class="QComboBox" name="DecoderComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                       </widget>
+                      </item>
                       <item row="1" column="0">
                        <widget class="QLabel" name="label_17">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
                         <property name="text">
                          <string>Group by</string>
                         </property>
@@ -1903,26 +1922,32 @@ color: rgba(255,255,255,51);
                         </property>
                        </widget>
                       </item>
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_18">
-                        <property name="text">
-                         <string>Decoder</string>
-                        </property>
-                       </widget>
+                      <item row="2" column="1">
+                       <layout class="QVBoxLayout" name="filterLayout"/>
                       </item>
-                      <item row="0" column="1">
-                       <widget class="QComboBox" name="DecoderComboBox">
+                      <item row="2" column="0">
+                       <widget class="QLabel" name="label_19">
                         <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                           <horstretch>0</horstretch>
                           <verstretch>0</verstretch>
                          </sizepolicy>
                         </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
+                        <property name="text">
+                         <string>Filter</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_18">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Decoder</string>
                         </property>
                        </widget>
                       </item>
@@ -2213,6 +2238,9 @@ QPushButton:checked { border-image: url(:/icons/setup_btn_checked.svg); }</strin
                <property name="checkable">
                 <bool>true</bool>
                </property>
+               <attribute name="buttonGroup">
+                <string notr="true">settings_group</string>
+               </attribute>
               </widget>
              </item>
             </layout>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -1694,6 +1694,37 @@ color: white;
                   </layout>
                  </item>
                  <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_38">
+                   <item>
+                    <widget class="QCheckBox" name="logicAnalyzerTableInfo">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_35">
+                     <property name="text">
+                      <string>Show sample and time info in decoder table</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_28">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
                   <spacer name="verticalSpacer_2">
                    <property name="orientation">
                     <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Groups decoders by messages
- cannot run LA when table is open, only single button is available
- information about decoder messages (sample, duration) can be enabled in preferences
- clicking rows in table will zoom in the plot on the message
- clicking annotations in plot will select the equivalent row in table (if available)

settings:
- selectable decoder
- selectable primary annotation type (groups annotations by the specified type)
- filter unwanted annotations
- regex search (only searches through what is visible with the current settings)

work in progress...

https://user-images.githubusercontent.com/92979643/188131356-e7c6426e-4121-40af-b8aa-800db21ee86e.mp4

