### PR TITLE
Add improvements to iio-widget

### DIFF
--- a/gui/include/gui/stylehelper.h
+++ b/gui/include/gui/stylehelper.h
@@ -24,6 +24,7 @@ class SpinBoxA;
 class MeasurementLabel;
 class StatsLabel;
 class MeasurementSelectorItem;
+class TitleSpinBox;
 } // namespace scopy
 
 namespace scopy {
@@ -105,6 +106,8 @@ public:
 	static void NoBackgroundIconButton(QPushButton *w, QIcon icon, QString objectName = "");
 	static void BackgroundAddPage(QWidget *w, QString objectName = "");
 	static void BrowseButton(QPushButton *btn, QString objectName = "");
+	static void SpinBoxUpButton(QPushButton *w, QString objectName);
+	static void SpinBoxDownButton(QPushButton *w, QString objectName);
 
 private:
 	QMap<QString, QString> colorMap;

--- a/gui/include/gui/widgets/titlespinbox.h
+++ b/gui/include/gui/widgets/titlespinbox.h
@@ -3,7 +3,7 @@
 
 #include <QLabel>
 #include <QPushButton>
-#include <QSpinBox>
+#include <QLineEdit>
 #include <QWidget>
 #include "scopy-gui_export.h"
 
@@ -19,13 +19,43 @@ public:
 	void setTitle(QString title);
 	QPushButton *getSpinBoxUpButton();
 	QPushButton *getSpinBoxDownButton();
-	QSpinBox *getSpinBox();
+	QLineEdit *getLineEdit();
+
+	double step() const;
+	void setStep(double newStep);
+
+	double max() const;
+	void setMax(double newMax);
+
+	double min() const;
+	void setMin(double newMin);
+
+	void setValue(double newValue);
+	void setSpinButtonsDisabled(bool isDisabled);
 
 private:
+	/**
+	 * @brief truncValue This function is needed because the QString::number function that
+	 * would be normally used to parse a QString to a number does not work well with large
+	 * numbers that end with multiple zeroes. The QString returned will be in scientific
+	 * notation. The alternative is that we can set a number of fixed decimal points, but
+	 * it would look awkward so this function converts it to a QString and chops the
+	 * trailing zeroes.
+	 * @param value
+	 * @return
+	 */
+	static QString truncValue(double value);
+
 	QPushButton *m_spinBoxUpButton;
 	QPushButton *m_spinBoxDownButton;
 	QLabel *m_titleLabel;
-	QSpinBox *m_spinBox;
+
+	// This lineedit will act like a spinbox because the QSpinBox
+	// is more restrictive than we would like :/
+	QLineEdit *m_lineedit;
+	double m_min;
+	double m_max;
+	double m_step;
 };
 } // namespace scopy
 #endif // TITLESPINBOX_H

--- a/gui/include/gui/widgets/titlespinbox.h
+++ b/gui/include/gui/widgets/titlespinbox.h
@@ -1,0 +1,31 @@
+#ifndef TITLESPINBOX_H
+#define TITLESPINBOX_H
+
+#include <QLabel>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QWidget>
+#include "scopy-gui_export.h"
+
+namespace scopy {
+class SCOPY_GUI_EXPORT TitleSpinBox : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit TitleSpinBox(QString title, QWidget *parent = nullptr);
+	~TitleSpinBox();
+
+	void setTitle(QString title);
+	QPushButton *getSpinBoxUpButton();
+	QPushButton *getSpinBoxDownButton();
+	QSpinBox *getSpinBox();
+
+private:
+	QPushButton *m_spinBoxUpButton;
+	QPushButton *m_spinBoxDownButton;
+	QLabel *m_titleLabel;
+	QSpinBox *m_spinBox;
+};
+} // namespace scopy
+#endif // TITLESPINBOX_H

--- a/gui/src/stylehelper.cpp
+++ b/gui/src/stylehelper.cpp
@@ -51,6 +51,11 @@ void StyleHelper::initColorMap()
 	sh->colorMap.insert("ProgressBarError", "#F44336");
 	sh->colorMap.insert("ProgressBarBusy", "#F8E71C");
 
+	sh->colorMap.insert("ButtonPressed", "#2a44df");
+	sh->colorMap.insert("ButtonHover", "#4a34ff");
+	sh->colorMap.insert("ButtonDisabled", "#868482");
+	sh->colorMap.insert("LabelTextTinted", "rgba(255, 255, 255, 150)");
+
 	sh->colorMap.insert("WarningText", "#FFC904");
 }
 
@@ -1318,6 +1323,48 @@ void StyleHelper::BrowseButton(QPushButton *btn, QString objectName)
 	btn->setStyleSheet(style);
 	btn->setProperty("blue_button", true);
 	btn->setText("...");
+}
+
+void StyleHelper::SpinBoxUpButton(QPushButton *w, QString objectName)
+{
+	if(!objectName.isEmpty())
+		w->setObjectName(objectName);
+
+	QString style = QString(R"css(
+	QPushButton {
+		background-color: transparent;
+		border-image: url(:/gui/icons/sba_up_btn.svg);
+		border: 0px;
+	}
+	QPushButton:pressed {
+		border-image: url(:/gui/icons/sba_up_btn_pressed.svg);
+	}
+	QPushButton:hover:!pressed {
+		border-image: url(:/gui/icons/sba_up_btn_hover.svg);
+	})css");
+
+	w->setStyleSheet(style);
+}
+
+void StyleHelper::SpinBoxDownButton(QPushButton *w, QString objectName)
+{
+	if(!objectName.isEmpty())
+		w->setObjectName(objectName);
+
+	QString style = QString(R"css(
+	QPushButton {
+		background-color: transparent;
+		border-image: url(:/gui/icons/sba_dn_btn.svg);
+		border: 0px;
+	}
+	QPushButton:pressed {
+		border-image: url(:/gui/icons/sba_dn_btn_pressed.svg);
+	}
+	QPushButton:hover:!pressed {
+		border-image: url(:/gui/icons/sba_dn_btn_hover.svg);
+	})css");
+
+	w->setStyleSheet(style);
 }
 
 #include "moc_stylehelper.cpp"

