### PR TITLE
iio-widgets/UIStrategy: Add compact mode to UI Strategies

### DIFF
--- a/gui/include/gui/stylehelper.h
+++ b/gui/include/gui/stylehelper.h
@@ -118,6 +118,7 @@ public:
 	static void ActiveStoredLabel(QLabel *w, QString objectName = "");
 	static void FaultsFrame(QFrame *w, QString objectName = "");
 	static void FaultsExplanation(QWidget *w, QString objectName = "");
+	static void IIOCompactLabel(QLabel *label, QString objectName = "");
 
 private:
 	QMap<QString, QString> colorMap;

--- a/gui/include/gui/widgets/titlespinbox.h
+++ b/gui/include/gui/widgets/titlespinbox.h
@@ -13,7 +13,7 @@ class SCOPY_GUI_EXPORT TitleSpinBox : public QWidget
 	Q_OBJECT
 
 public:
-	explicit TitleSpinBox(QString title, QWidget *parent = nullptr);
+	explicit TitleSpinBox(QString title, bool isCompact = false, QWidget *parent = nullptr);
 	~TitleSpinBox();
 
 	void setTitle(QString title);
@@ -45,6 +45,7 @@ private:
 	 * @return
 	 */
 	static QString truncValue(double value);
+	void connectSignalsAndSlots();
 
 	QPushButton *m_spinBoxUpButton;
 	QPushButton *m_spinBoxDownButton;

--- a/gui/src/stylehelper.cpp
+++ b/gui/src/stylehelper.cpp
@@ -1491,4 +1491,25 @@ void StyleHelper::FaultsExplanation(QWidget *w, QString objectName)
 	w->setStyleSheet(style);
 }
 
+void StyleHelper::IIOCompactLabel(QLabel *w, QString objectName)
+{
+	if(!objectName.isEmpty())
+		w->setObjectName(objectName);
+	w->setText(w->text().toUpper());
+	w->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+	QString style = R"css(
+			QLabel {
+				color: white;
+				background-color: rgba(255,255,255,0);
+				font-weight: 500;
+				font-family: Open Sans;
+				font-size: 12px;
+				font-style: normal;
+			}
+				QLabel:disabled {
+					color: grey;
+			})css";
+	w->setStyleSheet(style);
+}
+
 #include "moc_stylehelper.cpp"

--- a/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
@@ -37,7 +37,7 @@ public:
 	/**
 	 * @brief This contain a MenuComboWidget that takes the options for the combo from recipe->linkedAttributeValue.
 	 * */
-	explicit ComboAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
 	~ComboAttrUi();
 
 	/**
@@ -57,7 +57,8 @@ Q_SIGNALS:
 
 private:
 	QWidget *m_ui;
-	MenuCombo *m_comboWidget;
+	QComboBox *m_comboWidget;
+	bool m_isCompact;
 };
 } // namespace scopy
 

--- a/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
@@ -37,7 +37,7 @@ public:
 	/**
 	 * @brief This contain a MenuLineEdit with no validation on what the text can or cannot be set.
 	 * */
-	explicit EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
 	~EditableGuiStrategy();
 
 	/**

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -40,7 +40,7 @@ public:
 	 * string from recipe->linkedAttributeValue should look like "[begin step end]" where "begin", "step" and "end"
 	 * will be converted to double.
 	 * */
-	explicit RangeAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
 	~RangeAttrUi();
 
 	/**

--- a/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
@@ -38,7 +38,7 @@ public:
 	 * @brief This contain a CustomSwitch capable of holding no more than 2 values, the ones specified in
 	 * recipe->linkedAttributeValue.
 	 * */
