### PR TITLE
Bug regmap offset values

### DIFF
--- a/plugins/regmap/src/regmapplugin.cpp
+++ b/plugins/regmap/src/regmapplugin.cpp
@@ -175,9 +175,9 @@ bool RegmapPlugin::onConnect()
 					uint32_t axiAddressSpace = Utils::convertQStringToUint32("80000000");
 					iioReadStrategy->setAddressSpace(axiAddressSpace);
 					iioWriteStrategy->setAddressSpace(axiAddressSpace);
-					generateDevice(templatePath, dev, devName, iioReadStrategy, iioWriteStrategy,
-						       templatePaths->getBitsPerRow());
 				}
+				generateDevice(templatePath, dev, devName, iioReadStrategy, iioWriteStrategy,
+					       templatePaths->getBitsPerRow());
 			} else {
 				generateDevice(templatePath, dev, devName, iioReadStrategy, iioWriteStrategy);
 			}

--- a/plugins/regmap/src/xmlfilemanager.cpp
+++ b/plugins/regmap/src/xmlfilemanager.cpp
@@ -212,10 +212,8 @@ BitFieldModel *XmlFileManager::getBitField(QDomElement bitField)
 			description, bitField.firstChildElement("Visibility").firstChild().toText().data(),
 			bitField.firstChildElement("Width").firstChild().toText().data().toInt(),
 			bitField.firstChildElement("Notes").firstChild().toText().data(),
-			Utils::convertQStringToUint32(
-				bitField.firstChildElement("BitOffset").firstChild().toText().data()),
-			Utils::convertQStringToUint32(
-				bitField.firstChildElement("RegOffset").firstChild().toText().data()),
+			bitField.firstChildElement("BitOffset").firstChild().toText().data().toInt(),
+			bitField.firstChildElement("RegOffset").firstChild().toText().data().toInt(),
 			bitField.firstChildElement("SliceWidth").firstChild().toText().data().toInt(), options);
 	}
 	return nullptr;

--- a/plugins/regmap/xmls/ad74413r.xml
+++ b/plugins/regmap/xmls/ad74413r.xml
@@ -258,7 +258,7 @@
 				<DefaultValue>0</DefaultValue>
 				<Description>Sets the Sink Current on the DIN Pins.</Description>
 				<Visibility>Public</Visibility>
-				<Width>4</Width>
+				<Width>5</Width>
 				<Notes>On AD74413R(din_upgrade=1), all 5 bits(din_config&lt;10:6&gt;) are used to set the current.
 
 On AD74412R(din_upgrade=0) then only the lower 4 bits(din_config&lt;9:6&gt;) are used to set the current.
@@ -266,7 +266,7 @@ On AD74412R(din_upgrade=0) then only the lower 4 bits(din_config&lt;9:6&gt;) are
 Hence Fullscale DIN sink current =1.8mA on AD74412R.</Notes>
 				<BitOffset>0</BitOffset>
 				<RegOffset>6</RegOffset>
-				<SliceWidth>4</SliceWidth>
+				<SliceWidth>5</SliceWidth>
 			</BitField>
 			<BitField>
 				<Name>DIN_RANGE</Name>
@@ -1860,6 +1860,28 @@ When an ADC conversion causes this bit to be set, the ADC result is automaticall
 		</BitFields>
 	</Register>
 	<Register>
+		<Name>DIN_COUNTER</Name>
+		<Address>0x3D</Address>
+		<Description>Debounced DIN Count Register per Channel.</Description>
+		<Exists>True</Exists>
+		<Width>16</Width>
+		<Notes>This count is allowed to roll over by design as in normal operation it's update rate should be slow.</Notes>
+		<BitFields>
+			<BitField>
+				<Name>DIN_CNT</Name>
+				<Access>R</Access>
+				<DefaultValue>0</DefaultValue>
+				<Description>Contains the 16bit Count from the DIN Counter.</Description>
+				<Visibility>Public</Visibility>
+				<Width>16</Width>
+				<Notes></Notes>
+				<BitOffset>0</BitOffset>
+				<RegOffset>0</RegOffset>
+				<SliceWidth>16</SliceWidth>
+			</BitField>
+		</BitFields>
+	</Register>
+	<Register>
 		<Name>READ_SELECT</Name>
 		<Address>0x41</Address>
 		<Description>Readback Select Register</Description>