--- a/gui/src/widgets/titlespinbox.cpp
+++ b/gui/src/widgets/titlespinbox.cpp
@@ -1,0 +1,72 @@
+#include "titlespinbox.h"
+#include "stylehelper.h"
+
+#include <QBoxLayout>
+#include <utils.h>
+
+using namespace scopy;
+
+TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
+	: QWidget(parent)
+	, m_titleLabel(new QLabel(title, this))
+	, m_spinBox(new QSpinBox(this))
+	, m_spinBoxUpButton(new QPushButton(this))
+	, m_spinBoxDownButton(new QPushButton(this))
+{
+	QHBoxLayout *mainLayout = new QHBoxLayout(this);
+	mainLayout->setContentsMargins(0, 0, 0, 0);
+	setLayout(mainLayout);
+	m_spinBox->setStyleSheet("border: 0px solid gray; font-weight: normal;");
+
+	StyleHelper::MenuSmallLabel(m_titleLabel);
+	m_spinBox->setButtonSymbols(QSpinBox::NoButtons);
+	m_spinBox->setMaximumHeight(25);
+
+	QWidget *spinboxWidget = new QWidget(this);
+	QVBoxLayout *spinboxWidgetLayout = new QVBoxLayout(spinboxWidget);
+	spinboxWidgetLayout->setSpacing(0);
+	spinboxWidgetLayout->setMargin(0);
+
+	spinboxWidgetLayout->addWidget(m_titleLabel);
+	spinboxWidgetLayout->addWidget(m_spinBox);
+
+	QWidget *buttonWidget = new QWidget(this);
+	buttonWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+	QVBoxLayout *buttonWidgetLayout = new QVBoxLayout(buttonWidget);
+	buttonWidgetLayout->setSpacing(1);
+	buttonWidgetLayout->setContentsMargins(0, 0, 0, 1);
+
+	m_spinBoxUpButton->setAutoRepeat(true); // so the user can hold down the button and it will react
+	StyleHelper::SpinBoxUpButton(m_spinBoxUpButton, "SpinBoxUpButton");
+	m_spinBoxUpButton->setIconSize(QSize(20, 20));
+	m_spinBoxUpButton->setFixedSize(20, 20);
+
+	m_spinBoxDownButton->setAutoRepeat(true);
+	StyleHelper::SpinBoxDownButton(m_spinBoxDownButton, "SpinBoxDownButton");
+	m_spinBoxDownButton->setIconSize(QSize(20, 20));
+	m_spinBoxDownButton->setFixedSize(20, 20);
+
+	buttonWidgetLayout->addWidget(m_spinBoxUpButton);
+	buttonWidgetLayout->addWidget(m_spinBoxDownButton);
+
+	// here we preffer the pressed signal rather than the clicked one to speed up the change of values
+	connect(m_spinBoxUpButton,   &QPushButton::pressed, m_spinBox, [this] { m_spinBox->setValue(m_spinBox->value() + m_spinBox->singleStep()); });
+	connect(m_spinBoxDownButton, &QPushButton::pressed, m_spinBox, [this] { m_spinBox->setValue(m_spinBox->value() - m_spinBox->singleStep()); });
+
+	spinboxWidgetLayout->addWidget(m_titleLabel);
+	spinboxWidgetLayout->addWidget(m_spinBox);
+
+	mainLayout->addWidget(spinboxWidget);
+	mainLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Preferred));
+	mainLayout->addWidget(buttonWidget);
+}
+
+TitleSpinBox::~TitleSpinBox() {}
+
+void TitleSpinBox::setTitle(QString title) { m_titleLabel->setText(title); }
+
+QPushButton *TitleSpinBox::getSpinBoxUpButton() { return m_spinBoxUpButton; }
+
+QPushButton *TitleSpinBox::getSpinBoxDownButton() { return m_spinBoxDownButton; }
+
+QSpinBox *TitleSpinBox::getSpinBox() { return m_spinBox; }

--- a/gui/src/widgets/titlespinbox.cpp
+++ b/gui/src/widgets/titlespinbox.cpp
@@ -1,26 +1,32 @@
 #include "titlespinbox.h"
 #include "stylehelper.h"
 
+#include <string>
+
 #include <QBoxLayout>
+#include <QLoggingCategory>
 #include <utils.h>
 
 using namespace scopy;
+Q_LOGGING_CATEGORY(CAT_TITLESPINBOX, "TitleSpinBox")
 
 TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
 	: QWidget(parent)
 	, m_titleLabel(new QLabel(title, this))
-	, m_spinBox(new QSpinBox(this))
+	, m_lineedit(new QLineEdit(this))
 	, m_spinBoxUpButton(new QPushButton(this))
 	, m_spinBoxDownButton(new QPushButton(this))
+	, m_min(0)
+	, m_step(1)
+	, m_max(99)
 {
 	QHBoxLayout *mainLayout = new QHBoxLayout(this);
 	mainLayout->setContentsMargins(0, 0, 0, 0);
 	setLayout(mainLayout);
-	m_spinBox->setStyleSheet("border: 0px solid gray; font-weight: normal;");
+	m_lineedit->setStyleSheet("border: 0px solid gray; font-weight: normal;");
 
 	StyleHelper::MenuSmallLabel(m_titleLabel);
-	m_spinBox->setButtonSymbols(QSpinBox::NoButtons);
-	m_spinBox->setMaximumHeight(25);
+	m_lineedit->setMaximumHeight(25);
 
 	QWidget *spinboxWidget = new QWidget(this);
 	QVBoxLayout *spinboxWidgetLayout = new QVBoxLayout(spinboxWidget);
@@ -28,7 +34,7 @@ TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
 	spinboxWidgetLayout->setMargin(0);
 
 	spinboxWidgetLayout->addWidget(m_titleLabel);
-	spinboxWidgetLayout->addWidget(m_spinBox);
+	spinboxWidgetLayout->addWidget(m_lineedit);
 
 	QWidget *buttonWidget = new QWidget(this);
 	buttonWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
@@ -50,13 +56,48 @@ TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
 	buttonWidgetLayout->addWidget(m_spinBoxDownButton);
 
 	// here we preffer the pressed signal rather than the clicked one to speed up the change of values
-	connect(m_spinBoxUpButton, &QPushButton::pressed, m_spinBox,
-		[this] { m_spinBox->setValue(m_spinBox->value() + m_spinBox->singleStep()); });
-	connect(m_spinBoxDownButton, &QPushButton::pressed, m_spinBox,
-		[this] { m_spinBox->setValue(m_spinBox->value() - m_spinBox->singleStep()); });
+	connect(m_spinBoxUpButton, &QPushButton::pressed, m_lineedit, [this] {
+		bool ok = true;
+		QString text = m_lineedit->text();
+		double value = text.toDouble(&ok);
+		if(!ok) {
+			// If the cast fails that means that there is an issue with the text and the
+			// min/max/step values are useless here. The signal will just be skipped and
+			// a debug message will de displayed.
+			qDebug(CAT_TITLESPINBOX) << "Cannot increase the value:" << text;
+			return;
+		}
+
+		double newValue = value + m_step;
+		if(newValue > m_max) {
+			newValue = value;
+		}
+
+		m_lineedit->setText(truncValue(newValue));
+	});
+
+	connect(m_spinBoxDownButton, &QPushButton::pressed, m_lineedit, [this] {
+		bool ok = true;
+		QString text = m_lineedit->text();
+		double value = text.toDouble(&ok);
+		if(!ok) {
+			// If the cast fails that means that there is an issue with the text and the
+			// min/max/step values are useless here. The signal will just be skipped and
+			// a debug message will de displayed.
+			qDebug(CAT_TITLESPINBOX) << "Cannot decrease the value:" << text;
+			return;
+		}
+
+		double newValue = value - m_step;
+		if(newValue < m_min) {
+			newValue = value;
+		}
+
+		m_lineedit->setText(truncValue(newValue));
+	});
 
 	spinboxWidgetLayout->addWidget(m_titleLabel);
-	spinboxWidgetLayout->addWidget(m_spinBox);
+	spinboxWidgetLayout->addWidget(m_lineedit);
 
 	mainLayout->addWidget(spinboxWidget);
 	mainLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Preferred));
@@ -71,6 +112,44 @@ QPushButton *TitleSpinBox::getSpinBoxUpButton() { return m_spinBoxUpButton; }
 
 QPushButton *TitleSpinBox::getSpinBoxDownButton() { return m_spinBoxDownButton; }
 
-QSpinBox *TitleSpinBox::getSpinBox() { return m_spinBox; }
+QLineEdit *TitleSpinBox::getLineEdit() { return m_lineedit; }
+
+double TitleSpinBox::step() const { return m_step; }
+
+void TitleSpinBox::setStep(double newStep) { m_step = newStep; }
+
+double TitleSpinBox::max() const { return m_max; }
+
+void TitleSpinBox::setMax(double newMax) { m_max = newMax; }
+
+double TitleSpinBox::min() const { return m_min; }
+
+void TitleSpinBox::setMin(double newMin) { m_min = newMin; }
+
+void TitleSpinBox::setValue(double newValue) { m_lineedit->setText(truncValue(newValue)); }
+
+void TitleSpinBox::setSpinButtonsDisabled(bool isDisabled)
+{
+	m_spinBoxUpButton->setVisible(!isDisabled);
+	m_spinBoxDownButton->setVisible(!isDisabled);
+}
+
+QString TitleSpinBox::truncValue(double value)
+{
+	QString sReturn = QString::number(value, 'f', 7); // magic number
+	int i = sReturn.size() - 1;
+	int toChop = 0;
+	while(sReturn[i] == '0') {
+		++toChop;
+		--i;
+	}
+
+	if(sReturn[i] == '.') {
+		++toChop;
+	}
+
+	sReturn.chop(toChop);
+	return sReturn;
+}
 
 #include "moc_titlespinbox.cpp"

