### PR TITLE
Bug fix: preferences

### DIFF
--- a/pluginbase/src/preferences.cpp
+++ b/pluginbase/src/preferences.cpp
@@ -11,6 +11,7 @@ Preferences *Preferences::pinstance_{nullptr};
 
 Preferences::Preferences(QObject *parent)
 	: QObject(parent)
+	, s(nullptr)
 {
 	connect(parent, SIGNAL(aboutToQuit()), this, SLOT(save()));
 }


### PR DESCRIPTION
Initialized s with nullptr. The fact that it was not initialized caused unwanted behaviors.