@@ -2141,10 +2163,6 @@ When an ADC conversion causes this bit to be set, the ADC result is automaticall
 						<Value>65</Value>
 					</Option>
 					<Option>
-						<Description>ADC_CONV_CTRL_80SPS</Description>
-						<Value>66</Value>
-					</Option>
-					<Option>
 						<Description>THERM_RST</Description>
 						<Value>67</Value>
 					</Option>
@@ -2188,47 +2206,6 @@ When an ADC conversion causes this bit to be set, the ADC result is automaticall
 				<BitOffset>0</BitOffset>
 				<RegOffset>9</RegOffset>
 				<SliceWidth>1</SliceWidth>
-			</BitField>
-		</BitFields>
-	</Register>
-	<Register>
-		<Name>ADC_CONV_CTRL_80SPS</Name>
-		<Address>0x42</Address>
-		<Description>80SPS ADC Conversion Control Register.</Description>
-		<Exists>True</Exists>
-		<Width>16</Width>
-		<Notes></Notes>
-		<BitFields>
-			<BitField>
-				<Name>CONV_SEQ_40SPS</Name>
-				<Access>R/W</Access>
-				<DefaultValue>0</DefaultValue>
-				<Description>Selects Single or Continuous Mode.</Description>
-				<Visibility>Public</Visibility>
-				<Width>2</Width>
-				<Notes>If the fuse bit adc_40sps_dis is set then writing to this register will not start conversions.
-If the fuse bit adc_40sps_dis is 1 then this field is not available for writes.  Reads will return 0.</Notes>
-				<Options>
-					<Option>
-						<Description>Stop continuous conversions and leave the ADC powered up or power up the ADC.</Description>
-						<Value>0</Value>
-					</Option>
-					<Option>
-						<Description>Start single sequence conversion.</Description>
-						<Value>1</Value>
-					</Option>
-					<Option>
-						<Description>Start Continuous Conversions.</Description>
-						<Value>2</Value>
-					</Option>
-					<Option>
-						<Description>Stop continuous conversions and power down the ADC or power down the ADC.</Description>
-						<Value>3</Value>
-					</Option>
-				</Options>
-				<BitOffset>0</BitOffset>
-				<RegOffset>0</RegOffset>
-				<SliceWidth>2</SliceWidth>
 			</BitField>
 		</BitFields>
 	</Register>

--- a/plugins/regmap/xmls/regmap-config.json
+++ b/plugins/regmap/xmls/regmap-config.json
@@ -6,12 +6,6 @@
             "use_bitfield_description_as_name": true
         },
         {
-            "file_name": "AD74412.xml",
-            "compatible_drivers": [
-                "ad74413r"
-            ]
-        },
-        {
             "file_name": "adis16505-2.xml",
             "bits_per_row": 16
         }


### PR DESCRIPTION
Fixed 2 bugs on regmap 

* Map was only creating for AXI devices

* offset value and bit offset values were treated as hexa values


![image (4)](https://github.com/analogdevicesinc/scopy/assets/89773402/787bdd06-e3fc-4e6b-ac4d-0536e0422b59)
![image (3)](https://github.com/analogdevicesinc/scopy/assets/89773402/f07120e8-3e32-4e16-8891-3acdad75239f)
![image (2)](https://github.com/analogdevicesinc/scopy/assets/89773402/e6dccc2e-69d7-44f4-b288-91ffe25d0932)
![image (5)](https://github.com/analogdevicesinc/scopy/assets/89773402/aee5fc3c-b3ee-4723-908d-d6d6db3f3416)