--- a/gui/src/widgets/titlespinbox.cpp
+++ b/gui/src/widgets/titlespinbox.cpp
@@ -50,8 +50,10 @@ TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
 	buttonWidgetLayout->addWidget(m_spinBoxDownButton);
 
 	// here we preffer the pressed signal rather than the clicked one to speed up the change of values
-	connect(m_spinBoxUpButton,   &QPushButton::pressed, m_spinBox, [this] { m_spinBox->setValue(m_spinBox->value() + m_spinBox->singleStep()); });
-	connect(m_spinBoxDownButton, &QPushButton::pressed, m_spinBox, [this] { m_spinBox->setValue(m_spinBox->value() - m_spinBox->singleStep()); });
+	connect(m_spinBoxUpButton, &QPushButton::pressed, m_spinBox,
+		[this] { m_spinBox->setValue(m_spinBox->value() + m_spinBox->singleStep()); });
+	connect(m_spinBoxDownButton, &QPushButton::pressed, m_spinBox,
+		[this] { m_spinBox->setValue(m_spinBox->value() - m_spinBox->singleStep()); });
 
 	spinboxWidgetLayout->addWidget(m_titleLabel);
 	spinboxWidgetLayout->addWidget(m_spinBox);
@@ -70,3 +72,5 @@ QPushButton *TitleSpinBox::getSpinBoxUpButton() { return m_spinBoxUpButton; }
 QPushButton *TitleSpinBox::getSpinBoxDownButton() { return m_spinBoxDownButton; }
 
 QSpinBox *TitleSpinBox::getSpinBox() { return m_spinBox; }
+
+#include "moc_titlespinbox.cpp"

--- a/iio-widgets/doc/iio-widgets.qmodel
+++ b/iio-widgets/doc/iio-widgets.qmodel
@@ -365,7 +365,7 @@
                            <item>interface</item>
                           </qlist>
                          </stereotypes>
-                         <name>AttrUiStrategyInterface</name>
+                         <name>GuiStrategyInterface</name>
                          <pos>x:1135;y:1000</pos>
                          <rect>x:-20;y:-20;w:40;h:40</rect>
                          <visual-role>8</visual-role>
@@ -934,7 +934,7 @@
                     <uid>{cb209626-cea5-4435-9eb9-b967d485e566}</uid>
                     <visibility>1</visibility>
                     <type>2</type>
-                    <declaration>IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent = nullptr)</declaration>
+                    <declaration>IIOWidget(GuiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent = nullptr)</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -942,7 +942,7 @@
                     <uid>{cfd8f1f0-d2a0-43a8-a374-42af845bc7c5}</uid>
                     <visibility>1</visibility>
                     <type>2</type>
-                    <declaration>AttrUiStrategyInterface *getUiStrategy()</declaration>
+                    <declaration>GuiStrategyInterface *getUiStrategy()</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -1014,7 +1014,7 @@
                     <uid>{2cdbae79-028f-4acc-8ea7-83abd9f0b735}</uid>
                     <visibility>2</visibility>
                     <type>1</type>
-                    <declaration>AttrUiStrategyInterface *m_uiStrategy</declaration>
+                    <declaration>GuiStrategyInterface *m_uiStrategy</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -1778,7 +1778,7 @@
                     </stereotypes>
                    </MElement>
                   </base-MElement>
-                  <name>AttrUiStrategyInterface</name>
+                  <name>GuiStrategyInterface</name>
                   <relations>
                    <handles>
                     <handles>
@@ -1819,7 +1819,7 @@
                     <uid>{35b3d02d-42f5-4bb0-bc78-e260ac466af9}</uid>
                     <visibility>1</visibility>
                     <type>2</type>
-                    <declaration>~AttrUiStrategyInterface()</declaration>
+                    <declaration>~GuiStrategyInterface()</declaration>
                    </MClassMember>
                   </item>
                   <item>

--- a/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
@@ -45,7 +45,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private:
 	QString m_data;

--- a/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
@@ -44,6 +44,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private:

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
@@ -44,6 +44,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private Q_SLOTS:

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
@@ -45,7 +45,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private Q_SLOTS:
 	void attributeReadFinished(Command *cmd);

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
@@ -24,6 +24,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private Q_SLOTS:

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
@@ -25,7 +25,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private Q_SLOTS:
 	void attributeReadFinished(Command *cmd);

--- a/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
@@ -23,6 +23,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private:

--- a/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
@@ -24,7 +24,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private:
 	QString m_data;

--- a/iio-widgets/include/iio-widgets/datastrategy/datastrategyinterface.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/datastrategyinterface.h
@@ -64,6 +64,13 @@ Q_SIGNALS:
 	virtual void sendData(QString data, QString dataOptions) = 0;
 
 	/**
+	 * @brief This signal is emitted before a write operation
+	 * @param oldData String containing the data what is present before the write
+	 * @param newData String containing the data that will be written
+	 */
+	virtual void aboutToWrite(QString oldData, QString newData) = 0;
+
+	/**
 	 * @brief Emits the status of the operations (e.g. error code)
 	 * */
 	virtual void emitStatus(int status) = 0;

--- a/iio-widgets/include/iio-widgets/datastrategy/datastrategyinterface.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/datastrategyinterface.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QLoggingCategory>
+#include <QDateTime>
 #include <iio.h>
 #include "iiowidgetdata.h"
 #include "scopy-iio-widgets_export.h"
@@ -71,9 +72,17 @@ Q_SIGNALS:
 	virtual void aboutToWrite(QString oldData, QString newData) = 0;
 
 	/**
-	 * @brief Emits the status of the operations (e.g. error code)
-	 * */
-	virtual void emitStatus(int status) = 0;
+	 * @brief emitStatus Signal for emitting the status of the operation that was
+	 * just performed.
+	 * @param timestamp QDateTime that holds the timestamp
+	 * @param oldData The data that is present in the iio-widget before the operation
+	 * @param newData The new data that was given to the operation
+	 * @param returnCode int representing the return code of that operation
+	 * @param isReadOp Boolean value set to true if the operation is a read
+	 * operation and false if it is a write operation.
+	 */
+	virtual void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode,
+				bool isReadOp) = 0;
 
 protected:
 	IIOWidgetFactoryRecipe m_recipe;

--- a/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
@@ -45,7 +45,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private:
 	QString m_data;

--- a/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
@@ -44,6 +44,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private:

--- a/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
@@ -44,6 +44,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
+	void aboutToWrite(QString oldData, QString newData) override;
 	void emitStatus(int status) override;
 
 private:

--- a/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
@@ -23,7 +23,7 @@
 
 #include <QWidget>
 #include <iio.h>
-#include "datastrategy/channelattrdatastrategy.h"
+#include "datastrategy/datastrategyinterface.h"
 #include "iiowidgetdata.h"
 #include "scopy-iio-widgets_export.h"
 
@@ -45,7 +45,7 @@ public Q_SLOTS:
 Q_SIGNALS:
 	void sendData(QString data, QString dataOptions) override;
 	void aboutToWrite(QString oldData, QString newData) override;
-	void emitStatus(int status) override;
+	void emitStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp) override;
 
 private:
 	QString m_data;

