### PR TITLE
ScopyStatusBar fix.

### DIFF
--- a/gui/include/gui/widgets/scopystatusbar.h
+++ b/gui/include/gui/widgets/scopystatusbar.h
@@ -28,6 +28,7 @@
 #include <QLabel>
 #include <QList>
 #include <QStackedWidget>
+#include <pluginbase/statusbarmanager.h>
 #include "pluginbase/statusmessage.h"
 #include "utils.h"
 #include "menu_anim.hpp"
@@ -40,6 +41,7 @@ class SCOPY_GUI_EXPORT ScopyStatusBar : public MenuVAnim
 	QWIDGET_PAINT_EVENT_HELPER
 public:
 	explicit ScopyStatusBar(QWidget *parent = nullptr);
+	~ScopyStatusBar();
 
 Q_SIGNALS:
 	void requestHistory();
@@ -60,6 +62,7 @@ private:
 	// UI elements
 	QStackedWidget *m_stackedWidget;
 	QWidget *m_rightWidget;
+	StatusBarManager *m_statusManager;
 };
 } // namespace scopy
 

--- a/gui/src/widgets/scopystatusbar.cpp
+++ b/gui/src/widgets/scopystatusbar.cpp
@@ -20,7 +20,6 @@
 
 #include "scopystatusbar.h"
 #include "stylehelper.h"
-#include <pluginbase/statusbarmanager.h>
 #include <QLoggingCategory>
 #include <QApplication>
 #include <QTimer>
@@ -34,10 +33,16 @@ ScopyStatusBar::ScopyStatusBar(QWidget *parent)
 	: MenuVAnim(parent)
 {
 	initUi();
+	m_statusManager = StatusBarManager::GetInstance();
+	connect(m_statusManager, &StatusBarManager::sendStatus, this, &ScopyStatusBar::displayStatusMessage);
+	connect(m_statusManager, &StatusBarManager::clearDisplay, this, &ScopyStatusBar::clearStatusMessage);
+}
 
-	auto statusManager = StatusBarManager::GetInstance();
-	connect(statusManager, &StatusBarManager::sendStatus, this, &ScopyStatusBar::displayStatusMessage);
-	connect(statusManager, &StatusBarManager::clearDisplay, this, &ScopyStatusBar::clearStatusMessage);
+ScopyStatusBar::~ScopyStatusBar()
+{
+	clearStatusMessage();
+	disconnect(m_statusManager, &StatusBarManager::sendStatus, this, &ScopyStatusBar::displayStatusMessage);
+	disconnect(m_statusManager, &StatusBarManager::clearDisplay, this, &ScopyStatusBar::clearStatusMessage);
 }
 
 void ScopyStatusBar::initUi()


### PR DESCRIPTION
The clearStatusMessage method was called after the ScopyStatusBar widget had been destroyed.