### PR TITLE
Scopy 2.0: m2kplugin: close all libm2k contexts when disconnecting the M2K from …

### DIFF
--- a/plugins/m2k/src/m2kcontroller.cpp
+++ b/plugins/m2k/src/m2kcontroller.cpp
@@ -77,7 +77,7 @@ void M2kController::disconnectM2k()
 		if(identifyTask && identifyTask->isRunning()) {
 			identifyTask->requestInterruption();
 		}
-		contextClose(m_m2k, true);
+		contextCloseAll();
 	} catch(std::exception &ex) {
 		qDebug(CAT_M2KPLUGIN) << ex.what();
 	}


### PR DESCRIPTION
…Scopy

Fix the following scenario in the m2kplugin using libm2kv0.8.0: connect, disconnect, connect again - fails due to improper libm2k context deletion. See PR #1553 for more details on this issue.