--- a/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
@@ -29,10 +29,10 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT ComboAttrUi : public QWidget, public AttrUiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT ComboAttrUi : public QWidget, public GuiStrategyInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(scopy::AttrUiStrategyInterface)
+	Q_INTERFACES(scopy::GuiStrategyInterface)
 public:
 	/**
 	 * @brief This contain a MenuComboWidget that takes the options for the combo from recipe->linkedAttributeValue.
@@ -41,7 +41,7 @@ public:
 	~ComboAttrUi();
 
 	/**
-	 * @overload AttrUiStrategyInterface::ui()
+	 * @overload GuiStrategyInterface::ui()
 	 * */
 	QWidget *ui() override;
 

--- a/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
@@ -51,8 +51,9 @@ public Q_SLOTS:
 	void receiveData(QString currentData, QString optionalData) override;
 
 Q_SIGNALS:
-	void emitData(QString data);
-	void requestData();
+	void displayedNewData(QString data, QString optionalData) override;
+	void emitData(QString data) override;
+	void requestData() override;
 
 private:
 	QWidget *m_ui;

--- a/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
@@ -29,10 +29,10 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT EditableGuiStrategy : public QWidget, public AttrUiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT EditableGuiStrategy : public QWidget, public GuiStrategyInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(scopy::AttrUiStrategyInterface)
+	Q_INTERFACES(scopy::GuiStrategyInterface)
 public:
 	/**
 	 * @brief This contain a MenuLineEdit with no validation on what the text can or cannot be set.
@@ -41,7 +41,7 @@ public:
 	~EditableGuiStrategy();
 
 	/**
-	 * @overload AttrUiStrategyInterface::ui()
+	 * @overload GuiStrategyInterface::ui()
 	 * */
 	QWidget *ui() override;
 

--- a/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
@@ -51,8 +51,9 @@ public Q_SLOTS:
 	void receiveData(QString currentData, QString optionalData) override;
 
 Q_SIGNALS:
-	void emitData(QString data);
-	void requestData();
+	void displayedNewData(QString data, QString optionalData) override;
+	void emitData(QString data) override;
+	void requestData() override;
 
 private:
 	QWidget *m_ui;

--- a/iio-widgets/include/iio-widgets/guistrategy/guistrategyinterface.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/guistrategyinterface.h
@@ -33,10 +33,10 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT AttrUiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT GuiStrategyInterface
 {
 public:
-	~AttrUiStrategyInterface() = default;
+	~GuiStrategyInterface() = default;
 
 	/**
 	 * @brief This should implement the main method for displaying the value of an attribute and also editing data
@@ -82,5 +82,5 @@ protected:
 };
 } // namespace scopy
 
-Q_DECLARE_INTERFACE(scopy::AttrUiStrategyInterface, "scopy::AttrUiStrategyInterface")
+Q_DECLARE_INTERFACE(scopy::GuiStrategyInterface, "scopy::GuiStrategyInterface")
 #endif // SCOPY_GUISTRATEGYINTERFACE_H

--- a/iio-widgets/include/iio-widgets/guistrategy/guistrategyinterface.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/guistrategyinterface.h
@@ -58,13 +58,23 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	/**
+	 * @brief This signal is emitted when the ui strategy receives new data from external sources,
+	 * not from the user.
+	 * @param data The data that will be displayed.
+	 * @param optionalData The data options, if available. Empty string if the parameter is not
+	 * necessary in this case.
+	 * */
+	virtual void displayedNewData(QString data, QString optionalData) = 0;
+
+	/**
 	 * @brief This will be the signal that the user changed the data, it should be caught by an external function
 	 * and set accordingly.
-	 * @warning Do not override this.
 	 * */
 	virtual void emitData(QString data) = 0;
 
-	// sends a request to the data handler to be able to complete the display
+	/**
+	 * @brief Sends a request to the data handler to be able to complete the display
+	 * */
 	virtual void requestData() = 0;
 
 protected:

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -54,6 +54,7 @@ public Q_SLOTS:
 	void receiveData(QString currentData, QString optionalData) override;
 
 Q_SIGNALS:
+	void displayedNewData(QString data, QString optionalData) override;
 	void emitData(QString data) override;
 	void requestData() override;
 

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -23,7 +23,8 @@
 
 #include <QWidget>
 #include <iio.h>
-#include <gui/spinbox_a.hpp>
+// #include <gui/spinbox_a.hpp>
+#include <gui/widgets/titlespinbox.h>
 #include "guistrategy/guistrategyinterface.h"
 #include "iiowidgetdata.h"
 #include "scopy-iio-widgets_export.h"
@@ -53,12 +54,12 @@ public Q_SLOTS:
 	void receiveData(QString currentData, QString optionalData) override;
 
 Q_SIGNALS:
-	void emitData(QString data);
-	void requestData();
+	void emitData(QString data) override;
+	void requestData() override;
 
 private:
 	QWidget *m_ui;
-	PositionSpinButton *m_positionSpinButton;
+	TitleSpinBox *m_spinBox;
 };
 } // namespace scopy
 

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -59,6 +59,16 @@ Q_SIGNALS:
 	void requestData() override;
 
 private:
+	/**
+	 * @brief tryParse will try an parse a QString to a double and if it fails it will try
+	 * and parse it io an int and the cast it back to a double.
+	 * @param number A QString that represents a double or an int.
+	 * @param success This will be set to false if the QString parse fails and true if the
+	 * number is parsed successfully.
+	 * @return The double that was extracted from the QString.
+	 */
+	double tryParse(QString number, bool *success);
+
 	QWidget *m_ui;
 	TitleSpinBox *m_spinBox;
 };

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -30,10 +30,10 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT RangeAttrUi : public QWidget, public AttrUiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT RangeAttrUi : public QWidget, public GuiStrategyInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(scopy::AttrUiStrategyInterface)
+	Q_INTERFACES(scopy::GuiStrategyInterface)
 public:
 	/**
 	 * @brief This contain a PositionSpinButton that takes the 3 values from recipe->linkedAttributeValue. The
@@ -44,7 +44,7 @@ public:
 	~RangeAttrUi();
 
 	/**
-	 * @overload AttrUiStrategyInterface::ui()
+	 * @overload GuiStrategyInterface::ui()
 	 * */
 	QWidget *ui() override;
 

--- a/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
@@ -52,8 +52,9 @@ public Q_SLOTS:
 	void receiveData(QString currentData, QString optionalData) override;
 
 Q_SIGNALS:
-	void emitData(QString data);
-	void requestData();
+	void displayedNewData(QString data, QString optionalData) override;
+	void emitData(QString data) override;
+	void requestData() override;
 
 private:
 	QWidget *m_ui;

--- a/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
@@ -29,10 +29,10 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT SwitchAttrUi : public QWidget, public AttrUiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT SwitchAttrUi : public QWidget, public GuiStrategyInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(scopy::AttrUiStrategyInterface)
+	Q_INTERFACES(scopy::GuiStrategyInterface)
 public:
 	/**
 	 * @brief This contain a CustomSwitch capable of holding no more than 2 values, the ones specified in
@@ -42,7 +42,7 @@ public:
 	~SwitchAttrUi();
 
 	/**
-	 * @overload AttrUiStrategyInterface::ui()
+	 * @overload GuiStrategyInterface::ui()
 	 * */
 	QWidget *ui() override;
 

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -32,7 +32,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class AttrUiStrategyInterface;
+class GuiStrategyInterface;
 class DataStrategyInterface;
 
 class SCOPY_IIO_WIDGETS_EXPORT IIOWidget : public QWidget
@@ -47,13 +47,13 @@ public:
 		Error
 	} State;
 
-	IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent = nullptr);
+	IIOWidget(GuiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent = nullptr);
 
 	/**
 	 * @brief Returns the UI of the IIOWidget
-	 * @return AttrUiStrategyInterface
+	 * @return GuiStrategyInterface
 	 * */
