### PR TITLE
scopy.iss.cmakein: Set a specific value for MinVersion to avoid the default.

### DIFF
--- a/windows/scopy-32.iss.cmakein
+++ b/windows/scopy-32.iss.cmakein
@@ -25,6 +25,7 @@ DefaultDirName={pf}\{#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
 DisableDirPage=no
+MinVersion=6.2
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/windows/scopy-64.iss.cmakein
+++ b/windows/scopy-64.iss.cmakein
@@ -25,6 +25,7 @@ DefaultDirName={pf}\{#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
 DisableDirPage=no
+MinVersion=6.2
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/windows/scopy.iss.cmakein
+++ b/windows/scopy.iss.cmakein
@@ -25,6 +25,7 @@ DefaultDirName={pf}\{#AppDev}\{#AppName}
 DefaultGroupName={#AppName}
 AlwaysRestart=yes
 DisableDirPage=no
+MinVersion=6.2
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Starting with InnoSetup version 6, the default value for MinVersion is 6.2.sp1 which might break installation on newer Windows versions.