### PR TITLE
ScopyHomeAddPage.cpp: Don't add "serial:" as a parameter for libiio scan.

### DIFF
--- a/core/src/scopyhomeaddpage.cpp
+++ b/core/src/scopyhomeaddpage.cpp
@@ -206,7 +206,7 @@ void ScopyHomeAddPage::futureVerify()
 void ScopyHomeAddPage::futureScan()
 {
 	scanList.clear();
-	QString scanParams = scanParamsList.join("");
+	QString scanParams = scanParamsList.join("").remove("serial:");
 	QFuture<int> f = QtConcurrent::run(std::bind(&IIOScanTask::scan, &scanList, scanParams));
 	fwScan->setFuture(f);
 }


### PR DESCRIPTION
Serial device scanning is done through libserialport. Sending this param to libiio causes the scan process to fail.