-	AttrUiStrategyInterface *getUiStrategy();
+	GuiStrategyInterface *getUiStrategy();
 
 	/**
 	 * @brief Returns the data save/load strategy
@@ -106,7 +106,7 @@ protected:
 	void setLastOperationTimestamp(QDateTime timestamp);
 	void setLastOperationState(IIOWidget::State state);
 
-	AttrUiStrategyInterface *m_uiStrategy;
+	GuiStrategyInterface *m_uiStrategy;
 	DataStrategyInterface *m_dataStrategy;
 	IIOWidgetFactoryRecipe m_recipe;
 

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -40,9 +40,25 @@ class SCOPY_IIO_WIDGETS_EXPORT IIOWidget : public QWidget
 	Q_OBJECT
 	QWIDGET_PAINT_EVENT_HELPER
 public:
+	typedef enum
+	{
+		Busy,
+		Correct,
+		Error
+	} State;
+
 	IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent = nullptr);
 
+	/**
+	 * @brief Returns the UI of the IIOWidget
+	 * @return AttrUiStrategyInterface
+	 * */
 	AttrUiStrategyInterface *getUiStrategy();
+
+	/**
+	 * @brief Returns the data save/load strategy
+	 * @return DataStretegyInterface
+	 * */
 	DataStrategyInterface *getDataStrategy();
 
 	/**
@@ -59,16 +75,23 @@ public:
 	 * */
 	void setRecipe(IIOWidgetFactoryRecipe recipe);
 
-	typedef enum
-	{
-		Busy,
-		Correct,
-		Error
-	} State;
+	/**
+	 * @brief Returns the timestamp for the last operation
+	 * @return QDateTime if there exists a last operation or nullptr if no operation was performed on this IIOWidget
+	 * */
+	QDateTime *lastOperationTimestamp();
+
+	/**
+	 * @brief Returns the state of the last operation
+	 * @return IIOWidget::State if there exists a last operation or nullptr if no operation was performed on this
+	 * IIOWidget
+	 * */
+	IIOWidget::State *lastOperationState();
 
 Q_SIGNALS:
 	/**
-	 * @brief 0 - busy, 1 - correct, 2 error
+	 * @brief Emits the current state of the IIOWidget system and a string containing a more
+	 * elaborate explanation of the current state
 	 * */
 	void currentStateChanged(State currentState, QString explanation = "");
 
@@ -79,12 +102,17 @@ protected Q_SLOTS:
 	void startTimer(QString data);
 
 protected:
+	void setLastOperationTimestamp(QDateTime timestamp);
+	void setLastOperationState(IIOWidget::State state);
+
 	AttrUiStrategyInterface *m_uiStrategy;
 	DataStrategyInterface *m_dataStrategy;
 	IIOWidgetFactoryRecipe m_recipe;
 
 	QString m_lastData;
 	SmallProgressBar *m_progressBar;
+	QDateTime *m_lastOpTimestamp;
+	IIOWidget::State *m_lastOpState;
 };
 } // namespace scopy
 

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -100,6 +100,7 @@ protected Q_SLOTS:
 	void emitDataStatus(int status);
 
 	void startTimer(QString data);
+	void storeReadInfo(QString data, QString optionalData);
 
 protected:
 	void setLastOperationTimestamp(QDateTime timestamp);

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -97,7 +97,7 @@ Q_SIGNALS:
 
 protected Q_SLOTS:
 	void saveData(QString data);
-	void emitDataStatus(int status);
+	void emitDataStatus(QDateTime timestamp, QString oldData, QString newData, int returnCode, bool isReadOp);
 
 	void startTimer(QString data);
 	void storeReadInfo(QString data, QString optionalData);

--- a/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
@@ -42,6 +42,7 @@ void ChannelAttrDataStrategy::save(QString data)
 		return;
 	}
 
+	Q_EMIT aboutToWrite(m_data, data);
 	ssize_t res = iio_channel_attr_write(m_recipe.channel, m_recipe.data.toStdString().c_str(),
 					     data.toStdString().c_str());
 	if(res < 0) {

--- a/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
@@ -90,9 +90,11 @@ void ChannelAttrDataStrategy::requestData()
 		options[m_recipe.constDataOptions.size()] = '\0'; // safety measures
 	}
 
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, QString(currentValue), (int)(currentValueResult), true);
+	// the members that contain data need to be refreshed before the signals are emitted
+	QString oldData = m_data;
 	m_data = currentValue;
 	m_optionalData = options;
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), currentValue, m_data, (int)(currentValueResult), true);
 	Q_EMIT sendData(m_data, m_optionalData);
 }
 

--- a/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
@@ -49,7 +49,7 @@ void ChannelAttrDataStrategy::save(QString data)
 		qWarning(CAT_IIO_DATA_STRATEGY) << "Cannot write" << data << "to" << m_recipe.data;
 	}
 
-	Q_EMIT emitStatus((int)(res));
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, data, (int)(res), false);
 	requestData(); // readback
 }
 
@@ -76,6 +76,8 @@ void ChannelAttrDataStrategy::requestData()
 			qWarning(CAT_IIO_DATA_STRATEGY)
 				<< "Could not read" << m_recipe.data << "error code:" << optionsResult;
 		}
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_optionalData, options, (int)(currentValueResult),
+				  true);
 	}
 
 	if(m_recipe.constDataOptions != "") {
@@ -88,6 +90,7 @@ void ChannelAttrDataStrategy::requestData()
 		options[m_recipe.constDataOptions.size()] = '\0'; // safety measures
 	}
 
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, QString(currentValue), (int)(currentValueResult), true);
 	m_data = currentValue;
 	m_optionalData = options;
 	Q_EMIT sendData(m_data, m_optionalData);

--- a/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
@@ -48,6 +48,7 @@ void CmdQChannelAttrDataStrategy::save(QString data)
 		return;
 	}
 
+	Q_EMIT aboutToWrite(m_dataRead, data);
 	Command *writeCommand = new IioChannelAttributeWrite(m_recipe.channel, m_recipe.data.toStdString().c_str(),
 							     data.toStdString().c_str(), nullptr);
 	QObject::connect(

--- a/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
@@ -101,9 +101,10 @@ void CmdQChannelAttrDataStrategy::attributeReadFinished(Command *cmd)
 
 	QString newData = QString(tcmd->getResult());
 	if(!m_recipe.constDataOptions.isEmpty()) {
+		QString oldData = m_dataRead;
 		m_optionalDataRead = m_recipe.constDataOptions;
-		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_dataRead, newData, tcmd->getReturnCode(), true);
 		m_dataRead = newData;
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_dataRead, tcmd->getReturnCode(), true);
 		Q_EMIT sendData(m_dataRead, m_optionalDataRead);
 	} else if(!m_recipe.iioDataOptions.isEmpty()) {
 		Command *readOptionalCommand = new IioChannelAttributeRead(
@@ -112,9 +113,10 @@ void CmdQChannelAttrDataStrategy::attributeReadFinished(Command *cmd)
 				 &CmdQChannelAttrDataStrategy::optionalAttrReadFinished);
 		m_cmdQueue->enqueue(readOptionalCommand);
 	} else {
-		// no optional data available, emit empty string for it
-		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_dataRead, newData, tcmd->getReturnCode(), true);
+		QString oldData = m_dataRead;
 		m_dataRead = newData;
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_dataRead, tcmd->getReturnCode(), true);
+		// no optional data available, emit empty string for it
 		Q_EMIT sendData(m_dataRead, QString());
 	}
 }
@@ -130,11 +132,11 @@ void CmdQChannelAttrDataStrategy::optionalAttrReadFinished(Command *cmd)
 		qWarning(CAT_CMDQ_CHANNEL_DATA_STATEGY) << "Could not read the value for" << m_recipe.data;
 		return;
 	}
-
 	char *currentOptValue = tcmd->getResult();
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_optionalDataRead, QString(currentOptValue),
-			  tcmd->getReturnCode(), true);
+	QString oldData = m_optionalDataRead;
 	m_optionalDataRead = QString(currentOptValue);