-	explicit SwitchAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
 	~SwitchAttrUi();
 
 	/**

--- a/iio-widgets/include/iio-widgets/iiowidgetbuilder.h
+++ b/iio-widgets/include/iio-widgets/iiowidgetbuilder.h
@@ -82,6 +82,15 @@ public:
 	IIOWidgetBuilder &connection(scopy::Connection *connection);
 
 	/**
+	 * @brief Sets the UI of the widgets to compact mode, this way, the widget
+	 * sizes will be more compact.
+	 * @param isCompact If this is set to true, the widget will be in compact
+	 * mode. If false, the widget will be in normal mode.
+	 * @return
+	 */
+	IIOWidgetBuilder &compactMode(bool isCompact);
+
+	/**
 	 * @brief Sets the context that will be used, if no iio_device or iio_channel
 	 * is set, the build functions will work with the context.
 	 * @param context
@@ -151,6 +160,7 @@ private:
 	GuiStrategyInterface *createUIS();
 
 	Connection *m_connection;
+	bool m_isCompact;
 	struct iio_context *m_context;
 	struct iio_device *m_device;
 	struct iio_channel *m_channel;

--- a/iio-widgets/src/guistrategy/editableguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/editableguistrategy.cpp
@@ -22,19 +22,25 @@
 
 using namespace scopy;
 
-EditableGuiStrategy::EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
+EditableGuiStrategy::EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
 	: QWidget(parent)
 	, m_ui(new QWidget(nullptr))
 	, m_lineEdit(new MenuLineEdit(m_ui))
 {
 	m_recipe = recipe;
-	m_ui->setLayout(new QVBoxLayout(m_ui));
-	m_ui->layout()->setContentsMargins(0, 0, 0, 0);
+	QLabel *label = new QLabel(recipe.data, m_ui);
 
-	auto label = new QLabel(recipe.data, m_ui);
-	StyleHelper::MenuSmallLabel(label, "MenuSmallLabel");
+	if(isCompact) {
+		m_ui->setLayout(new QHBoxLayout(m_ui));
+		StyleHelper::IIOCompactLabel(label, "TitleLabel");
+		m_lineEdit->edit()->setAlignment(Qt::AlignRight);
+	} else {
+		m_ui->setLayout(new QVBoxLayout(m_ui));
+		StyleHelper::MenuSmallLabel(label, "MenuSmallLabel");
+	}
+
 	StyleHelper::IIOLineEdit(m_lineEdit->edit(), "IIOLineEdit");
-
+	m_ui->layout()->setContentsMargins(0, 0, 0, 0);
 	m_ui->layout()->addWidget(label);
 	m_ui->layout()->addWidget(m_lineEdit);
 

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -25,7 +25,7 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_ATTR_GUI_STRATEGY, "AttrGuiStrategy")
 
-RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent)
+RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
 	: QWidget(parent)
 	, m_ui(new QWidget(nullptr))
 {
@@ -34,16 +34,17 @@ RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent)
 		qCritical(CAT_ATTR_GUI_STRATEGY)
 			<< "The data you sent to this range gui strategy is not complete. Cannot create object";
 	}
+
 	m_ui->setLayout(new QVBoxLayout(m_ui));
 	m_ui->layout()->setContentsMargins(0, 0, 0, 0);
 
 	// FIXME: this does not look right when uninitialized, also crashes...
-	m_spinBox = new TitleSpinBox(m_recipe.data.toUpper(), this);
+	m_spinBox = new TitleSpinBox(m_recipe.data.toUpper(), isCompact, this);
 	m_ui->layout()->addWidget(m_spinBox);
-	Q_EMIT requestData();
 
 	connect(m_spinBox->getLineEdit(), &QLineEdit::textChanged, this,
 		[this](QString text) { Q_EMIT emitData(text); });
+	Q_EMIT requestData();
 }
 
 RangeAttrUi::~RangeAttrUi() { m_ui->deleteLater(); }

--- a/iio-widgets/src/guistrategy/switchguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/switchguistrategy.cpp
@@ -25,7 +25,7 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_SWITCHGUISTRATEGY, "SwitchGuiStrategy")
 
-SwitchAttrUi::SwitchAttrUi(IIOWidgetFactoryRecipe recipe, QWidget *parent)
+SwitchAttrUi::SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
 	: QWidget(parent)
 	, m_ui(new QWidget(nullptr))
 	, m_optionsList(new QStringList)

--- a/iio-widgets/src/iiowidgetbuilder.cpp
+++ b/iio-widgets/src/iiowidgetbuilder.cpp
@@ -39,6 +39,7 @@ Q_LOGGING_CATEGORY(CAT_ATTRFACTORY, "AttrFactory")
 IIOWidgetBuilder::IIOWidgetBuilder(QObject *parent)
 	: QObject(parent)
 	, m_connection(nullptr)
+	, m_isCompact(false)
 	, m_context(nullptr)
 	, m_device(nullptr)
 	, m_channel(nullptr)
@@ -167,6 +168,7 @@ QList<IIOWidget *> IIOWidgetBuilder::buildAll()
 void IIOWidgetBuilder::clear()
 {
 	m_connection = nullptr;
+	m_isCompact = false;
 	m_context = nullptr;
 	m_device = nullptr;
 	m_channel = nullptr;
@@ -181,6 +183,12 @@ void IIOWidgetBuilder::clear()
 IIOWidgetBuilder &IIOWidgetBuilder::connection(Connection *connection)
 {
 	m_connection = connection;
+	return *this;
+}
+
+IIOWidgetBuilder &IIOWidgetBuilder::compactMode(bool isCompact)
+{
+	m_isCompact = isCompact;
 	return *this;
 }
 
@@ -335,14 +343,14 @@ GuiStrategyInterface *IIOWidgetBuilder::createUIS()
 
 	switch(strategy) {
 	case UIS::EditableUi:
-		ui = new EditableGuiStrategy(m_generatedRecipe, m_widgetParent);
+		ui = new EditableGuiStrategy(m_generatedRecipe, m_isCompact, m_widgetParent);
 		break;
 	case UIS::SwitchUi:
 	case UIS::ComboUi:
-		ui = new ComboAttrUi(m_generatedRecipe, m_widgetParent);
+		ui = new ComboAttrUi(m_generatedRecipe, m_isCompact, m_widgetParent);
 		break;
 	case UIS::RangeUi:
-		ui = new RangeAttrUi(m_generatedRecipe, m_widgetParent);
+		ui = new RangeAttrUi(m_generatedRecipe, m_isCompact, m_widgetParent);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Compact mode reduces the size of the IIOWidgets to a single line. It can be toggled on/off by the compactMode() function in the builder.