### PR TITLE
swiot: remove copyright header from autogenerated file

### DIFF
--- a/plugins/swiot/include/swiot/scopy-swiot_export.h
+++ b/plugins/swiot/include/swiot/scopy-swiot_export.h
@@ -1,24 +1,3 @@
-/*
- * Copyright (c) 2023 Analog Devices Inc.
- *
- * This file is part of Scopy
- * (see https://www.github.com/analogdevicesinc/scopy).
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
- */
-
-
 
 #ifndef SCOPY_SWIOT_EXPORT_H
 #define SCOPY_SWIOT_EXPORT_H


### PR DESCRIPTION
This causes modifications on every file autogeneration