### PR TITLE
IIOWidget: Add optional lazy loading

### DIFF
--- a/core/src/scopymainwindow.cpp
+++ b/core/src/scopymainwindow.cpp
@@ -272,6 +272,7 @@ void ScopyMainWindow::initPreferences()
 	p->init("general_language", "en");
 	p->init("show_grid", true);
 	p->init("show_graticule", false);
+	p->init("iiowidgets_use_lazy_loading", true);
 	p->init("general_plot_target_fps", "60");
 	p->init("general_show_plot_fps", true);
 	p->init("general_use_native_dialogs", true);

--- a/core/src/scopypreferencespage.cpp
+++ b/core/src/scopypreferencespage.cpp
@@ -208,6 +208,8 @@ QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 		PreferencesHelper::addPreferenceCheckBox(p, "show_grid", "Show Grid", generalSection));
 	generalSection->contentLayout()->addWidget(
 		PreferencesHelper::addPreferenceCheckBox(p, "show_graticule", "Show Graticule", generalSection));
+	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
+		p, "iiowidgets_use_lazy_loading", "Use Lazy Loading", generalSection));
 	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
 		p, "general_theme", "Theme", {"default", "light"}, generalSection));
 	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -30,6 +30,7 @@
 #include "guistrategy/guistrategyinterface.h"
 #include "datastrategy/datastrategyinterface.h"
 #include "scopy-iio-widgets_export.h"
