### PR TITLE
regmap: fix label not added to layout

### DIFF
--- a/plugins/regmap/src/register/bitfield/bitfielddetailedwidget.cpp
+++ b/plugins/regmap/src/register/bitfield/bitfielddetailedwidget.cpp
@@ -107,6 +107,7 @@ void BitFieldDetailedWidget::firstRead()
 		layout->addWidget(valueLineEdit);
 	} else if(access == "R") {
 		value = new QLabel(this);
+		layout->addWidget(value);
 	} else if(options && !options->isEmpty()) {
 		valueComboBox = new QComboBox(this);
 


### PR DESCRIPTION
fixed bug where when detailed bitfield value  was read only label was not added to layout 