### PR TITLE
M2kController: Fix the deletion order of the ping task and timer.

### DIFF
--- a/plugins/m2k/src/m2kcontroller.cpp
+++ b/plugins/m2k/src/m2kcontroller.cpp
@@ -34,8 +34,8 @@ void M2kController::startPingTask()
 void M2kController::stopPingTask()
 {
 	pingTask->requestInterruption();
-	pingTask->deleteLater();
 	pingTimer->deleteLater();
+	pingTask->deleteLater();
 }
 
 void M2kController::startTemperatureTask()


### PR DESCRIPTION
Scopy sometimes crashes in the CyclicTask destructor when trying to stop an assigned task and the task is being destroyed.