+
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_optionalDataRead, tcmd->getReturnCode(), true);
 	Q_EMIT sendData(m_dataRead, m_optionalDataRead);
 }
 

--- a/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
@@ -107,6 +107,7 @@ void CmdQChannelAttrDataStrategy::attributeReadFinished(Command *cmd)
 		Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_dataRead, tcmd->getReturnCode(), true);
 		Q_EMIT sendData(m_dataRead, m_optionalDataRead);
 	} else if(!m_recipe.iioDataOptions.isEmpty()) {
+		m_dataRead = newData;
 		Command *readOptionalCommand = new IioChannelAttributeRead(
 			m_recipe.channel, m_recipe.iioDataOptions.toStdString().c_str(), nullptr);
 		QObject::connect(readOptionalCommand, &Command::finished, this,

--- a/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
@@ -49,6 +49,7 @@ void CmdQDeviceAttrDataStrategy::save(QString data)
 		return;
 	}
 
+	Q_EMIT aboutToWrite(m_dataRead, data);
 	Command *writeCommand = new IioDeviceAttributeWrite(m_recipe.device, m_recipe.data.toStdString().c_str(),
 							    data.toStdString().c_str(), nullptr);
 	QObject::connect(

--- a/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
@@ -101,9 +101,10 @@ void CmdQDeviceAttrDataStrategy::attributeReadFinished(Command *cmd)
 
 	QString newData = QString(tcmd->getResult());
 	if(!m_recipe.constDataOptions.isEmpty()) {
+		QString oldData = m_dataRead;
 		m_optionalDataRead = m_recipe.constDataOptions;
-		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_dataRead, newData, tcmd->getReturnCode(), true);
 		m_dataRead = newData;
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_dataRead, tcmd->getReturnCode(), true);
 		Q_EMIT sendData(m_dataRead, m_optionalDataRead);
 	} else if(!m_recipe.iioDataOptions.isEmpty()) {
 		// if we have an attribute we have to read, we should read it, increase the counter and emit if
@@ -115,8 +116,9 @@ void CmdQDeviceAttrDataStrategy::attributeReadFinished(Command *cmd)
 		m_cmdQueue->enqueue(readOptionalCommand);
 	} else {
 		// no optional data available, emit empty string for it
-		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_dataRead, newData, tcmd->getReturnCode(), true);
+		QString oldData = m_dataRead;
 		m_dataRead = newData;
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_dataRead, tcmd->getReturnCode(), true);
 		Q_EMIT sendData(m_dataRead, QString());
 	}
 }
@@ -134,11 +136,9 @@ void CmdQDeviceAttrDataStrategy::optionalAttrReadFinished(Command *cmd)
 	}
 
 	char *currentOptValue = tcmd->getResult();
+	QString oldData = m_optionalDataRead;
 	m_optionalDataRead = QString(currentOptValue);
-
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_optionalDataRead, QString(currentOptValue),
-			  tcmd->getReturnCode(), true);
-	m_optionalDataRead = QString(currentOptValue);
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_optionalDataRead, tcmd->getReturnCode(), true);
 	Q_EMIT sendData(m_dataRead, m_optionalDataRead);
 }
 

--- a/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
@@ -109,6 +109,7 @@ void CmdQDeviceAttrDataStrategy::attributeReadFinished(Command *cmd)
 	} else if(!m_recipe.iioDataOptions.isEmpty()) {
 		// if we have an attribute we have to read, we should read it, increase the counter and emit if
 		// possible
+		m_dataRead = newData;
 		Command *readOptionalCommand = new IioDeviceAttributeRead(
 			m_recipe.device, m_recipe.iioDataOptions.toStdString().c_str(), nullptr);
 		QObject::connect(readOptionalCommand, &Command::finished, this,

--- a/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
@@ -18,6 +18,9 @@ QString ContextAttrDataStrategy::optionalData() { return m_optionalData; }
 void ContextAttrDataStrategy::save(QString data)
 {
 	qInfo(CAT_CONTEXT_ATTR_DATA_STRATEGY) << "ContextAttrDataStrategy::save called, but the attr is read only";
+	// The status needs to be emitted in order to keep the iio-widget from getting stuck in
+	// the "Busy" state
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, data, 0, false);
 	requestData();
 }
 

--- a/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
@@ -35,6 +35,8 @@ void ContextAttrDataStrategy::requestData()
 		return;
 	}
 
+	// There is no return code for the context attr read op, just return 0
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, value, 0, true);
 	m_data = value;
 	Q_EMIT sendData(m_data, "");
 }

--- a/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
@@ -39,8 +39,9 @@ void ContextAttrDataStrategy::requestData()
 	}
 
 	// There is no return code for the context attr read op, just return 0
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, value, 0, true);
+	QString oldData = m_data;
 	m_data = value;
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_data, 0, true);
 	Q_EMIT sendData(m_data, "");
 }
 

--- a/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
@@ -17,7 +17,7 @@ QString ContextAttrDataStrategy::optionalData() { return m_optionalData; }
 
 void ContextAttrDataStrategy::save(QString data)
 {
-	qDebug(CAT_CONTEXT_ATTR_DATA_STRATEGY) << "ContextAttrDataStrategy::save called, but the attr is read only";
+	qInfo(CAT_CONTEXT_ATTR_DATA_STRATEGY) << "ContextAttrDataStrategy::save called, but the attr is read only";
 	requestData();
 }
 

--- a/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
@@ -87,9 +87,10 @@ void DeviceAttrDataStrategy::requestData()
 		options[m_recipe.constDataOptions.size()] = '\0'; // safety measures
 	}
 
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, currentValue, currentValueResult, true);
+	QString oldData = m_data;
 	m_data = currentValue;
 	m_optionalData = options;
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_data, currentValueResult, true);
 	Q_EMIT sendData(m_data, m_optionalData);
 }
 

--- a/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
@@ -48,7 +48,7 @@ void DeviceAttrDataStrategy::save(QString data)
 		qWarning(CAT_DEVICE_DATA_STRATEGY) << "Cannot write" << data << "to" << m_recipe.data;
 	}
 
-	Q_EMIT emitStatus((int)(res));
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, data, (int)(res), false);
 	requestData();
 }
 
@@ -74,6 +74,7 @@ void DeviceAttrDataStrategy::requestData()
 			qWarning(CAT_DEVICE_DATA_STRATEGY)
 				<< "Could not read" << m_recipe.data << "error code:" << optionsResult;
 		}
+		Q_EMIT emitStatus(QDateTime::currentDateTime(), m_optionalData, options, currentValueResult, true);
 	}
 
 	if(m_recipe.constDataOptions != "") {
@@ -86,6 +87,7 @@ void DeviceAttrDataStrategy::requestData()
 		options[m_recipe.constDataOptions.size()] = '\0'; // safety measures
 	}
 
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, currentValue, currentValueResult, true);
 	m_data = currentValue;
 	m_optionalData = options;
 	Q_EMIT sendData(m_data, m_optionalData);

--- a/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
@@ -41,6 +41,7 @@ void DeviceAttrDataStrategy::save(QString data)
 		return;
 	}
 
+	Q_EMIT aboutToWrite(m_data, data);
 	ssize_t res =
 		iio_device_attr_write(m_recipe.device, m_recipe.data.toStdString().c_str(), data.toStdString().c_str());
 	if(res < 0) {

--- a/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
@@ -105,9 +105,10 @@ void TriggerDataStrategy::requestData()
 		}
 	}
 
-	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, currentTriggerName, res, true);
+	QString oldData = m_data;
 	m_data = currentTriggerName;
 	m_optionalData = triggerOptions;
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), oldData, m_data, res, true);
 	Q_EMIT sendData(m_data, m_optionalData);
 }
 

--- a/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
@@ -64,7 +64,7 @@ void TriggerDataStrategy::save(QString data)
 		}
 	}
 
