### PR TITLE
patterngenerator/spi: fix SPI generation

### DIFF
--- a/src/patterngenerator/patterns/patterns.cpp
+++ b/src/patterngenerator/patterns/patterns.cpp
@@ -2142,15 +2142,14 @@ uint8_t SPIPattern::generate_pattern(uint32_t sample_rate,
 	for (std::deque<uint8_t>::iterator it = v.begin(); it != v.end();
 	     ++it) {
 		uint8_t val = *it;
-		bool oldbit = 0;
 		bool bit;
 
-		if(CPHA && start_new_frame)
-		{
-			for (auto i=samples_per_bit/2; i<samples_per_bit && buf_ptr < buf_ptr_end; i++,buf_ptr++) {
-				*buf_ptr = changeBit(*buf_ptr,csBit,CSPOL);
-				*buf_ptr = changeBit(*buf_ptr,clkActiveBit,!CPOL);
-				*buf_ptr = changeBit(*buf_ptr,outputBit,oldbit);
+		if(CPHA && start_new_frame) {
+			for(auto i = samples_per_bit / 2; i < samples_per_bit && buf_ptr < buf_ptr_end;
+			    i++, buf_ptr++) {
+				*buf_ptr = changeBit(*buf_ptr, csBit, CSPOL);
+				*buf_ptr = changeBit(*buf_ptr, clkActiveBit, CPOL);
+				*buf_ptr = changeBit(*buf_ptr, outputBit, 0); // start high-Z state is=0
 			}
 		}
 
@@ -2164,35 +2163,39 @@ uint8_t SPIPattern::generate_pattern(uint32_t sample_rate,
 				val = val >> 1;
 			}
 
-			for (size_t i=0; i<samples_per_bit/2 && buf_ptr < buf_ptr_end; i++,buf_ptr++) {
-				*buf_ptr = changeBit(*buf_ptr,csBit,CSPOL);
-				*buf_ptr = changeBit(*buf_ptr,clkActiveBit,CPOL);
+			for(size_t i = 0; i < samples_per_bit / 2 && buf_ptr < buf_ptr_end; i++, buf_ptr++) {
+				*buf_ptr = changeBit(*buf_ptr, csBit, CSPOL);
+				*buf_ptr = changeBit(*buf_ptr, outputBit, bit);
 
-				if (!CPHA) {
-					*buf_ptr = changeBit(*buf_ptr,outputBit,oldbit);
+				if(!CPHA) {
+					*buf_ptr = changeBit(*buf_ptr, clkActiveBit, CPOL);
 				} else {
-					*buf_ptr = changeBit(*buf_ptr,outputBit,bit);
+					*buf_ptr = changeBit(*buf_ptr, clkActiveBit, !CPOL);
 				}
 			}
 
-			for (auto i=samples_per_bit/2; i<samples_per_bit && buf_ptr < buf_ptr_end; i++,buf_ptr++) {
-				*buf_ptr = changeBit(*buf_ptr,csBit,CSPOL);
-				*buf_ptr = changeBit(*buf_ptr,clkActiveBit,!CPOL);
-				*buf_ptr = changeBit(*buf_ptr,outputBit,bit);
-			}
+			for(auto i = samples_per_bit / 2; i < samples_per_bit && buf_ptr < buf_ptr_end;
+			    i++, buf_ptr++) {
+				*buf_ptr = changeBit(*buf_ptr, csBit, CSPOL);
+				*buf_ptr = changeBit(*buf_ptr, outputBit, bit);
 
-			oldbit = bit;
+				if(!CPHA) {
+					*buf_ptr = changeBit(*buf_ptr, clkActiveBit, !CPOL);
+				} else {
+					*buf_ptr = changeBit(*buf_ptr, clkActiveBit, CPOL);
+				}
+			}
 		}
 
 		frameBytesLeft--;
 
-		if (frameBytesLeft == 0) {
-			if(!CPHA)
-			{
-				for (auto i=samples_per_bit/2; i<samples_per_bit && buf_ptr < buf_ptr_end; i++,buf_ptr++) {
-					*buf_ptr = changeBit(*buf_ptr,csBit,CSPOL);
-					*buf_ptr = changeBit(*buf_ptr,clkActiveBit,!CPOL);
-					*buf_ptr = changeBit(*buf_ptr,outputBit,bit);
+		if(frameBytesLeft == 0) {
+			if(!CPHA) {
+				for(auto i = samples_per_bit / 2; i < samples_per_bit && buf_ptr < buf_ptr_end;
+				    i++, buf_ptr++) {
+					*buf_ptr = changeBit(*buf_ptr, csBit, CSPOL);
+					*buf_ptr = changeBit(*buf_ptr, clkActiveBit, CPOL);
+					*buf_ptr = changeBit(*buf_ptr, outputBit, bit);
 				}
 			}
 			buf_ptr += waitClocks * samples_per_bit;


### PR DESCRIPTION
- Fix the generation of the clock sequence to ensure clock edges at fixed locations.
- Align the data sequence to the clock edges, previously was the other way around and edge cases due to CPHA were not handled correctly.
- NOTE: when CPHA=1 data sequence is shifted with T_ck/2 at the start. When CPHA=0 an aditional T_ck/2 is added at the end of the sequence. This preserves the data sequence length and ensures normal behaviour when changin the bytes per frame.
- LINK: https://upload.wikimedia.org/wikipedia/commons/f/f0/SPI_timing_diagram_CS.svg