### PR TITLE
DebuggerPlugin: Use deleteLater for the instrument on disconnect.

### DIFF
--- a/plugins/debugger/src/debuggerplugin.cpp
+++ b/plugins/debugger/src/debuggerplugin.cpp
@@ -64,7 +64,7 @@ bool DebuggerPlugin::onDisconnect()
 		tme->setEnabled(false);
 		tme->setRunBtnVisible(false);
 		tme->setRunning(false);
-		delete tme->tool();
+		tme->tool()->deleteLater();
 		tme->setTool(nullptr);
 	}
 


### PR DESCRIPTION
If the Instrument is detached, this causes illegal memory access when disconnecting from the device.