-	Q_EMIT emitStatus((int)(res));
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, data, (int)(res), false);
 	requestData();
 }
 
@@ -105,6 +105,7 @@ void TriggerDataStrategy::requestData()
 		}
 	}
 
+	Q_EMIT emitStatus(QDateTime::currentDateTime(), m_data, currentTriggerName, res, true);
 	m_data = currentTriggerName;
 	m_optionalData = triggerOptions;
 	Q_EMIT sendData(m_data, m_optionalData);

--- a/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
@@ -48,6 +48,7 @@ void TriggerDataStrategy::save(QString data)
 		qWarning(CAT_TRIGGER_DATA_STRATEGY) << "Invalid arguments, no trigger with name" << data << "was found";
 	}
 
+	Q_EMIT aboutToWrite(m_data, data);
 	int res;
 	if(data == "None") {
 		res = iio_device_set_trigger(m_recipe.device, nullptr);

--- a/iio-widgets/src/guistrategy/comboguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/comboguistrategy.cpp
@@ -64,6 +64,7 @@ void ComboAttrUi::receiveData(QString currentData, QString optionalData)
 	}
 
 	m_comboWidget->combo()->setCurrentText(currentData);
+	Q_EMIT displayedNewData(currentData, optionalData);
 }
 
 #include "moc_comboguistrategy.cpp"

--- a/iio-widgets/src/guistrategy/editableguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/editableguistrategy.cpp
@@ -66,6 +66,7 @@ void EditableGuiStrategy::receiveData(QString currentData, QString optionalData)
 	QSignalBlocker blocker(m_lineEdit);
 	m_lastEmittedText = currentData;
 	m_lineEdit->edit()->setText(currentData);
+	Q_EMIT displayedNewData(currentData, optionalData);
 }
 
 #include "moc_editableguistrategy.cpp"

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -81,5 +81,8 @@ void RangeAttrUi::receiveData(QString currentData, QString optionalData)
 	m_spinBox->getSpinBox()->setMaximum(max);
 	m_spinBox->getSpinBox()->setSingleStep(step);
 	m_spinBox->getSpinBox()->setValue(currentNum);
+
+	Q_EMIT displayedNewData(currentData, optionalData);
 }
-// #include "moc_rangeguistrategy.cpp"
+
+#include "moc_rangeguistrategy.cpp"

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -61,7 +61,7 @@ bool RangeAttrUi::isValid()
 
 void RangeAttrUi::receiveData(QString currentData, QString optionalData)
 {
-	QSignalBlocker blocker(m_spinBox);
+	QSignalBlocker blocker(m_spinBox->getSpinBox());
 	QString availableAttributeValue = QString(optionalData).mid(1, QString(optionalData).size() - 2);
 	QStringList optionsList = availableAttributeValue.split(" ", Qt::SkipEmptyParts);
 	bool ok = true, finalOk = true;

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "guistrategy/rangeguistrategy.h"
+#include <QSpinBox>
 
 using namespace scopy;
 
@@ -34,15 +35,15 @@ RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent)
 			<< "The data you sent to this range gui strategy is not complete. Cannot create object";
 	}
 	m_ui->setLayout(new QVBoxLayout(m_ui));
+	m_ui->layout()->setContentsMargins(0, 0, 0, 0);
 
 	// FIXME: this does not look right when uninitialized, also crashes...
-	m_positionSpinButton = new PositionSpinButton({{"-", 1}}, m_recipe.data);
-	StyleHelper::MenuSpinBox(m_positionSpinButton, "RangeSpinButton");
-	m_ui->layout()->addWidget(m_positionSpinButton);
+	m_spinBox = new TitleSpinBox(m_recipe.data.toUpper(), this);
+	m_ui->layout()->addWidget(m_spinBox);
 	Q_EMIT requestData();
 
-	connect(m_positionSpinButton, &PositionSpinButton::valueChanged, this,
-		[this](double value) { Q_EMIT emitData(QString::number(value)); });
+	connect(m_spinBox->getSpinBox(), QOverload<int>::of(&QSpinBox::valueChanged), this,
+		[this](int value) { Q_EMIT emitData(QString::number(value)); });
 }
 
 RangeAttrUi::~RangeAttrUi() { m_ui->deleteLater(); }
@@ -60,7 +61,7 @@ bool RangeAttrUi::isValid()
 
 void RangeAttrUi::receiveData(QString currentData, QString optionalData)
 {
-	QSignalBlocker blocker(m_positionSpinButton);
+	QSignalBlocker blocker(m_spinBox);
 	QString availableAttributeValue = QString(optionalData).mid(1, QString(optionalData).size() - 2);
 	QStringList optionsList = availableAttributeValue.split(" ", Qt::SkipEmptyParts);
 	bool ok = true, finalOk = true;
@@ -76,9 +77,9 @@ void RangeAttrUi::receiveData(QString currentData, QString optionalData)
 		qWarning(CAT_ATTR_GUI_STRATEGY)
 			<< "Could not parse the values from" << availableAttributeValue << "as double ";
 	}
-	m_positionSpinButton->setMinValue(min);
-	m_positionSpinButton->setMaxValue(max);
-	m_positionSpinButton->setStep(step);
-	m_positionSpinButton->setValue(currentNum);
+	m_spinBox->getSpinBox()->setMinimum(min);
+	m_spinBox->getSpinBox()->setMaximum(max);
+	m_spinBox->getSpinBox()->setSingleStep(step);
+	m_spinBox->getSpinBox()->setValue(currentNum);
 }
-#include "moc_rangeguistrategy.cpp"
+// #include "moc_rangeguistrategy.cpp"

--- a/iio-widgets/src/guistrategy/switchguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/switchguistrategy.cpp
@@ -78,6 +78,8 @@ void SwitchAttrUi::receiveData(QString currentData, QString optionalData)
 	} else {
 		m_menuBigSwitch->setChecked(false);
 	}
+
+	Q_EMIT displayedNewData(currentData, optionalData);
 }
 
 #include "moc_switchguistrategy.cpp"

--- a/iio-widgets/src/iiowidget.cpp
+++ b/iio-widgets/src/iiowidget.cpp
@@ -25,7 +25,7 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_IIOWIDGET, "iioWidget")
 
-IIOWidget::IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent)
+IIOWidget::IIOWidget(GuiStrategyInterface *uiStrategy, DataStrategyInterface *dataStrategy, QWidget *parent)
 	: QWidget(parent)
 	, m_uiStrategy(uiStrategy)
 	, m_dataStrategy(dataStrategy)
@@ -104,7 +104,7 @@ void IIOWidget::emitDataStatus(int status)
 	timer->start(4000);
 }
 
-AttrUiStrategyInterface *IIOWidget::getUiStrategy() { return m_uiStrategy; }
+GuiStrategyInterface *IIOWidget::getUiStrategy() { return m_uiStrategy; }
 
 DataStrategyInterface *IIOWidget::getDataStrategy() { return m_dataStrategy; }
 

--- a/iio-widgets/src/iiowidget.cpp
+++ b/iio-widgets/src/iiowidget.cpp
@@ -30,6 +30,8 @@ IIOWidget::IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface 
 	, m_uiStrategy(uiStrategy)
 	, m_dataStrategy(dataStrategy)
 	, m_progressBar(new SmallProgressBar(this))