+#include <pluginbase/lazyloadwidget.h>
 
 namespace scopy {
 class GuiStrategyInterface;
@@ -39,6 +40,7 @@ class SCOPY_IIO_WIDGETS_EXPORT IIOWidget : public QWidget
 {
 	Q_OBJECT
 	QWIDGET_PAINT_EVENT_HELPER
+	QWIDGET_LAZY_INIT(initialize)
 public:
 	typedef enum
 	{
@@ -138,6 +140,8 @@ protected Q_SLOTS:
 	void storeReadInfo(QString data, QString optionalData);
 
 protected:
+	void initialize();
+
 	void setLastOperationTimestamp(QDateTime timestamp);
 	void setLastOperationState(IIOWidget::State state);
 

--- a/iio-widgets/src/iiowidgetbuilder.cpp
+++ b/iio-widgets/src/iiowidgetbuilder.cpp
@@ -34,7 +34,7 @@
 
 #define ATTR_BUFFER_SIZE 16384
 using namespace scopy;
-Q_LOGGING_CATEGORY(CAT_ATTRFACTORY, "AttrFactory")
+Q_LOGGING_CATEGORY(CAT_ATTRBUILDER, "AttrBuilder")
 
 IIOWidgetBuilder::IIOWidgetBuilder(QObject *parent)
 	: QObject(parent)
@@ -59,12 +59,12 @@ IIOWidget *IIOWidgetBuilder::buildSingle()
 	GuiStrategyInterface *ui = nullptr;
 
 	if(!m_context && !m_device && !m_channel) {
-		qWarning(CAT_ATTRFACTORY) << "No channel/device/context set.";
+		qWarning(CAT_ATTRBUILDER) << "No channel/device/context set.";
 		return nullptr;
 	}
 
 	if(m_attribute.isEmpty()) {
-		qWarning(CAT_ATTRFACTORY) << "No attribute name set.";
+		qWarning(CAT_ATTRBUILDER) << "No attribute name set.";
 		return nullptr;
 	}
 
@@ -98,7 +98,7 @@ QList<IIOWidget *> IIOWidgetBuilder::buildAll()
 		for(ssize_t i = 0; i < attrCount; ++i) {
 			attrName = iio_channel_get_attr(m_channel, i);
 			if(!attrName) {
-				qWarning(CAT_ATTRFACTORY)
+				qWarning(CAT_ATTRBUILDER)
 					<< "Could not read the channel attribute name with index" << i;
 				continue;
 			}
@@ -121,7 +121,7 @@ QList<IIOWidget *> IIOWidgetBuilder::buildAll()
 		for(ssize_t i = 0; i < attrCount; ++i) {
 			attrName = iio_device_get_attr(m_device, i);
 			if(!attrName) {
-				qWarning(CAT_ATTRFACTORY) << "Could not read the device attribute name with index" << i;
+				qWarning(CAT_ATTRBUILDER) << "Could not read the device attribute name with index" << i;
 				continue;
 			}
 
@@ -139,14 +139,14 @@ QList<IIOWidget *> IIOWidgetBuilder::buildAll()
 			result.append(buildSingle());
 		}
 	} else if(m_context) {
-		attrCount = iio_context_get_devices_count(m_context);
+		attrCount = iio_context_get_attrs_count(m_context);
 		for(ssize_t i = 0; i < attrCount; ++i) {
 			const char *name;
 			const char *value;
 			int res = iio_context_get_attr(m_context, i, &name, &value);
 
 			if(res < 0) {
-				qWarning(CAT_ATTRFACTORY) << "Coutd not get the context attribute with index" << i;
+				qWarning(CAT_ATTRBUILDER) << "Coutd not get the context attribute with index" << i;
 				continue;
 			}
 
@@ -154,7 +154,7 @@ QList<IIOWidget *> IIOWidgetBuilder::buildAll()
 			result.append(buildSingle());
 		}
 	} else {
-		qWarning(CAT_ATTRFACTORY) << "Not enough information to build IIOWidgets";
+		qWarning(CAT_ATTRBUILDER) << "Not enough information to build IIOWidgets";
 		return {};
 	}
 
@@ -266,7 +266,7 @@ DataStrategyInterface *IIOWidgetBuilder::createDS()
 
 	switch(strategy) {
 	case DS::NoDataStrategy:
-		qWarning(CAT_ATTRFACTORY) << "Could not determine the Data Strategy";
+		qWarning(CAT_ATTRBUILDER) << "Could not determine the Data Strategy";
 		break;
 	case DS::AttrData:
 		if(m_connection)
@@ -287,7 +287,7 @@ DataStrategyInterface *IIOWidgetBuilder::createDS()
 		ds = new TriggerDataStrategy(m_generatedRecipe, m_widgetParent);
 		break;
 	default:
-		qWarning(CAT_ATTRFACTORY) << "No valid Data Strategy was provided.";
+		qWarning(CAT_ATTRBUILDER) << "No valid Data Strategy was provided.";
 		break;
 	}
 
@@ -320,7 +320,7 @@ GuiStrategyInterface *IIOWidgetBuilder::createUIS()
 			}
 
 			if(res < 0) {
-				qWarning(CAT_ATTRFACTORY) << "Could not read options from" << m_optionsAttribute;
+				qWarning(CAT_ATTRBUILDER) << "Could not read options from" << m_optionsAttribute;
 				strategy = UIS::EditableUi;
 			} else {
 				if(QString(buffer).startsWith('[') && strategy == UIS::NoUIStrategy) {

--- a/pluginbase/include/pluginbase/lazyloadwidget.h
+++ b/pluginbase/include/pluginbase/lazyloadwidget.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LAZYLOADWIDGET_H
+#define LAZYLOADWIDGET_H
+
+#include <QWidget>
+#include <QShowEvent>
+
+/**
+ * Used to instantly perform the lazy load in a class that contains the QWIDGET_LAZY_INIT macro.
+ */
+#define LAZY_LOAD(func)                                                                                                \
+	do {                                                                                                           \
+		func();                                                                                                \
+		m_lazy_load_initialized = true;                                                                        \
+	} while(0)
+
+/**
+ * Used in a class header to make the class use the lazy load mechanism. The parameter is the name of function
+ * that will be called as part of the initializaiton process. CAUTION: The function signature should not have
+ * any mandatory parameters.
+ */
+#define QWIDGET_LAZY_INIT(func)                                                                                        \
+protected:                                                                                                             \
+	void showEvent(QShowEvent *event) override                                                                     \
+	{                                                                                                              \
+		if(!m_lazy_load_initialized) {                                                                         \
+			LAZY_LOAD(func);                                                                               \
+		}                                                                                                      \
+		QWidget::showEvent(event);                                                                             \
+	}                                                                                                              \
+	bool m_lazy_load_initialized = false;
+
+#endif // LAZYLOADWIDGET_H


### PR DESCRIPTION
The IIOWidget now has the ability to lazy load. By default (if not changed from the preference page) the IIOWidgets will only initialise on the first show event, not in the constructor, thus improving the loading time when connecting to a device. Deselecting this option will make the IIOWidgets initialise when created.