### PR TITLE
core/scopymainwindow_api: Changed runScript method.

### DIFF
--- a/core/include/core/scopymainwindow_api.h
+++ b/core/include/core/scopymainwindow_api.h
@@ -3,6 +3,7 @@
 
 #include "scopy-core_export.h"
 #include "scopymainwindow.h"
+#include <QFile>
 
 namespace scopy {
 class SCOPY_CORE_EXPORT ScopyMainWindow_API : public ApiObject
@@ -20,10 +21,11 @@ public:
 	Q_INVOKABLE bool disconnectDevice();
 	Q_INVOKABLE void switchTool(QString devID, QString toolName);
 	Q_INVOKABLE void switchTool(QString toolName);
-	Q_INVOKABLE void runScript(QString content, QString fileName);
+	Q_INVOKABLE void runScript(QString scriptPath, bool exitApp = true);
 
 private:
 	static bool sortByUUID(const QString &k1, const QString &k2);
+	const QString getScriptContent(QFile *file);
 	ScopyMainWindow *m_w;
 };
 

--- a/core/src/cmdlinehandler.cpp
+++ b/core/src/cmdlinehandler.cpp
@@ -23,23 +23,16 @@ int CmdLineHandler::handle(QCommandLineParser &parser, ScopyMainWindow_API &scop
 		}
 	}
 
+	bool keepRunning = parser.isSet("keep-running");
+	if(keepRunning) {
+		qInfo() << "keep-running option is only useful with a script!";
+	}
+
 	QString scriptPath = parser.value("script");
 	if(!scriptPath.isEmpty()) {
-		QFile file(scriptPath);
-		if(!file.open(QFile::ReadOnly)) {
-			qCritical() << "Unable to open script file";
-			return EXIT_FAILURE;
-		}
-
-		QTextStream stream(&file);
-		QString firstLine = stream.readLine();
-		if(!firstLine.startsWith("#!"))
-			stream.seek(0);
-
-		QString content = stream.readAll();
-		file.close();
-		QMetaObject::invokeMethod(&scopyApi, "runScript", Qt::QueuedConnection, Q_ARG(QString, content),
-					  Q_ARG(QString, scriptPath));
+		bool exitApp = !keepRunning;
+		QMetaObject::invokeMethod(&scopyApi, "runScript", Qt::QueuedConnection, Q_ARG(QString, scriptPath),
+					  Q_ARG(bool, exitApp));
 	}
 	return EXIT_SUCCESS;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char *argv[])
 	parser.addVersionOption();
 	parser.addOptions({
 		{{"s", "script"}, "Run given script.", "script"},
+		{{"r", "keep-running"}, "Keep the application session after running a certain script."},
 		{{"a", "accept-license"}, "Accept the license in advance."},
 		{{"l", "logfile"}, "Saves all the logging messages into a file.", "filename"},
 		{{"c", "connect"}, "Establish the connection to a given device by URI.", "URI"},

--- a/tools/js/README.md
+++ b/tools/js/README.md
@@ -28,6 +28,6 @@ Scopy Scripting Guide is available at: https://wiki.analog.com/university/tools/
 			- devID: The device ID that was returned upon adding it to the device browser
 			- toolName: The name of the desired tool
 5. Running a script from a given file
-	- Command: `scopy.runScript(QString content, QString fileName)`
-		- content: The content of the script
-		- fileName: The path to the file
+	- Command: `scopy.runScript(QString scriptPath, bool exitApp = true)`
+		- scriptPath: The path to the script
+		- exitApp: If set to true, the application will be closed after running the given script


### PR DESCRIPTION
The method no longer requires the contents of the script as a parameter and does not automatically close the application.
Closing the application can now be managed by the user both from the command line through the --keep-running (r) option and from ScopyJS through runScript(QString scriptPath, bool exitApp) method.