### PR TITLE
Plugins CMakeLists: Include sub-directories

### DIFF
--- a/plugins/datalogger/CMakeLists.txt
+++ b/plugins/datalogger/CMakeLists.txt
@@ -70,8 +70,14 @@ generate_export_header(
 	${PROJECT_NAME} EXPORT_FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/${PROJECT_NAME}_export.h
 )
 
+set(INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE} ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/menus
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/datamonitor
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/datamonitor/readstrategy
+)
+
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE})
+target_include_directories(${PROJECT_NAME} PRIVATE ${INCLUDE_DIRECTORIES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC scopy-pluginbase scopy-gui)
 target_include_directories(${PROJECT_NAME} PRIVATE ${IIO_INCLUDE_DIRS} scopy-gui scopy-iio-widgets)

--- a/plugins/swiot/CMakeLists.txt
+++ b/plugins/swiot/CMakeLists.txt
@@ -86,8 +86,14 @@ generate_export_header(
 	${PROJECT_NAME} EXPORT_FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/${PROJECT_NAME}_export.h
 )
 
+set(INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE} ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/ad74413r
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/faults
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE}/max14906
+)
+
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/${SCOPY_MODULE})
+target_include_directories(${PROJECT_NAME} PRIVATE ${INCLUDE_DIRECTORIES})
 
 include_directories(${Qt${QT_VERSION_MAJOR}Concurrent_INCLUDE_DIRS})
 


### PR DESCRIPTION
I added the sub-directories from datalogger/include/dataloggerplugin and swiot/include/swiot as target_include_directories in the cmakelists specific to each plugin.