### PR TITLE
ConnectionProvider: Create a Connection object which includes the iio_context and the CommandQueue.

### DIFF
--- a/iioutil/include/iioutil/commandqueue.h
+++ b/iioutil/include/iioutil/commandqueue.h
@@ -18,29 +18,21 @@ public:
 	 * @param numberOfThreads
 	 * @param parent
 	 */
-	explicit CommandQueue(int numberOfThreads = 1, QObject *parent = nullptr);
+	explicit CommandQueue(QObject *parent = nullptr);
 	~CommandQueue();
 	void enqueue(Command *newCmd);
 	void start();
 	void wait();
 	void requestStop();
-Q_SIGNALS:
-	void started(scopy::Command *);
-	void finished(scopy::Command *);
+	void runCmd();
 private Q_SLOTS:
-	void work();
-	void cmdStarted(scopy::Command *cmd);
-	void cmdFinished(scopy::Command *cmd);
+	void resolveNext(scopy::Command *cmd);
 
 private:
-	Command *m_currentCommand;
 	std::deque<Command *> m_commandQueue;
 	std::mutex m_commandMutex;
 	std::atomic<bool> m_running;
 	QThreadPool m_commandExecThreadPool;
-	int m_nbThreads;
-	bool m_async;
-	bool m_workNewThread;
 };
 } // namespace scopy
 #endif // IIOCOMMANDQUEUE_H

--- a/iioutil/include/iioutil/connection.h
+++ b/iioutil/include/iioutil/connection.h
@@ -1,0 +1,65 @@
+#ifndef CONNECTION_H
+#define CONNECTION_H
+#include "scopy-iioutil_export.h"
+#include "commandqueue.h"
+#include <iio.h>
+#include <QObject>
+
+namespace scopy {
+class SCOPY_IIOUTIL_EXPORT Connection : public QObject
+{
+	Q_OBJECT
+public:
+	Connection(QString uri);
+
+	const QString &uri() const;
+	CommandQueue *commandQueue() const;
+	struct iio_context *context() const;
+	int refCount() const;
+
+protected:
+	~Connection();
+
+	/**
+	 * @brief open
+	 * Initialize the connection if not previously opened.
+	 * If previously opened, increase the internal refCount.
+	 */
+	void open();
+
+	/**
+	 * @brief close
+	 * Decrement the internal refCount.
+	 * Emit the aboutToBeDestroyed() signal if refCount is zero.
+	 */
+	void close();
+
+	/**
+	 * @brief closeAll
+	 * Reset the internal refCount to zero.
+	 * Force close the Connection.
+	 * Emit the aboutToBeDestroyed() signal.
+	 */
+	void closeAll();
+
+Q_SIGNALS:
+	/**
+	 * @brief aboutToBeDestroyed
+	 * Connection clients should handle deinitialization
+	 * of their iio_context/CommandQueue related operations
+	 * in a slot connected to this signal.
+	 * After the signal is emitted, the Connection object
+	 * will no longer be valid.
+	 */
+	void aboutToBeDestroyed();
+
+private:
+	friend class ConnectionProvider;
+	QString m_uri;
+	CommandQueue *m_commandQueue;
+	struct iio_context *m_context;
+	int m_refCount = 0;
+};
+} // namespace scopy
+
+#endif // CONNECTION_H

--- a/iioutil/include/iioutil/connectionprovider.h
+++ b/iioutil/include/iioutil/connectionprovider.h
@@ -1,0 +1,39 @@
+#ifndef CONNECTIONPROVIDER_H
+#define CONNECTIONPROVIDER_H
+
+#include "scopy-iioutil_export.h"
+#include "connection.h"
+
+#include <QObject>
+#include <QMap>
+#include <mutex>
+
+namespace scopy {
+class SCOPY_IIOUTIL_EXPORT ConnectionProvider : public QObject
+{
+	Q_OBJECT
+protected:
+	ConnectionProvider(QObject *parent = nullptr);
+	~ConnectionProvider();
+
+public:
+	ConnectionProvider(ConnectionProvider &other) = delete;
+	void operator=(const ConnectionProvider &) = delete;
+
+	static ConnectionProvider *GetInstance();
+	static Connection *open(QString uri);
+	static void close(QString uri);
+	static void closeAll(QString uri);
+
+private:
+	Connection *_open(QString uri);
+	void _close(QString uri);
+	void _closeAll(QString uri);
+	void _closeAndRemove(QString uri);
+	static ConnectionProvider *pinstance_;
+	static std::mutex mutex_;
+	QMap<QString, Connection *> map;
+};
+} // namespace scopy
+
+#endif // CONNECTIONPROVIDER_H

--- a/iioutil/src/commandqueueprovider.cpp
+++ b/iioutil/src/commandqueueprovider.cpp
@@ -12,7 +12,7 @@ CommandQueueRefCounter::CommandQueueRefCounter(struct iio_context *ctx)
 	this->ctx = ctx;
 	this->refcnt++;
 	// TBD: automatically check the iio_context to see if multiple threads are possible (iiod vs tinyiiod)
-	this->cmdQueue = new CommandQueue(1);
+	this->cmdQueue = new CommandQueue();
 }
 
 CommandQueueRefCounter::~CommandQueueRefCounter()

