### PR TITLE
DeviceBrowser: set fixed height

### DIFF
--- a/core/src/devicebrowser.cpp
+++ b/core/src/devicebrowser.cpp
@@ -16,6 +16,7 @@ DeviceBrowser::DeviceBrowser(QWidget *parent) :
 {
 	qDebug(CAT_DEVBROWSER) << "ctor";
 	ui->setupUi(this);
+	this->setFixedHeight(185);
 
 	auto dbm = ui->wDeviceBrowserMenu;
 	layout = new QHBoxLayout(dbm);


### PR DESCRIPTION
Set fixed height in order to avoid unnecessary resizes