### PR TITLE
open discussion - m2kplugin: Close all libm2k contexts when disconnecting the M2K from Scopy.

### DIFF
--- a/plugins/m2k/src/m2kcontroller.cpp
+++ b/plugins/m2k/src/m2kcontroller.cpp
@@ -78,7 +78,7 @@ void M2kController::disconnectM2k()
 		if(identifyTask && identifyTask->isRunning()) {
 			identifyTask->requestInterruption();
 		}
-		contextClose(m_m2k, true);
+		contextCloseAll();
 	} catch(std::exception &ex) {
 		qDebug(CAT_M2KPLUGIN) << ex.what();
 	}


### PR DESCRIPTION
PR needs more discussions on the subject:

This change is needed for proper compatibility with libm2k v0.8.0 which introduced the concept of reference count for all open contexts together with handling context ownership (iio_context created outside libm2k or by libm2k). For libm2k to cleanup all the context refs, every m2kOpen call should be matched by a closeContext call.
The libm2k change ( check PR https://github.com/analogdevicesinc/libm2k/pull/344 ) was motivated by the bug that prevented clients who had ownership over the iio_context to properly destroy it because libm2k was assuming ownership.
Now for every m2kOpen we should have a contextClose call to cleanup the ref count. The issue here is: 
- all the m2kOpen calls from the M2kPlugin are done without providing the context uri: ( https://github.com/analogdevicesinc/scopy/blob/dev/plugins/m2k/src/old/calibration.cpp#L60 )
- the reference count in libm2k is mapped to the Context URI ( https://github.com/analogdevicesinc/libm2k/blob/main/include/libm2k/contextbuilder.hpp#L116 )

Up to libm2k v0.7.0 there wasn't an issue with NOT providing the uri for m2kOpen with a previously created iio_context because it didn't actually depend on it. Now the reference count and open/close context actions depend on it. 
The contextCloseAll() s not necessarily a good choice here since it would close all device contexts existing at that time.
Possible ways to fix this: 
- If the URI is not provided in the m2kOpen call, add a check in libm2k and get it from the existing iio_context (would need to parse context attributes until found).
- Pass the uri in every m2kOpen call that the M2kPlugin has.
- Call m2kOpen once in the M2kPlugin and pass the M2k* (libm2k context object) to all the objects needing it.
- Change the reference count mapping in libm2k to? (iio_context, ref_count)?


