### PR TITLE
datalogger: fixed warning messages

### DIFF
--- a/plugins/datalogger/src/datamonitor/sevensegmentdisplay.cpp
+++ b/plugins/datalogger/src/datamonitor/sevensegmentdisplay.cpp
@@ -14,14 +14,14 @@ SevenSegmentDisplay::SevenSegmentDisplay(QWidget *parent)
 	mainLayout->setSpacing(10);
 	setLayout(mainLayout);
 
-	QWidget *mainContainer = new QWidget(this);
-	QVBoxLayout *mainContainerLayout = new QVBoxLayout(this);
+	QWidget *mainContainer = new QWidget();
+	QVBoxLayout *mainContainerLayout = new QVBoxLayout();
 	mainContainerLayout->setMargin(0);
 	mainContainerLayout->setSpacing(10);
 	mainContainer->setLayout(mainContainerLayout);
 
 	QWidget *widgetBody = new QWidget(this);
-	layout = new QVBoxLayout(this);
+	layout = new QVBoxLayout();
 	layout->setMargin(0);
 	layout->setSpacing(10);
 	widgetBody->setLayout(layout);

--- a/plugins/datalogger/src/menus/channelattributesmenu.cpp
+++ b/plugins/datalogger/src/menus/channelattributesmenu.cpp
@@ -23,8 +23,6 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, QWidget *p
 	layout->setSpacing(10);
 	settingsBody->setLayout(layout);
 
-	mainLayout->addLayout(layout);
-
 	QScrollArea *scrollArea = new QScrollArea(this);
 	scrollArea->setWidgetResizable(true);
 	scrollArea->setWidget(settingsBody);

--- a/plugins/datalogger/src/menus/datamonitorsettings.cpp
+++ b/plugins/datalogger/src/menus/datamonitorsettings.cpp
@@ -45,7 +45,7 @@ void DataMonitorSettings::init(QString title, QColor color)
 		[=, this]() { Q_EMIT titleUpdated(header->lineEdit()->text()); });
 
 	settingsBody = new QWidget(this);
-	layout = new QVBoxLayout(this);
+	layout = new QVBoxLayout();
 	layout->setMargin(0);
 	layout->setSpacing(10);
 	settingsBody->setLayout(layout);

--- a/plugins/datalogger/src/menus/monitorselectionmenu.cpp
+++ b/plugins/datalogger/src/menus/monitorselectionmenu.cpp
@@ -19,7 +19,7 @@ MonitorSelectionMenu::MonitorSelectionMenu(QMap<QString, DataMonitorModel *> *mo
 	setLayout(mainLayout);
 
 	QWidget *settingsBody = new QWidget(this);
-	layout = new QVBoxLayout(this);
+	layout = new QVBoxLayout();
 	layout->setMargin(0);
 	layout->setSpacing(10);
 	settingsBody->setLayout(layout);

--- a/plugins/datalogger/src/menus/plottimeaxiscontroller.cpp
+++ b/plugins/datalogger/src/menus/plottimeaxiscontroller.cpp
@@ -6,6 +6,7 @@
 #include <menuonoffswitch.h>
 #include <menusectionwidget.h>
 #include <timemanager.hpp>
+#include <cfloat>
 
 using namespace scopy;
 using namespace datamonitor;
@@ -43,7 +44,7 @@ PlotTimeAxisController::PlotTimeAxisController(MonitorPlot *m_plot, QWidget *par
 			{"min", 60},
 			{"hour", 3600},
 		},
-		"Delta", (double)((long)(-1 << 31)), (double)((long)1 << 31), false, false, xAxisContainer);
+		"Delta", -DBL_MAX, DBL_MAX, false, false, xAxisContainer);
 	m_xdelta->setValue(DataMonitorUtils::getAxisDefaultMaxValue());
 
 	auto &&timeTracker = TimeManager::GetInstance();

--- a/plugins/datalogger/src/menus/sevensegmentmonitorsettings.cpp
+++ b/plugins/datalogger/src/menus/sevensegmentmonitorsettings.cpp
@@ -24,7 +24,7 @@ SevenSegmentMonitorSettings::SevenSegmentMonitorSettings(QWidget *parent)
 	sevenSegmentSettingsContainer->contentLayout()->addWidget(sevenSegmentSettingsSection);
 	sevenSegmentSettingsSection->contentLayout()->setSpacing(10);
 
-	QHBoxLayout *precisionLayout = new QHBoxLayout(this);
+	QHBoxLayout *precisionLayout = new QHBoxLayout();
 
 	precision = new QLineEdit(sevenSegmentSettingsSection);
 	precision->setText(QString::number(DataMonitorUtils::getDefaultPrecision()));


### PR DESCRIPTION
Changes made to remove warnings 
on windows system spinbox min and max values don't work if using "(double)((long)(-1 << 31))" for value