### PR TITLE
bufferpreviewer: fixed rolling mode bug

### DIFF
--- a/gui/include/gui/widgets/plotbufferpreviewer.h
+++ b/gui/include/gui/widgets/plotbufferpreviewer.h
@@ -17,14 +17,15 @@ public:
 
 	void updateDataLimits();
 	void updateDataLimits(double min, double max);
+
 public Q_SLOTS:
 	void updateBufferPreviewer();
 
 private:
+	double m_bufferDataLimitMin;
+	double m_bufferDataLimitMax;
 	double m_bufferPrevInitMin;
 	double m_bufferPrevInitMax;
-
-	double m_bufferPrevData;
 
 	void setupBufferPreviewer();
 	PlotWidget *m_plot;

--- a/gui/src/buffer_previewer.cpp
+++ b/gui/src/buffer_previewer.cpp
@@ -50,9 +50,11 @@ BufferPreviewer::BufferPreviewer(int pixelsPerPeriod, double wavePhase, QWidget 
 	, m_leftGateWidth(0)
 	, m_rightGateWidth(0)
 	, m_cursorVisible(true)
-{}
+{
+	m_wavePoints = new QPointF();
+}
 
-BufferPreviewer::~BufferPreviewer() { delete[] m_wavePoints; }
+BufferPreviewer::~BufferPreviewer() { delete m_wavePoints; }
 
 double BufferPreviewer::waveformPos() const { return m_waveformPos; }
 

--- a/plugins/datamonitor/src/datamonitor/monitorplot.cpp
+++ b/plugins/datamonitor/src/datamonitor/monitorplot.cpp
@@ -239,6 +239,6 @@ void MonitorPlot::updatePlotStartingPoint(double time, double delta)
 
 		m_plot->xAxis()->setInterval(time - (delta * 1000), time);
 	}
-
+	m_bufferPreviewer->updateDataLimits(m_startTime, time);
 	m_plot->replot();
 }


### PR DESCRIPTION
data limit now has min and max value instead of beeing the absolte diff between two values
 use lower and upper axis bound instead of axis min and max value on drag to account for zoom level