### PR TITLE
ScopyMainWindow.cpp: Load Python on WIN before trying to load decoders.

### DIFF
--- a/core/src/scopymainwindow.cpp
+++ b/core/src/scopymainwindow.cpp
@@ -39,9 +39,8 @@ ScopyMainWindow::ScopyMainWindow(QWidget *parent)
 	setWindowTitle("Scopy-" + scopy::config::fullversion());
 
 	setAttribute(Qt::WA_QuitOnClose, true);
-	initPreferences();
 	initPythonWIN32();
-
+	initPreferences();
 
 	ScopyJS::GetInstance();
 	ContextProvider::GetInstance();
@@ -311,7 +310,7 @@ void ScopyMainWindow::initPythonWIN32(){
 	path_str += QCoreApplication::applicationDirPath() + "\\" + PYTHON_VERSION + "\\lib-dynload;";
 	path_str += QCoreApplication::applicationDirPath() + "\\" + PYTHON_VERSION + "\\site-packages;";
 	path_str += QString::fromLocal8Bit(pythonpath);
-
+	qInfo(CAT_SCOPY) << "PYTHONPATH: " << path_str;
 	qputenv("PYTHONPATH", path_str.toLocal8Bit());
 #endif
 }


### PR DESCRIPTION
This will work on the official installer. In local builds(development) we will need to implement a CMakeLists setup of SCOPY_PYTHONPATH when SCOPY_DEV is true. But for now, we need the Windows official installer to work.

Tested this on Windows and compared it with the current dev branch installer. Scopy will start on this version, I was able to connect to M2K and start the Logic Analyzer decoders with correct data displayed on the screen. In the meantime, the Scopy version installed from the current dev branch will not start.

@bindea-cristian will take a look at adding the SCOPY_PYTHONPATH env var when in SCOPY_DEV mode.