+	, m_lastOpTimestamp(nullptr)
+	, m_lastOpState(nullptr)
 {
 	setLayout(new QVBoxLayout(this));
 	layout()->setContentsMargins(0, 0, 0, 0);
@@ -46,8 +48,11 @@ IIOWidget::IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface 
 	connect(dynamic_cast<QWidget *>(m_uiStrategy), SIGNAL(emitData(QString)), this, SLOT(startTimer(QString)));
 	connect(dynamic_cast<QWidget *>(m_dataStrategy), SIGNAL(emitStatus(int)), this, SLOT(emitDataStatus(int)));
 
+	// forward data request from ui strategy to data strategy
 	connect(dynamic_cast<QWidget *>(m_uiStrategy), SIGNAL(requestData()), dynamic_cast<QWidget *>(m_dataStrategy),
 		SLOT(requestData()));
+
+	// forward data from data strategy to ui strategy
 	connect(dynamic_cast<QWidget *>(m_dataStrategy), SIGNAL(sendData(QString, QString)),
 		dynamic_cast<QWidget *>(m_uiStrategy), SLOT(receiveData(QString, QString)));
 
@@ -56,6 +61,7 @@ IIOWidget::IIOWidget(AttrUiStrategyInterface *uiStrategy, DataStrategyInterface 
 
 void IIOWidget::saveData(QString data)
 {
+	setLastOperationState(IIOWidget::Busy);
 	m_progressBar->setBarColor(StyleHelper::getColor("ProgressBarBusy"));
 	setToolTip("Operation in progress.");
 
@@ -65,17 +71,20 @@ void IIOWidget::saveData(QString data)
 
 void IIOWidget::emitDataStatus(int status)
 {
-	QString timestamp = QDateTime::currentDateTime().toString("hh:mm:ss");
+	setLastOperationTimestamp(QDateTime::currentDateTime());
+	QString timestamp = m_lastOpTimestamp->toString("hh:mm:ss");
 	if(status < 0) {
 		m_progressBar->setBarColor(StyleHelper::getColor("ProgressBarError"));
 		QString statusString = "Tried to write \"" + m_lastData +
 			"\", but failed.\nError: " + QString(strerror(-status)) + " (" + QString::number(status) + ").";
 		setToolTip("[" + timestamp + "] " + statusString);
+		setLastOperationState(IIOWidget::Error);
 		qDebug(CAT_IIOWIDGET) << statusString;
 	} else {
 		m_progressBar->setBarColor(StyleHelper::getColor("ProgressBarSuccess"));
 		QString statusString = "Operation finished successfully.";
 		setToolTip("[" + timestamp + "] " + statusString);
+		setLastOperationState(IIOWidget::Correct);
 		qDebug(CAT_IIOWIDGET) << statusString << ". Wrote " + m_lastData + ".";
 	}
 	auto *timer = new QTimer();
@@ -96,11 +105,31 @@ IIOWidgetFactoryRecipe IIOWidget::getRecipe() { return m_recipe; }
 
 void IIOWidget::setRecipe(IIOWidgetFactoryRecipe recipe) { m_recipe = recipe; }
 
+QDateTime *IIOWidget::lastOperationTimestamp() { return m_lastOpTimestamp; }
+
+IIOWidget::State *IIOWidget::lastOperationState() { return m_lastOpState; }
+
 void IIOWidget::startTimer(QString data)
 {
 	m_lastData = data;
 	m_progressBar->setBarColor(StyleHelper::getColor("ScopyBlue"));
 	m_progressBar->startProgress();
+}
+
+void IIOWidget::setLastOperationTimestamp(QDateTime timestamp)
+{
+	if(m_lastOpTimestamp == nullptr) {
+		m_lastOpTimestamp = new QDateTime();
+	}
+	*m_lastOpTimestamp = timestamp;
+}
+
+void IIOWidget::setLastOperationState(State state)
+{
+	if(m_lastOpState == nullptr) {
+		m_lastOpState = new IIOWidget::State;
+	}
+	*m_lastOpState = state;
 }
 
 #include "moc_iiowidget.cpp"

--- a/iio-widgets/src/iiowidgetfactory.cpp
+++ b/iio-widgets/src/iiowidgetfactory.cpp
@@ -32,7 +32,7 @@
 #include <iioutil/connectionprovider.h>
 #include <QLoggingCategory>
 
-#define ATTR_BUFFER_SIZE 256
+#define ATTR_BUFFER_SIZE 16384
 using namespace scopy;
 Q_LOGGING_CATEGORY(CAT_ATTRFACTORY, "AttrFactory")
 
@@ -55,7 +55,7 @@ QList<IIOWidget *> IIOWidgetFactory::buildAllAttrsForChannel(struct iio_channel 
 		}
 	}
 
-	for(const auto &attributeName : channelAttributes) {
+	for(const QString &attributeName : channelAttributes) {
 		if(attributeName.endsWith("_available")) {
 			continue;
 		}

--- a/iio-widgets/src/iiowidgetfactory.cpp
+++ b/iio-widgets/src/iiowidgetfactory.cpp
@@ -172,7 +172,7 @@ QList<IIOWidget *> IIOWidgetFactory::buildAllAttrsForContext(struct iio_context 
 
 IIOWidget *IIOWidgetFactory::buildSingle(uint32_t hint, IIOWidgetFactoryRecipe recipe, QWidget *parent)
 {
-	AttrUiStrategyInterface *uiStrategy = nullptr;
+	GuiStrategyInterface *uiStrategy = nullptr;
 	DataStrategyInterface *dataStrategy = nullptr;
 	IIOWidget *attrWidget = nullptr;
 

--- a/plugins/testplugin/res/attrfactory.qmodel
+++ b/plugins/testplugin/res/attrfactory.qmodel
@@ -117,7 +117,7 @@
                           </DElement>
                          </base-DElement>
                          <object>{1c9987ae-2179-4156-9dee-022dd667158f}</object>
-                         <name>AttrUiStrategyInterface</name>
+                         <name>GuiStrategyInterface</name>
                          <pos>x:-610;y:950</pos>
                          <rect>x:-195;y:-75;w:390;h:150</rect>
                          <visual-role>5</visual-role>
@@ -1139,7 +1139,7 @@
                     <uid>{ab980556-499c-4303-a883-4f61cd7fcb14}</uid>
                     <visibility>1</visibility>
                     <type>2</type>
-                    <declaration>IIOWidget(QString title, attr::AttrUiStrategyInterface *uiStrategy, attr::SaveStrategyInterface *saveStrategy, 		   attr::DataStrategyInterface *dataStrategy, QWidget *parent = nullptr)</declaration>
+                    <declaration>IIOWidget(QString title, attr::GuiStrategyInterface *uiStrategy, attr::SaveStrategyInterface *saveStrategy, 		   attr::DataStrategyInterface *dataStrategy, QWidget *parent = nullptr)</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -1155,7 +1155,7 @@
                     <uid>{5037be51-da11-4a3b-a44e-7a4673869e33}</uid>
                     <visibility>1</visibility>
                     <type>2</type>
-                    <declaration>attr::AttrUiStrategyInterface *getUiStrategy()</declaration>
+                    <declaration>attr::GuiStrategyInterface *getUiStrategy()</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -1179,7 +1179,7 @@
                     <uid>{754ca53e-b5e4-49a1-9d86-06dd531369b6}</uid>
                     <visibility>2</visibility>
                     <type>1</type>
-                    <declaration>attr::AttrUiStrategyInterface *m_uiStrategy</declaration>
+                    <declaration>attr::GuiStrategyInterface *m_uiStrategy</declaration>
                    </MClassMember>
                   </item>
                   <item>
@@ -1226,7 +1226,7 @@
                     <uid>{1c9987ae-2179-4156-9dee-022dd667158f}</uid>
                    </MElement>
                   </base-MElement>
-                  <name>AttrUiStrategyInterface</name>
+                  <name>GuiStrategyInterface</name>
                   <relations>
                    <handles>
                     <handles>


### PR DESCRIPTION
- Change the spinbox used in the range gui strategy
- Add new methods for reading the timestamp and status of the last operation
- Add aboutToWrite signal to DataStrategyInterface that returns the old and new value of a write operation
- Add displayedNewData signal to GuiStrategyInterface for signaling when the result of an operation is finished
- Rename AttrUiStrategyInterface to GuiStrategyInterface