--- a/iioutil/src/connection.cpp
+++ b/iioutil/src/connection.cpp
@@ -1,0 +1,64 @@
+#include "connection.h"
+
+using namespace scopy;
+
+Connection::Connection(QString uri)
+{
+	this->m_uri = uri;
+	this->m_context = nullptr;
+	this->m_commandQueue = nullptr;
+	this->m_refCount = 0;
+}
+
+Connection::~Connection()
+{
+	if(this->m_commandQueue) {
+		delete this->m_commandQueue;
+		this->m_commandQueue = nullptr;
+	}
+	if(this->m_context) {
+		iio_context_destroy(this->m_context);
+		this->m_context = nullptr;
+	}
+}
+
+const QString &Connection::uri() const { return m_uri; }
+
+CommandQueue *Connection::commandQueue() const { return m_commandQueue; }
+
+iio_context *Connection::context() const { return m_context; }
+
+int Connection::refCount() const { return m_refCount; }
+
+void Connection::open()
+{
+	if(!this->m_context) {
+		this->m_context = iio_create_context_from_uri(this->m_uri.toStdString().c_str());
+		if(this->m_context) {
+			this->m_commandQueue = new CommandQueue();
+			this->m_refCount++;
+		}
+	} else {
+		this->m_refCount++;
+	}
+}
+
+void Connection::closeAll()
+{
+	this->m_refCount = 0;
+	close();
+}
+
+void Connection::close()
+{
+	this->m_refCount--;
+	if(this->m_refCount <= 0) {
+		/* If the open() and close() number of calls done by a client
+		 * is mismatched, all the remaining clients should be notified of the
+		 * destruction. */
+		this->m_refCount = 0;
+		Q_EMIT aboutToBeDestroyed();
+	}
+}
+
+#include "moc_connection.cpp"

--- a/iioutil/src/connectionprovider.cpp
+++ b/iioutil/src/connectionprovider.cpp
@@ -1,0 +1,93 @@
+#include "connectionprovider.h"
+#include <QLoggingCategory>
+#include <QApplication>
+
+Q_LOGGING_CATEGORY(CAT_CONNECTIONMGR, "ConnectionProvider")
+
+using namespace scopy;
+
+ConnectionProvider *ConnectionProvider::pinstance_{nullptr};
+std::mutex ConnectionProvider::mutex_;
+
+scopy::ConnectionProvider::ConnectionProvider(QObject *parent)
+	: QObject(parent)
+{
+	qDebug(CAT_CONNECTIONMGR) << "ConnectionProvider object ctor";
+}
+
+scopy::ConnectionProvider::~ConnectionProvider() { qDebug(CAT_CONNECTIONMGR) << "ConnectionProvider object dtor"; }
+
+ConnectionProvider *ConnectionProvider::GetInstance()
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	if(pinstance_ == nullptr) {
+		pinstance_ = new ConnectionProvider(QApplication::instance()); // singleton has the app as parent
+	} else {
+		qDebug(CAT_CONNECTIONMGR) << "ConnectionProvider: Got instance from singleton";
+	}
+	return pinstance_;
+}
+
+Connection *ConnectionProvider::open(QString uri) { return ConnectionProvider::GetInstance()->_open(uri); }
+
+Connection *ConnectionProvider::_open(QString uri)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	Connection *connectionObject = nullptr;
+	if(!map.contains(uri)) {
+		connectionObject = new Connection(uri);
+		map.insert(uri, connectionObject);
+		qDebug(CAT_CONNECTIONMGR) << uri << " created in map ";
+	} else {
+		connectionObject = map.value(uri);
+		qDebug(CAT_CONNECTIONMGR) << uri << " found in map ";
+	}
+	connectionObject->open();
+	if(connectionObject->refCount() == 0) {
+		qDebug(CAT_CONNECTIONMGR) << uri << " Connection: failed to open, removed from map.";
+		map.remove(uri);
+		delete connectionObject;
+		return nullptr;
+	}
+	qDebug(CAT_CONNECTIONMGR) << uri << " Connection: open, refcount++ = " << connectionObject->refCount();
+	return connectionObject;
+}
+
+void ConnectionProvider::closeAll(QString uri) { return ConnectionProvider::GetInstance()->_closeAll(uri); }
+
+void ConnectionProvider::close(QString uri) { return ConnectionProvider::GetInstance()->_close(uri); }
+
+void ConnectionProvider::_closeAll(QString uri)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	if(map.contains(uri)) {
+		map.value(uri)->closeAll();
+	}
+	_closeAndRemove(uri);
+}
+
+void ConnectionProvider::_close(QString uri)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	if(map.contains(uri)) {
+		map.value(uri)->close();
+	}
+	_closeAndRemove(uri);
+}
+
+void ConnectionProvider::_closeAndRemove(QString uri)
+{
+	if(map.contains(uri)) {
+		qDebug(CAT_CONNECTIONMGR)
+			<< uri << " Connection: closing - found in map - refcnt-- = " << map.value(uri)->refCount();
+		if(map.value(uri)->refCount() == 0) {
+			delete map[uri];
+			map.remove(uri);
+			qDebug(CAT_CONNECTIONMGR) << uri << " Connection: destroyed, removed from map";
+		}
+	} else {
+		qInfo(CAT_CONNECTIONMGR) << uri << " Connection: not found in map. nop";
+	}
+}
+
+#include "moc_connectionprovider.cpp"

--- a/iioutil/test/CMakeLists.txt
+++ b/iioutil/test/CMakeLists.txt
@@ -3,3 +3,4 @@ cmake_minimum_required(VERSION 3.5)
 include(ScopyTest)
 
 setup_scopy_tests(iiocommandqueue)
+setup_scopy_tests(connectionprovider)

