### PR TITLE
ChannelWidget: added default enabled value

### DIFF
--- a/gui/ui/channel.ui
+++ b/gui/ui/channel.ui
@@ -111,6 +111,9 @@
           <property name="enabled">
            <bool>true</bool>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
This causes the channel to initialize as checked when Scopy is started for the first time. From the second run onward the API object will save the enabled value (since it is marked as Q_PROPERTY) and override the default "checked" value with the value from the last run.