### PR TITLE
gr-util: gr-gui library is never used.

### DIFF
--- a/gr-util/CMakeLists.txt
+++ b/gr-util/CMakeLists.txt
@@ -62,7 +62,6 @@ target_link_libraries(
 	PUBLIC Qt${QT_VERSION_MAJOR}::Core
 	       scopy-iioutil
 	       scopy-gui
-	       scopy-gr-gui
 	       scopy-iio-widgets
 	       gnuradio::gnuradio-runtime
 	       gnuradio::gnuradio-analog


### PR DESCRIPTION
gr-gui is included in the m2k module. For this reason when we disable the m2k plugin the build fails. 