### PR TITLE
iio-widget: Fix parentless IIOWidgets

### DIFF
--- a/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/channelattrdatastrategy.h
@@ -28,12 +28,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT ChannelAttrDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT ChannelAttrDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit ChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit ChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	~ChannelAttrDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqchannelattrdatastrategy.h
@@ -28,12 +28,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT CmdQChannelAttrDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT CmdQChannelAttrDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit CmdQChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit CmdQChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	~CmdQChannelAttrDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/cmdqdeviceattrdatastrategy.h
@@ -8,12 +8,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT CmdQDeviceAttrDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT CmdQDeviceAttrDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit CmdQDeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit CmdQDeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	CmdQDeviceAttrDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/contextattrdatastrategy.h
@@ -7,12 +7,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT ContextAttrDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT ContextAttrDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit ContextAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit ContextAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	ContextAttrDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/deviceattrdatastrategy.h
@@ -28,12 +28,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT DeviceAttrDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT DeviceAttrDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit DeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit DeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	~DeviceAttrDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/datastrategy/multidatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/multidatastrategy.h
@@ -29,7 +29,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT MultiDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT MultiDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
@@ -42,7 +42,8 @@ public:
 	 * added after creation.
 	 * @param parent QWidget*
 	 */
-	explicit MultiDataStrategy(QList<DataStrategyInterface *> strategies, QWidget *parent = nullptr);
+	explicit MultiDataStrategy(QList<DataStrategyInterface *> strategies, QObject *parent = nullptr);
+	~MultiDataStrategy();
 
 	/**
 	 * @brief addDataStrategy Add and connect a new Data Strategy.

--- a/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
+++ b/iio-widgets/include/iio-widgets/datastrategy/triggerdatastrategy.h
@@ -28,12 +28,13 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT TriggerDataStrategy : public QWidget, public DataStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT TriggerDataStrategy : public QObject, public DataStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::DataStrategyInterface)
 public:
-	explicit TriggerDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent = nullptr);
+	explicit TriggerDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent = nullptr);
+	~TriggerDataStrategy();
 
 	QString data() override;
 	QString optionalData() override;

--- a/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/comboguistrategy.h
@@ -29,7 +29,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT ComboAttrUi : public QWidget, public GuiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT ComboAttrUi : public QObject, public GuiStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::GuiStrategyInterface)
@@ -37,7 +37,7 @@ public:
 	/**
 	 * @brief This contain a MenuComboWidget that takes the options for the combo from recipe->linkedAttributeValue.
 	 * */
-	explicit ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
+	explicit ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QObject *parent = nullptr);
 	~ComboAttrUi();
 
 	/**

--- a/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/editableguistrategy.h
@@ -29,7 +29,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT EditableGuiStrategy : public QWidget, public GuiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT EditableGuiStrategy : public QObject, public GuiStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::GuiStrategyInterface)
@@ -37,7 +37,7 @@ public:
 	/**
 	 * @brief This contain a MenuLineEdit with no validation on what the text can or cannot be set.
 	 * */
-	explicit EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
+	explicit EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QObject *parent = nullptr);
 	~EditableGuiStrategy();
 
 	/**

--- a/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/rangeguistrategy.h
@@ -30,7 +30,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT RangeAttrUi : public QWidget, public GuiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT RangeAttrUi : public QObject, public GuiStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::GuiStrategyInterface)
@@ -40,7 +40,7 @@ public:
 	 * string from recipe->linkedAttributeValue should look like "[begin step end]" where "begin", "step" and "end"
 	 * will be converted to double.
 	 * */
-	explicit RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
+	explicit RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QObject *parent = nullptr);
 	~RangeAttrUi();
 
 	/**

--- a/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/switchguistrategy.h
@@ -29,7 +29,7 @@
 #include "scopy-iio-widgets_export.h"
 
 namespace scopy {
-class SCOPY_IIO_WIDGETS_EXPORT SwitchAttrUi : public QWidget, public GuiStrategyInterface
+class SCOPY_IIO_WIDGETS_EXPORT SwitchAttrUi : public QObject, public GuiStrategyInterface
 {
 	Q_OBJECT
 	Q_INTERFACES(scopy::GuiStrategyInterface)
@@ -38,7 +38,7 @@ public:
 	 * @brief This contain a CustomSwitch capable of holding no more than 2 values, the ones specified in
 	 * recipe->linkedAttributeValue.
 	 * */