--- a/iioutil/test/tst_connectionprovider.cpp
+++ b/iioutil/test/tst_connectionprovider.cpp
@@ -1,0 +1,224 @@
+#include <iioutil/connectionprovider.h>
+#include <iioutil/commandqueue.h>
+
+#include <QTest>
+
+using namespace scopy;
+
+class TestCommandAdd : public Command
+{
+	Q_OBJECT
+public:
+	explicit TestCommandAdd(int a, int b, QObject *parent)
+		: m_a(a)
+		, m_b(b)
+	{
+		this->setParent(parent);
+		m_cmdResult = new CommandResult();
+	}
+
+	virtual ~TestCommandAdd() { qDebug() << "TestCommand deleted"; }
+
+	virtual void execute() override
+	{
+		Q_EMIT started(this);
+		m_cmdResult->errorCode = m_a + m_b;
+		Q_EMIT finished(this);
+	}
+
+private:
+	int m_a, m_b;
+};
+
+class Plugin1 : public QObject
+{
+	Q_OBJECT
+public:
+	explicit Plugin1(QString boarduri)
+	{
+		uri = boarduri;
+		conn = ConnectionProvider::open(uri);
+		if(conn) {
+			connect(conn, &Connection::aboutToBeDestroyed, this, &Plugin1::handleClose);
+			commandQueue = conn->commandQueue();
+			ctx = conn->context();
+		} else {
+			conn = nullptr;
+			commandQueue = nullptr;
+			uri = nullptr;
+		}
+	}
+
+	virtual ~Plugin1() { ConnectionProvider::close(uri); }
+
+	void close()
+	{
+		qInfo() << "Plugin1 close connection";
+		ConnectionProvider::close(uri);
+	}
+
+	void closeAll() { ConnectionProvider::closeAll(uri); }
+
+	const QString &getUri() const { return uri; }
+
+	Connection *getConn() const { return conn; }
+
+	CommandQueue *getCommandQueue() const { return commandQueue; }
+
+	iio_context *getCtx() const { return ctx; }
+
+public Q_SLOTS:
+	void handleClose()
+	{
+		// notify any thread that might be using command queue or ctx
+		qInfo() << "Plugin1 handle close on aboutToBeDestroyed() signal";
+		conn = nullptr;
+		commandQueue = nullptr;
+		uri = nullptr;
+	}
+
+private:
+	QString uri;
+	Connection *conn;
+	CommandQueue *commandQueue;
+	struct iio_context *ctx;
+};
+
+class TST_ConnectionProvider : public QObject
+{
+	Q_OBJECT
+private Q_SLOTS:
+	void testReferenceCount();
+	void testMismatchedOpenClose();
+	void testSignalAboutToBeDestroyed();
+	void testForceClose();
+	void testConnectionCmdQ();
+
+private:
+	int TEST_A = 100;
+	int TEST_B = 20;
+};
+
+void TST_ConnectionProvider::testReferenceCount()
+{
+	QString uri = "ip:192.168.2.1";
+	Plugin1 *p1 = new Plugin1(uri);
+	if(!p1->getConn()) {
+		QSKIP("No context. Skipping");
+	}
+	QVERIFY2(p1->getConn()->refCount() == 1, "P1 object connection not opened");
+
+	Plugin1 *p2 = new Plugin1(uri);
+	QVERIFY2(p1->getConn()->refCount() == 2, "P2 object connection not opened");
+
+	Plugin1 *p3 = new Plugin1(uri);
+	QVERIFY2(p1->getConn()->refCount() == 3, "P3 object connection not opened");
+
+	p1->close();
+	QVERIFY2(p1->getConn()->refCount() == 2, "P1 object connection not closed");
+	p2->close();
+	QVERIFY2(p2->getConn()->refCount() == 1, "P2 object connection not closed");
+	p3->close();
+	QVERIFY2(p3->getConn() == nullptr, "P3 object connection not closed");
+}
+
+void TST_ConnectionProvider::testMismatchedOpenClose()
+{
+	QString uri = "ip:192.168.2.1";
+	Plugin1 *p1 = new Plugin1(uri);
+	Plugin1 *p2 = new Plugin1(uri);
+	if(!p1->getConn()) {
+		QSKIP("No context. Skipping");
+	}
+
+	QVERIFY2(p1->getConn()->refCount() == 2, "P1 object connection not opened");
+
+	p1->close();
+	p1->close();
+	QVERIFY2(p1->getConn() == nullptr, "P1 object connection not closed");
+	p2->close();
+}
+
+void TST_ConnectionProvider::testSignalAboutToBeDestroyed()
+{
+	QString uri = "ip:192.168.2.1";
+	Plugin1 *p1 = new Plugin1(uri);
+	Plugin1 *p2 = new Plugin1(uri);
+	Plugin1 *p3 = new Plugin1(uri);
+	if(!p1->getConn()) {
+		QSKIP("No context. Skipping");
+	}
+
+	QVERIFY2(p1->getConn() != nullptr, "P1 object connection not opened");
+	QVERIFY2(p2->getConn() != nullptr, "P2 object connection not opened");
+	QVERIFY2(p3->getConn() != nullptr, "P3 object connection not opened");
+
+	p1->close();
+	p2->close();
+	p3->close();
+	QVERIFY2(p1->getConn() == nullptr, "P1 object connection not closed");
+	QVERIFY2(p2->getConn() == nullptr, "P2 object connection not closed");
+	QVERIFY2(p3->getConn() == nullptr, "P3 object connection not closed");
+}
+
+void TST_ConnectionProvider::testForceClose()
+{
+	QString uri = "ip:192.168.2.1";
+	Plugin1 *p1 = new Plugin1(uri);
+	Plugin1 *p2 = new Plugin1(uri);
+	Plugin1 *p3 = new Plugin1(uri);
+	if(!p1->getConn()) {
+		QSKIP("No context. Skipping");
+	}
+
+	QVERIFY2(p1->getConn() != nullptr, "P1 object connection not opened");
+	QVERIFY2(p2->getConn() != nullptr, "P2 object connection not opened");
+	QVERIFY2(p3->getConn() != nullptr, "P3 object connection not opened");
+
+	p3->closeAll();
+	QVERIFY2(p1->getConn() == nullptr, "P1 object connection not closed");
+	QVERIFY2(p2->getConn() == nullptr, "P2 object connection not closed");
+	QVERIFY2(p3->getConn() == nullptr, "P3 object connection not closed");
+}
+
+void TST_ConnectionProvider::testConnectionCmdQ()
+{
+	Command *cmd1 = new TestCommandAdd(TEST_A, TEST_B, nullptr);
+	QString uri = "ip:192.168.2.1";
+	Plugin1 *p1 = new Plugin1(uri);
+	Plugin1 *p2 = new Plugin1(uri);
+	Plugin1 *p3 = new Plugin1(uri);
+	if(!p1->getConn()) {
+		QSKIP("No context. Skipping");
+	}
+
+	QVERIFY2(p1->getConn() != nullptr, "P1 object connection not opened");
+	QVERIFY2(p2->getConn() != nullptr, "P2 object connection not opened");
+	QVERIFY2(p3->getConn() != nullptr, "P3 object connection not opened");
+
+	connect(
+		cmd1, &scopy::Command::finished, this,
+		[=](scopy::Command *cmd) {
+			if(!cmd) {
+				cmd = dynamic_cast<Command *>(QObject::sender());
+			}
+			TestCommandAdd *tcmd = dynamic_cast<TestCommandAdd *>(cmd);
+			QVERIFY2(tcmd != nullptr, "Capture command is null");
+			QVERIFY2(tcmd == cmd1, "Captured command not the expected one");
+			QVERIFY2(tcmd->getReturnCode() == (TEST_B + TEST_A), "TestCommandAdd did not execute");
+		},
+		Qt::QueuedConnection);
+
+	p1->getCommandQueue()->enqueue(cmd1);
+
+	QTest::qWait(100);
+	p3->close();
+	p2->close();
+	p1->close();
+	QVERIFY2(p1->getConn() == nullptr, "P1 object connection not closed");
+	QVERIFY2(p2->getConn() == nullptr, "P2 object connection not closed");
+	QVERIFY2(p3->getConn() == nullptr, "P3 object connection not closed");
+}
+
+QTEST_MAIN(TST_ConnectionProvider)
+#include "tst_connectionprovider.moc"

