### PR TITLE
Scopy 1.5.0: tool_launcher: close all libm2k contexts when disconnecting the M2K.

### DIFF
--- a/src/tool_launcher.cpp
+++ b/src/tool_launcher.cpp
@@ -1430,7 +1430,7 @@ void adiscope::ToolLauncher::destroyContext()
 			dev->setConnected(false, false);
 		if (m_m2k) {
 			try {
-				libm2k::context::contextClose(m_m2k);
+				libm2k::context::contextCloseAll();
 			} catch (libm2k::m2k_exception &e) {
 				HANDLE_EXCEPTION(e);
 				qDebug() << e.what();


### PR DESCRIPTION
Fix the following scenario in Scopy using libm2kv0.8.0: connect, disconnect, connect again - fails due to improper libm2k context deletion. See PR #1553 for more details on this issue.