### PR TITLE
Loading preferences on restart bug fix

### DIFF
--- a/core/include/core/application_restarter.h
+++ b/core/include/core/application_restarter.h
@@ -11,6 +11,7 @@ class SCOPY_CORE_EXPORT ApplicationRestarter
 public:
 	ApplicationRestarter(const QString &executable);
 
+	static ApplicationRestarter *GetInstance();
 	void setArguments(const QStringList &arguments);
 	QStringList getArguments() const;
 
@@ -18,9 +19,11 @@ public:
 	static void triggerRestart();
 
 private:
+	static ApplicationRestarter *pinstance_;
 	QString m_executable;
 	QStringList m_arguments;
 	QString m_currentPath;
+	bool m_restart;
 };
 } // namespace scopy
 #endif // APPLICATIONRESTARTER_H

--- a/core/src/application_restarter.cpp
+++ b/core/src/application_restarter.cpp
@@ -10,11 +10,19 @@
 
 using namespace scopy;
 
-ApplicationRestarter::ApplicationRestarter(const QString &executable)
-        : m_executable(executable)
-        , m_currentPath(QDir::currentPath())
-{
+ApplicationRestarter* ApplicationRestarter::pinstance_{nullptr};
 
+ApplicationRestarter::ApplicationRestarter(const QString &executable)
+	: m_executable(executable)
+	, m_currentPath(QDir::currentPath())
+	, m_restart(false)
+{
+	pinstance_ = this;
+}
+
+ApplicationRestarter *ApplicationRestarter::GetInstance()
+{
+	return pinstance_;
 }
 
 void ApplicationRestarter::setArguments(const QStringList &arguments)
@@ -29,7 +37,7 @@ QStringList ApplicationRestarter::getArguments() const
 
 int ApplicationRestarter::restart(int exitCode)
 {
-	if (qApp->property("restart").toBool()) {
+	if (m_restart) {
 #ifdef __ANDROID__
 		QAndroidJniObject activity = QtAndroid::androidActivity();
 		activity.callMethod<void>("restart");
@@ -43,6 +51,6 @@ int ApplicationRestarter::restart(int exitCode)
 
 void ApplicationRestarter::triggerRestart()
 {
-	qApp->setProperty("restart", QVariant(true));
+	GetInstance()->m_restart = true;
 	qApp->exit();
 }

--- a/pluginbase/include/pluginbase/preferences.h
+++ b/pluginbase/include/pluginbase/preferences.h
@@ -49,6 +49,14 @@ public:
 	void setPreferences(QMap<QString, QVariant> s);
 
 	/**
+	 * @brief setPreferencesFilename
+	 * @param s
+	 * Sets preferences filename
+	 */
+	void setPreferencesFilename(QString s);
+
+public Q_SLOTS:
+	/**
 	 * @brief save
 	 * Save preferences to file
 	 */
@@ -58,12 +66,6 @@ public:
 	 * Loads preferences from file
 	 */
 	void load();
-	/**
-	 * @brief setPreferencesFilename
-	 * @param s
-	 * Sets preferences filename
-	 */
-	void setPreferencesFilename(QString s);
 
 Q_SIGNALS:
 	/**

--- a/pluginbase/src/preferences.cpp
+++ b/pluginbase/src/preferences.cpp
@@ -11,12 +11,12 @@ Preferences* Preferences::pinstance_{nullptr};
 
 Preferences::Preferences(QObject *parent) : QObject(parent)
 {
-
+	connect(parent, SIGNAL(aboutToQuit()),this,SLOT(save()));
 }
 
 Preferences::~Preferences()
 {
-	save();
+
 }
 
 void Preferences::init(QString k, QVariant v)
@@ -73,6 +73,8 @@ void Preferences::save()
 	for(const QString &key : keys) {
 		s->setValue(key,p[key]);
 	}
+
+	s->sync();
 }
 
 void Preferences::load()


### PR DESCRIPTION
- preferences are now saved on aboutToQuit signal instead of inside the destructor
- made ApplicationRestarter a singleton