--- a/iioutil/test/tst_iiocommandqueue.cpp
+++ b/iioutil/test/tst_iiocommandqueue.cpp
@@ -138,7 +138,7 @@ private:
 
 void TST_IioCommandQueue::testResults()
 {
-	CommandQueue *cmdQ = new CommandQueue(1, nullptr);
+	CommandQueue *cmdQ = new CommandQueue(nullptr);
 	Command *cmd1 = new TestCommandAdd(TEST_A, TEST_B, nullptr);
 	Command *cmd2 = new TestCommandMultiply(TEST_A, TEST_B, nullptr);
 	Command *cmd3 = new TestCommandMsg(TEST_A, "Test command 300", nullptr);
@@ -196,7 +196,7 @@ void TST_IioCommandQueue::testResults()
 
 void TST_IioCommandQueue::testCommandOrder()
 {
-	CommandQueue *cmdQ = new CommandQueue(1, nullptr);
+	CommandQueue *cmdQ = new CommandQueue(nullptr);
 	Command *cmd1 = new TestCommandAdd(TEST_A, TEST_B, nullptr);
 
 	Command *cmd3 = new TestCommandMsg(TEST_A, "Test command 300", nullptr);

--- a/plugins/swiot/include/swiot/swiotplugin.h
+++ b/plugins/swiot/include/swiot/swiotplugin.h
@@ -34,7 +34,6 @@
 #include "src/swiotinfopage.h"
 
 #include <gui/tutorialbuilder.h>
-#include <iioutil/commandqueue.h>
 #include <iioutil/cyclicaltask.h>
 #include <pluginbase/plugin.h>
 #include <pluginbase/pluginbase.h>

--- a/plugins/swiot/src/config/swiotconfig.h
+++ b/plugins/swiot/src/config/swiotconfig.h
@@ -49,7 +49,7 @@ class SwiotConfig : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit SwiotConfig(struct iio_context *ctx, QWidget *parent = nullptr);
+	explicit SwiotConfig(QString uri, QWidget *parent = nullptr);
 	~SwiotConfig();
 
 public Q_SLOTS:
@@ -62,6 +62,7 @@ Q_SIGNALS:
 	void configBtnPressed();
 
 private:
+	QString m_uri;
 	QMap<QString, struct iio_device *> m_iioDevices;
 	struct iio_context *m_context;
 	struct iio_device *m_swiotDevice;

--- a/plugins/swiot/src/externalpsreaderthread.h
+++ b/plugins/swiot/src/externalpsreaderthread.h
@@ -22,6 +22,7 @@
 #define SCOPY_EXTERNALPSREADERTHREAD_H
 
 #include <QThread>
+#include <iioutil/connection.h>
 
 namespace scopy::swiot {
 class ExternalPsReaderThread : public QThread
@@ -29,14 +30,16 @@ class ExternalPsReaderThread : public QThread
 	Q_OBJECT
 public:
 	explicit ExternalPsReaderThread(QString uri, QString attr, QObject *parent = nullptr);
-	void run() override;
+	~ExternalPsReaderThread();
 
+	void run() override;
 Q_SIGNALS:
 	void hasConnectedPowerSupply(bool ps);
 
 private:
 	QString m_uri;
 	QString m_attribute;
+	Connection *m_conn;
 };
 } // namespace scopy::swiot
 

--- a/plugins/swiot/src/runtime/ad74413r/ad74413r.h
+++ b/plugins/swiot/src/runtime/ad74413r/ad74413r.h
@@ -36,6 +36,7 @@
 #include <gui/osc_export_settings.h>
 #include <gui/tool_view.hpp>
 
+#include <iioutil/connection.h>
 #define MAX_CURVES_NUMBER 8
 #define AD_NAME "ad74413r"
 #define SWIOT_DEVICE_NAME "swiot"
@@ -57,7 +58,7 @@ class Ad74413r : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit Ad74413r(iio_context *ctx = nullptr, ToolMenuEntry *tme = 0, QWidget *parent = nullptr);
+	explicit Ad74413r(QString uri = "", ToolMenuEntry *tme = 0, QWidget *parent = nullptr);
 
 	~Ad74413r();
 
@@ -87,6 +88,7 @@ public Q_SLOTS:
 
 	void onActivateRunBtns(bool activate);
 
+	void handleConnectionDestroyed();
 Q_SIGNALS:
 	void broadcastReadThreshold(QString value);
 	void thresholdControlEnable(bool enable);
@@ -117,6 +119,7 @@ private:
 	QMap<QString, iio_device *> m_iioDevicesMap;
 	int m_enabledChnlsNo = 0;
 	int m_currentChannelSelected;
+	bool m_backBtnPressed;
 
 	scopy::gui::ChannelManager *m_monitorChannelManager;
 	scopy::gui::ToolView *m_toolView;
@@ -141,6 +144,8 @@ private:
 	ExportSettings *m_exportSettings;
 
 	struct iio_context *m_ctx;
+	Connection *m_conn;
+	QString m_uri;
 };
 } // namespace swiot
 } // namespace scopy