-	explicit SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
+	explicit SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QObject *parent = nullptr);
 	~SwitchAttrUi();
 
 	/**

--- a/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/channelattrdatastrategy.cpp
@@ -25,12 +25,14 @@
 Q_LOGGING_CATEGORY(CAT_IIO_DATA_STRATEGY, "AttrDataStrategy")
 using namespace scopy;
 
-ChannelAttrDataStrategy::ChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+ChannelAttrDataStrategy::ChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 {
 	m_recipe = recipe;
 	m_returnCode = 0;
 }
+
+ChannelAttrDataStrategy::~ChannelAttrDataStrategy() {}
 
 QString ChannelAttrDataStrategy::data() { return m_data; }
 

--- a/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqchannelattrdatastrategy.cpp
@@ -28,14 +28,16 @@ Q_LOGGING_CATEGORY(CAT_CMDQ_CHANNEL_DATA_STATEGY, "CmdQChannelDataStrategy")
 
 using namespace scopy;
 
-CmdQChannelAttrDataStrategy::CmdQChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+CmdQChannelAttrDataStrategy::CmdQChannelAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 	, m_cmdQueue(recipe.connection->commandQueue())
 	, m_dataRead("")
 	, m_optionalDataRead("")
 {
 	m_recipe = recipe;
 }
+
+CmdQChannelAttrDataStrategy::~CmdQChannelAttrDataStrategy() {}
 
 QString CmdQChannelAttrDataStrategy::data() { return m_dataRead; }
 

--- a/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/cmdqdeviceattrdatastrategy.cpp
@@ -29,14 +29,16 @@ Q_LOGGING_CATEGORY(CAT_CMDQ_DEVICE_DATA_STRATEGY, "CmdQDeviceDataStrategy")
 
 using namespace scopy;
 
-CmdQDeviceAttrDataStrategy::CmdQDeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+CmdQDeviceAttrDataStrategy::CmdQDeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 	, m_cmdQueue(recipe.connection->commandQueue())
 	, m_dataRead("")
 	, m_optionalDataRead("")
 {
 	m_recipe = recipe;
 }
+
+CmdQDeviceAttrDataStrategy::CmdQDeviceAttrDataStrategy() {}
 
 QString CmdQDeviceAttrDataStrategy::data() { return m_dataRead; }
 

--- a/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/contextattrdatastrategy.cpp
@@ -4,12 +4,14 @@
 Q_LOGGING_CATEGORY(CAT_CONTEXT_ATTR_DATA_STRATEGY, "ContextAttrDataStrategy")
 using namespace scopy;
 
-ContextAttrDataStrategy::ContextAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+ContextAttrDataStrategy::ContextAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 {
 	m_recipe = recipe;
 	m_optionalData = "";
 }
+
+ContextAttrDataStrategy::ContextAttrDataStrategy() {}
 
 QString ContextAttrDataStrategy::data() { return m_data; }
 

--- a/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/deviceattrdatastrategy.cpp
@@ -24,11 +24,13 @@
 Q_LOGGING_CATEGORY(CAT_DEVICE_DATA_STRATEGY, "DeviceDataStrategy")
 using namespace scopy;
 
-DeviceAttrDataStrategy::DeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+DeviceAttrDataStrategy::DeviceAttrDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 {
 	m_recipe = recipe;
 }
+
+DeviceAttrDataStrategy::~DeviceAttrDataStrategy() {}
 
 QString DeviceAttrDataStrategy::data() { return m_data; }
 

--- a/iio-widgets/src/datastrategy/multidatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/multidatastrategy.cpp
@@ -3,8 +3,8 @@
 Q_LOGGING_CATEGORY(CAT_MULTI_DATA_STRATEGY, "MultiDataStrategy")
 using namespace scopy;
 
-MultiDataStrategy::MultiDataStrategy(QList<DataStrategyInterface *> strategies, QWidget *parent)
-	: QWidget(parent)
+MultiDataStrategy::MultiDataStrategy(QList<DataStrategyInterface *> strategies, QObject *parent)
+	: QObject(parent)
 	, m_dataStrategies(strategies)
 	, m_data("")
 	, m_optionalData("")
@@ -26,6 +26,8 @@ MultiDataStrategy::MultiDataStrategy(QList<DataStrategyInterface *> strategies, 
 		connect(widgetDS, SIGNAL(aboutToWrite(QString, QString)), this, SIGNAL(aboutToWrite(QString, QString)));
 	}
 }
+
+MultiDataStrategy::~MultiDataStrategy() {}
 
 void MultiDataStrategy::addDataStrategy(DataStrategyInterface *ds)
 {

--- a/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
+++ b/iio-widgets/src/datastrategy/triggerdatastrategy.cpp
@@ -26,11 +26,13 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_TRIGGER_DATA_STRATEGY, "TriggerDataStrategy")
 
-TriggerDataStrategy::TriggerDataStrategy(IIOWidgetFactoryRecipe recipe, QWidget *parent)
-	: QWidget(parent)
+TriggerDataStrategy::TriggerDataStrategy(IIOWidgetFactoryRecipe recipe, QObject *parent)
+	: QObject(parent)
 {
 	m_recipe = recipe;
 }
+
+TriggerDataStrategy::~TriggerDataStrategy() {}
 
 QString TriggerDataStrategy::data() { return m_data; }
 

--- a/iio-widgets/src/guistrategy/comboguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/comboguistrategy.cpp
@@ -23,8 +23,9 @@
 
 using namespace scopy;
 
-ComboAttrUi::ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
-	: m_ui(new QWidget(nullptr))
+ComboAttrUi::ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QObject *parent)
+	: QObject(parent)
+	, m_ui(new QWidget(nullptr))
 	, m_isCompact(isCompact)
 {
 	m_recipe = recipe;
@@ -63,7 +64,7 @@ ComboAttrUi::ComboAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget 
 	Q_EMIT requestData();
 }
 
-ComboAttrUi::~ComboAttrUi() { m_ui->deleteLater(); }
+ComboAttrUi::~ComboAttrUi() {}
 
 QWidget *ComboAttrUi::ui() { return m_ui; }
 

--- a/iio-widgets/src/guistrategy/editableguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/editableguistrategy.cpp
@@ -22,8 +22,8 @@
 
 using namespace scopy;
 
-EditableGuiStrategy::EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
-	: QWidget(parent)
+EditableGuiStrategy::EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isCompact, QObject *parent)
+	: QObject(parent)
 	, m_ui(new QWidget(nullptr))
 	, m_lineEdit(new MenuLineEdit(m_ui))
 {
@@ -55,7 +55,7 @@ EditableGuiStrategy::EditableGuiStrategy(IIOWidgetFactoryRecipe recipe, bool isC
 	Q_EMIT requestData();
 }
 
-EditableGuiStrategy::~EditableGuiStrategy() { m_ui->deleteLater(); }
+EditableGuiStrategy::~EditableGuiStrategy() {}
 
 QWidget *EditableGuiStrategy::ui() { return m_ui; }
 

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -25,8 +25,8 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_ATTR_GUI_STRATEGY, "AttrGuiStrategy")
 
-RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
-	: QWidget(parent)
+RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QObject *parent)
+	: QObject(parent)
 	, m_ui(new QWidget(nullptr))
 {
 	m_recipe = recipe;
@@ -39,7 +39,7 @@ RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget 
 	m_ui->layout()->setContentsMargins(0, 0, 0, 0);
 
 	// FIXME: this does not look right when uninitialized, also crashes...
-	m_spinBox = new TitleSpinBox(m_recipe.data.toUpper(), isCompact, this);
+	m_spinBox = new TitleSpinBox(m_recipe.data.toUpper(), isCompact, m_ui);
 	m_ui->layout()->addWidget(m_spinBox);
 
 	connect(m_spinBox->getLineEdit(), &QLineEdit::textChanged, this,
@@ -47,7 +47,7 @@ RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget 
 	Q_EMIT requestData();
 }
 
-RangeAttrUi::~RangeAttrUi() { m_ui->deleteLater(); }
+RangeAttrUi::~RangeAttrUi() {}
 
 QWidget *RangeAttrUi::ui() { return m_ui; }
 

--- a/iio-widgets/src/guistrategy/switchguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/switchguistrategy.cpp
@@ -25,8 +25,8 @@ using namespace scopy;
 
 Q_LOGGING_CATEGORY(CAT_SWITCHGUISTRATEGY, "SwitchGuiStrategy")
 
-SwitchAttrUi::SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
-	: QWidget(parent)
+SwitchAttrUi::SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QObject *parent)
+	: QObject(parent)
 	, m_ui(new QWidget(nullptr))
 	, m_optionsList(new QStringList)
 {
@@ -43,11 +43,7 @@ SwitchAttrUi::SwitchAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidge
 	});
 }
 
-SwitchAttrUi::~SwitchAttrUi()
-{
-	delete m_optionsList;
-	m_ui->deleteLater();
-}
+SwitchAttrUi::~SwitchAttrUi() { delete m_optionsList; }
 
 QWidget *SwitchAttrUi::ui() { return m_ui; }
 

--- a/plugins/debugger/src/iioexplorer/iiostandarditem.cpp
+++ b/plugins/debugger/src/iioexplorer/iiostandarditem.cpp
@@ -143,7 +143,7 @@ void IIOStandardItem::connectLog()
 	// this is leaf iio widget, it can probably read/write
 	IIOWidget *widget = m_iioWidgets.at(0);
 
-	connect(dynamic_cast<QWidget *>(widget->getDataStrategy()),
+	connect(dynamic_cast<QObject *>(widget->getDataStrategy()),
 		SIGNAL(emitStatus(QDateTime, QString, QString, int, bool)), this,
 		SLOT(forwardLog(QDateTime, QString, QString, int, bool)));
 }


### PR DESCRIPTION
The Data and UI strategy from the IIOWidget are not QObjects, not QWidgets. The LAZY_LOAD function from the IIOWidget now contains only the initial read operation, the setup is done in the constructor.