--- a/plugins/swiot/src/runtime/faults/faults.cpp
+++ b/plugins/swiot/src/runtime/faults/faults.cpp
@@ -33,11 +33,11 @@ using namespace scopy::swiot;
 
 #define POLLING_INTERVAL 1000
 
-Faults::Faults(struct iio_context *ctx, ToolMenuEntry *tme, QWidget *parent)
+Faults::Faults(QString uri, ToolMenuEntry *tme, QWidget *parent)
 	: QWidget(parent)
-	, ctx(ctx)
+	, m_uri(uri)
 	, ui(new Ui::Faults)
-	, m_faultsPage(new FaultsPage(ctx, this))
+	, m_faultsPage(new FaultsPage(m_uri, this))
 	, m_statusLabel(new QLabel(this))
 	, m_statusContainer(new QWidget(this))
 	, timer(new QTimer())
@@ -48,7 +48,6 @@ Faults::Faults(struct iio_context *ctx, ToolMenuEntry *tme, QWidget *parent)
 	, m_tme(tme)
 {
 	qInfo(CAT_SWIOT_FAULTS) << "Initialising SWIOT faults page.";
-
 	ui->setupUi(this);
 
 	this->setupDynamicUi(parent);

--- a/plugins/swiot/src/runtime/faults/faults.h
+++ b/plugins/swiot/src/runtime/faults/faults.h
@@ -37,7 +37,7 @@ class Faults : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit Faults(struct iio_context *ctx, ToolMenuEntry *tme, QWidget *parent = nullptr);
+	explicit Faults(QString uri, ToolMenuEntry *tme, QWidget *parent = nullptr);
 	~Faults();
 
 	void pollFaults();
@@ -60,7 +60,7 @@ private:
 	void initTutorialProperties();
 	static QPushButton *createBackButton();
 
-	struct iio_context *ctx;
+	QString m_uri;
 
 	Ui::Faults *ui;
 	QPushButton *m_backButton;

--- a/plugins/swiot/src/runtime/faults/faultsdevice.h
+++ b/plugins/swiot/src/runtime/faults/faultsdevice.h
@@ -40,8 +40,8 @@ class FaultsDevice : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit FaultsDevice(const QString &name, QString path, struct iio_device *device, struct iio_device *swiot,
-			      struct iio_context *context, QVector<uint32_t> &registers, QWidget *parent = nullptr);
+	explicit FaultsDevice(const QString &name, QString path, QString uri, QVector<uint32_t> &registers,
+			      QWidget *parent = nullptr);
 	~FaultsDevice();
 
 	void update();
@@ -70,11 +70,12 @@ private:
 	void connectSignalsAndSlots();
 	void initSpecialFaults();
 
+	QString m_uri;
+	CommandQueue *m_cmdQueue;
+
 	Ui::FaultsDevice *ui;
 	QWidget *m_faults_explanation;
 	scopy::gui::SubsectionSeparator *m_subsectionSeparator;
-
-	CommandQueue *m_cmdQueue;
 
 	FaultsGroup *m_faultsGroup;
 	QVector<QWidget *> m_faultExplanationWidgets;

--- a/plugins/swiot/src/runtime/faults/faultspage.h
+++ b/plugins/swiot/src/runtime/faults/faultspage.h
@@ -41,12 +41,13 @@ class FaultsPage : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit FaultsPage(struct iio_context *context, QWidget *parent = nullptr);
+	explicit FaultsPage(QString uri, QWidget *parent = nullptr);
 	~FaultsPage();
 
 	void update();
 
 private:
+	QString m_uri;
 	struct iio_context *m_context;
 
 	Ui::FaultsPage *ui;

--- a/plugins/swiot/src/runtime/max14906/max14906.h
+++ b/plugins/swiot/src/runtime/max14906/max14906.h
@@ -31,6 +31,7 @@
 
 #include <gui/flexgridlayout.hpp>
 #include <gui/tool_view.hpp>
+#include <iioutil/connection.h>
 
 namespace scopy::swiot {
 #define MAX_NAME "max14906"
@@ -41,7 +42,7 @@ class Max14906 : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit Max14906(struct iio_context *ctx, ToolMenuEntry *tme, QWidget *parent = nullptr);
+	explicit Max14906(QString uri, ToolMenuEntry *tme, QWidget *parent = nullptr);
 	~Max14906() override;
 
 Q_SIGNALS:
@@ -49,6 +50,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
 	void externalPowerSupply(bool ps);
+	void handleConnectionDestroyed();
 
 private Q_SLOTS:
 	void runButtonToggled();
@@ -70,8 +72,6 @@ private:
 	static QMainWindow *createDockableMainWindow(const QString &title, DioDigitalChannel *digitalChannel,
 						     QWidget *parent);
 
-	struct iio_context *m_ctx;
-
 	QPushButton *m_backButton;
 	QWidget *m_statusContainer;
 	QLabel *m_statusLabel;
@@ -87,6 +87,9 @@ private:
 
 	CommandQueue *m_cmdQueue;
 	ReaderThread *m_readerThread;
+	Connection *m_conn;
+	struct iio_context *m_ctx;
+	QString m_uri;
 	QMap<int, DioDigitalChannelController *> m_channelControls;
 
 	ToolMenuEntry *m_tme;

--- a/plugins/swiot/src/runtime/readerthread.cpp
+++ b/plugins/swiot/src/runtime/readerthread.cpp
@@ -45,9 +45,15 @@ ReaderThread::ReaderThread(bool isBuffered, CommandQueue *cmdQueue, QObject *par
 	, bufferCounter(0)
 	, m_running(false)
 	, m_bufferInvalid(false)
+	, m_deinit(true)
 {}
 
-ReaderThread::~ReaderThread() { forcedStop(); }
+ReaderThread::~ReaderThread()
+{
+	if(m_deinit) {
+		forcedStop();
+	}
+}
 
 void ReaderThread::addDioChannel(int index, struct iio_channel *channel) { m_dioChannels.insert(index, channel); }
 
@@ -363,4 +369,10 @@ void ReaderThread::forcedStop()
 		cancelIioBuffer();
 	}
 	wait();
+}
+
+void ReaderThread::handleConnectionDestroyed()
+{
+	m_deinit = false;
+	requestInterruption();
 }

--- a/plugins/swiot/src/runtime/readerthread.h
+++ b/plugins/swiot/src/runtime/readerthread.h
@@ -69,7 +69,7 @@ public:
 	void requestStop();
 	void forcedStop();
 public Q_SLOTS:
-
+	void handleConnectionDestroyed();
 	void onChnlsChange(QMap<int, ChnlInfo *> chnlsInfo);
 	void onSamplingFreqWritten(int samplingFreq);
 
@@ -89,6 +89,7 @@ private:
 	void run() override;
 
 	bool isBuffered;
+	bool m_deinit;
 	QMap<int, struct iio_channel *> m_dioChannels;
 
 	int m_samplingFreq = 4800;

--- a/plugins/swiot/src/runtime/swiotruntime.cpp
+++ b/plugins/swiot/src/runtime/swiotruntime.cpp
@@ -22,31 +22,23 @@
 
 #include "src/swiot_logging_categories.h"
 
-#include <iioutil/commandqueueprovider.h>
+#include <iioutil/connectionprovider.h>
 #include <iioutil/iiocommand/iiodevicesettrigger.h>
 #include <string>
 
 using namespace scopy::swiot;
 
-SwiotRuntime::SwiotRuntime(struct iio_context *ctx, QObject *parent)
+SwiotRuntime::SwiotRuntime(QString uri, QObject *parent)
 	: QObject(parent)
-	, m_iioCtx(ctx)
-	, m_cmdQueue(nullptr)
+	, m_uri(uri)
 {
-	if(m_iioCtx) {
-		m_cmdQueue = CommandQueueProvider::GetInstance()->open(m_iioCtx);
-	}
+	Connection *conn = ConnectionProvider::open(m_uri);
+	m_iioCtx = conn->context();
+	m_cmdQueue = conn->commandQueue();
 	createDevicesMap();
 }
 
-SwiotRuntime::~SwiotRuntime()
-{
-	if(m_cmdQueue) {
-		CommandQueueProvider::GetInstance()->close(m_iioCtx);
-		m_cmdQueue = nullptr;
-		m_iioCtx = nullptr;
-	}
-}
+SwiotRuntime::~SwiotRuntime() { ConnectionProvider::close(m_uri); }
 
 void SwiotRuntime::onIsRuntimeCtxChanged(bool isRuntimeCtx)
 {

--- a/plugins/swiot/src/runtime/swiotruntime.h
+++ b/plugins/swiot/src/runtime/swiotruntime.h
@@ -37,7 +37,7 @@ class SwiotRuntime : public QObject
 {
 	Q_OBJECT
 public:
-	SwiotRuntime(struct iio_context *ctx, QObject *parent = nullptr);
+	SwiotRuntime(QString m_uri, QObject *parent = nullptr);
 	~SwiotRuntime();
 
 public Q_SLOTS:
@@ -55,6 +55,7 @@ private:
 	void createDevicesMap();
 
 private:
+	QString m_uri;
 	iio_context *m_iioCtx;
 	QMap<QString, struct iio_device *> m_iioDevices;
 	CommandQueue *m_cmdQueue;

--- a/plugins/swiot/src/swiotcontroller.cpp
+++ b/plugins/swiot/src/swiotcontroller.cpp
@@ -90,6 +90,7 @@ void SwiotController::connectSwiot(iio_context *ctx)
 void SwiotController::disconnectSwiot()
 {
 	if(m_cmdQueue) {
+		m_cmdQueue->requestStop();
 		CommandQueueProvider::GetInstance()->close(m_iioCtx);
 		m_cmdQueue = nullptr;
 	}

--- a/plugins/swiot/src/swiotcontroller.h
+++ b/plugins/swiot/src/swiotcontroller.h
@@ -53,7 +53,7 @@ public:
 	void startTemperatureTask();
 	void stopTemperatureTask();
 
-	void connectSwiot(iio_context *ctx);
+	void connectSwiot();
 	void disconnectSwiot();
 
 public Q_SLOTS:
@@ -83,12 +83,12 @@ private:
 	SwiotReadTemperatureTask *temperatureTask;
 	CommandQueue *m_cmdQueue;
 	iio_context *m_iioCtx;
+	Connection *m_conn;
 	QString uri;
 	bool m_isRuntimeCtx;
 	bool m_temperatureReadEn;
 
 	CyclicalTask *pingTimer;
-	CyclicalTask *switchCtxTimer;
 	CyclicalTask *powerSupplyTimer;
 	CyclicalTask *temperatureTimer;
 };

--- a/plugins/swiot/src/swiotidentifytask.h
+++ b/plugins/swiot/src/swiotidentifytask.h
@@ -2,6 +2,8 @@
 #define SWIOTIDENTIFYTASK_H
 
 #include <QThread>
+#include <iioutil/connection.h>
+
 namespace scopy::swiot {
 class SwiotIdentifyTask : public QThread
 {
@@ -12,6 +14,7 @@ public:
 
 private:
 	QString m_uri;
+	Connection *m_conn;
 };
 } // namespace scopy::swiot
 #endif // SWIOTIDENTIFYTASK_H

--- a/plugins/swiot/src/swiotpingtask.cpp
+++ b/plugins/swiot/src/swiotpingtask.cpp
@@ -4,37 +4,34 @@
 
 #include <QDebug>
 
-#include <iioutil/commandqueueprovider.h>
+#include <iioutil/connectionprovider.h>
 #include <iioutil/iiocommand/iiodevicegettrigger.h>
 
 using namespace scopy;
 using namespace scopy::swiot;
-SwiotPingTask::SwiotPingTask(iio_context *c, QObject *parent)
+SwiotPingTask::SwiotPingTask(Connection *conn, QObject *parent)
 	: QThread(parent)
-	, c(c)
-{}
+{
+	c = conn;
+}
 
 SwiotPingTask::~SwiotPingTask() {}
 
 void SwiotPingTask::run()
 {
-
 	enabled = true;
-	CommandQueue *commandQueue = CommandQueueProvider::GetInstance()->open(c);
-	if(!commandQueue || !c) {
+	if(!c) {
 		Q_EMIT pingFailed();
 		return;
 	}
 
-	auto dev = iio_context_find_device(c, "sw_trig");
+	auto dev = iio_context_find_device(c->context(), "sw_trig");
 
 	if(dev) {
 		Command *getTriggerCommand = new IioDeviceGetTrigger(dev, nullptr);
 		connect(getTriggerCommand, &scopy::Command::finished, this, &SwiotPingTask::getTriggerCommandFinished,
 			Qt::QueuedConnection);
-		commandQueue->enqueue(getTriggerCommand);
-	} else {
-		CommandQueueProvider::GetInstance()->close(c);
+		c->commandQueue()->enqueue(getTriggerCommand);
 	}
 }
 
@@ -42,7 +39,6 @@ void SwiotPingTask::getTriggerCommandFinished(scopy::Command *cmd)
 {
 	IioDeviceGetTrigger *tcmd = dynamic_cast<IioDeviceGetTrigger *>(cmd);
 	if(!tcmd) {
-		CommandQueueProvider::GetInstance()->close(c);
 		return;
 	}
 	int ret = tcmd->getReturnCode();
@@ -51,7 +47,6 @@ void SwiotPingTask::getTriggerCommandFinished(scopy::Command *cmd)
 	} else {
 		Q_EMIT pingFailed();
 	}
-	CommandQueueProvider::GetInstance()->close(c);
 }
 
 #include "moc_swiotpingtask.cpp"

--- a/plugins/swiot/src/swiotpingtask.h
+++ b/plugins/swiot/src/swiotpingtask.h
@@ -8,13 +8,14 @@
 #include <QThread>
 
 #include <iioutil/command.h>
+#include <iioutil/connection.h>
 
 namespace scopy::swiot {
 class SwiotPingTask : public QThread
 {
 	Q_OBJECT
 public:
-	SwiotPingTask(iio_context *c, QObject *parent = nullptr);
+	SwiotPingTask(Connection *conn, QObject *parent = nullptr);
 	~SwiotPingTask();
 	virtual void run() override;
 Q_SIGNALS:
@@ -22,7 +23,8 @@ Q_SIGNALS:
 	void pingFailed();
 
 protected:
-	iio_context *c;
+	QString m_uri;
+	Connection *c;
 	bool enabled;
 
 private Q_SLOTS:

--- a/plugins/swiot/src/swiotreadtemperaturetask.h
+++ b/plugins/swiot/src/swiotreadtemperaturetask.h
@@ -26,7 +26,7 @@
 #include <QThread>
 
 #include <iioutil/command.h>
-#include <iioutil/commandqueue.h>
+#include <iioutil/connection.h>
 
 namespace scopy::swiot {
 class SwiotReadTemperatureTask : public QThread
@@ -47,10 +47,9 @@ private Q_SLOTS:
 
 private:
 	QString m_uri;
-	struct iio_context *m_context;
 	struct iio_channel *m_channel;
 	struct iio_device *m_device;
-	CommandQueue *m_commandQueue;
+	Connection *m_conn;
 	double m_raw, m_scale, m_offset;
 };
 } // namespace scopy::swiot

--- a/plugins/swiot/src/swiotswitchctxtask.cpp
+++ b/plugins/swiot/src/swiotswitchctxtask.cpp
@@ -22,8 +22,7 @@
 
 #include "src/swiot_logging_categories.h"
 
-#include <iioutil/commandqueueprovider.h>
-#include <iioutil/contextprovider.h>
+#include <iioutil/connectionprovider.h>
 #include <iioutil/iiocommand/iiodeviceattributeread.h>
 
 using namespace scopy::swiot;
@@ -32,54 +31,71 @@ SwiotSwitchCtxTask::SwiotSwitchCtxTask(QString uri, bool wasRuntime)
 	: QThread()
 	, m_uri(uri)
 	, m_wasRuntime(wasRuntime)
-{}
+	, m_conn(nullptr)
+{
+	connect(this, &SwiotSwitchCtxTask::contextSwitchFailed, this, [=, this]() { start(); });
+}
+
+SwiotSwitchCtxTask::~SwiotSwitchCtxTask() {}
 
 void SwiotSwitchCtxTask::run()
 {
-	iio_context *ctx = ContextProvider::GetInstance()->open(m_uri);
-	if(!ctx) {
+	m_conn = ConnectionProvider::open(m_uri);
+	if(!m_conn) {
 		return;
 	}
+	connect(m_conn, &Connection::aboutToBeDestroyed, this, [=, this]() {
+		if(m_conn) {
+			ConnectionProvider::close(m_uri);
+			m_conn = nullptr;
+		}
+	});
+
 	if(isInterruptionRequested()) {
-		ContextProvider::GetInstance()->close(m_uri);
+		ConnectionProvider::close(m_uri);
+		m_conn = nullptr;
 		return;
 	}
 
-	CommandQueue *commandQueue = CommandQueueProvider::GetInstance()->open(ctx);
-	if(!commandQueue) {
-		ContextProvider::GetInstance()->close(m_uri);
-		return;
-	}
-
-	iio_device *swiotDevice = iio_context_find_device(ctx, "swiot");
+	iio_device *swiotDevice = iio_context_find_device(m_conn->context(), "swiot");
 	if(swiotDevice) {
 		IioDeviceAttributeRead *iioAttrRead = new IioDeviceAttributeRead(swiotDevice, "mode", nullptr, true);
 
-		connect(
-			iioAttrRead, &scopy::Command::finished, this,
-			[=, this](scopy::Command *cmd) {
-				IioDeviceAttributeRead *tcmd = dynamic_cast<IioDeviceAttributeRead *>(cmd);
-				if(!tcmd) {
-					CommandQueueProvider::GetInstance()->close(ctx);
-					ContextProvider::GetInstance()->close(m_uri);
-					return;
-				}
-				char *readMode = tcmd->getResult();
-				if(tcmd->getReturnCode() >= 0) {
-					if((m_wasRuntime && (strcmp(readMode, "config") == 0)) ||
-					   (!m_wasRuntime && (strcmp(readMode, "runtime") == 0))) {
-						qDebug(CAT_SWIOT) << "Context has been changed";
-						Q_EMIT contextSwitched();
-					}
-				}
-				CommandQueueProvider::GetInstance()->close(ctx);
-				ContextProvider::GetInstance()->close(m_uri);
-			},
+		connect(iioAttrRead, &scopy::Command::finished, this, &SwiotSwitchCtxTask::onReadModeFinished,
 			Qt::QueuedConnection);
+		connect(m_conn, &scopy::Connection::aboutToBeDestroyed, this, [=, this]() {
+			disconnect(iioAttrRead, &scopy::Command::finished, this,
+				   &SwiotSwitchCtxTask::onReadModeFinished);
+		});
 
-		commandQueue->enqueue(iioAttrRead);
+		m_conn->commandQueue()->enqueue(iioAttrRead);
 	} else {
-		CommandQueueProvider::GetInstance()->close(ctx);
-		ContextProvider::GetInstance()->close(m_uri);
+		ConnectionProvider::close(m_uri);
+	}
+}
+
+void SwiotSwitchCtxTask::onReadModeFinished(scopy::Command *cmd)
+{
+	IioDeviceAttributeRead *tcmd = dynamic_cast<IioDeviceAttributeRead *>(cmd);
+	if(!tcmd) {
+		Q_EMIT contextSwitchFailed();
+		ConnectionProvider::close(m_uri);
+		return;
+	}
+	char *readMode = tcmd->getResult();
+	if(tcmd->getReturnCode() >= 0) {
+		if((m_wasRuntime && (strcmp(readMode, "config") == 0)) ||
+		   (!m_wasRuntime && (strcmp(readMode, "runtime") == 0))) {
+			qDebug(CAT_SWIOT) << "Context has been changed";
+			if(m_conn) {
+				m_conn = nullptr;
+				ConnectionProvider::close(m_uri);
+			}
+			Q_EMIT contextSwitched();
+		}
+	} else if(m_conn) {
+		Q_EMIT contextSwitchFailed();
+		m_conn = nullptr;
+		ConnectionProvider::close(m_uri);
 	}
 }

--- a/plugins/swiot/src/swiotswitchctxtask.h
+++ b/plugins/swiot/src/swiotswitchctxtask.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QThread>
+#include <iioutil/connection.h>
 
 namespace scopy::swiot {
 class SwiotSwitchCtxTask : public QThread
@@ -30,14 +31,20 @@ class SwiotSwitchCtxTask : public QThread
 	Q_OBJECT
 public:
 	SwiotSwitchCtxTask(QString uri, bool wasRuntime);
+	~SwiotSwitchCtxTask();
 	void run() override;
 
 Q_SIGNALS:
 	void contextSwitched();
+	void contextSwitchFailed();
+
+private Q_SLOTS:
+	void onReadModeFinished(scopy::Command *cmd);
 
 private:
 	QString m_uri;
 	bool m_wasRuntime;
+	Connection *m_conn;
 };
 } // namespace scopy::swiot
 


### PR DESCRIPTION
- Change the behavior of the CommandQueue.
- Introduce the Connection object which handles the iio_context and CommandQueue creation and destruction.
- Handle the reference count inside the Connection object.
- Emit a signal when the Connection reference count is 0 and the object is about to be destroyed. Every client of the ConnectionProvider should make sure that this signal is handled and no further operations regarding iio_context or CommandQueue are performed.
- Add a closeAll() method to force the destruction of the Connection and signal all the other clients to deinitialize.