### PR TITLE
Adc delete tool bug fix

### DIFF
--- a/plugins/adc/src/adcinstrumentcontroller.cpp
+++ b/plugins/adc/src/adcinstrumentcontroller.cpp
@@ -48,7 +48,9 @@ void ADCInstrumentController::setEnableAddRemovePlot(bool) {}
 void ADCInstrumentController::setEnableAddRemoveInstrument(bool b)
 {
 	m_ui->addBtn->setVisible(b);
-	m_ui->removeBtn->setVisible(b);
+	if(!m_isMainInstrument) {
+		m_ui->removeBtn->setVisible(b);
+	}
 }
 
 void ADCInstrumentController::init() {}
@@ -184,6 +186,14 @@ void ADCInstrumentController::setupChannelMeasurement(PlotManager *c, ChannelCom
 		connect(chMeasureManager, &MeasureManagerInterface::enableStat, statsPanel, &StatsPanel::addStat);
 		connect(chMeasureManager, &MeasureManagerInterface::disableStat, statsPanel, &StatsPanel::removeStat);
 	}
+}
+
+bool ADCInstrumentController::isMainInstrument() const { return m_isMainInstrument; }
+
+void ADCInstrumentController::setIsMainInstrument(bool newIsMainInstrument)
+{
+	m_isMainInstrument = newIsMainInstrument;
+	m_ui->removeBtn->setVisible(!newIsMainInstrument);
 }
 
 ADCInstrument *ADCInstrumentController::ui() const { return m_ui; }

--- a/plugins/adc/src/adcinstrumentcontroller.h
+++ b/plugins/adc/src/adcinstrumentcontroller.h
@@ -32,6 +32,9 @@ public:
 public:
 	ADCInstrument *ui() const;
 
+	bool isMainInstrument() const;
+	void setIsMainInstrument(bool newIsMainInstrument);
+
 public Q_SLOTS:
 	virtual void init();
 	virtual void deinit();
@@ -83,6 +86,7 @@ protected:
 	QMap<AcqTreeNode *, ToolComponent *> m_acqNodeComponentMap;
 
 	bool m_refreshTimerRunning;
+	bool m_isMainInstrument = false;
 };
 
 } // namespace adc

--- a/plugins/adc/src/adcplugin.cpp
+++ b/plugins/adc/src/adcplugin.cpp
@@ -304,6 +304,10 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root)
 
 	adc->setEnableAddRemovePlot(Preferences::get("adc_add_remove_plot").toBool());
 	adc->setEnableAddRemoveInstrument(Preferences::get("adc_add_remove_instrument").toBool());
+
+	// prevent user from deleting first time and fft tool
+	if(idx <= 2)
+		adc->setIsMainInstrument(true);
 }
 
 void ADCPlugin::deleteInstrument(ToolMenuEntry *tool)

--- a/plugins/adc/src/adcplugin.cpp
+++ b/plugins/adc/src/adcplugin.cpp
@@ -244,8 +244,7 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root)
 		connect(root, &AcqTreeNode::deletedChild, dynamic_cast<ADCTimeInstrumentController *>(adc),
 			&ADCTimeInstrumentController::removeChannel, Qt::QueuedConnection);
 
-		connect(ui, &ADCInstrument::requestNewInstrument, this,
-			[=](ADCInstrumentType t) { newInstrument(t, root); });
+		connect(ui, &ADCInstrument::requestNewInstrument, this, [=]() { newInstrument(t, root); });
 
 		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [=]() {
 			ToolMenuEntry *t = nullptr;
@@ -278,8 +277,7 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root)
 		connect(root, &AcqTreeNode::deletedChild, dynamic_cast<ADCFFTInstrumentController *>(adc),
 			&ADCFFTInstrumentController::removeChannel, Qt::QueuedConnection);
 
-		connect(ui, &ADCInstrument::requestNewInstrument, this,
-			[=](ADCInstrumentType t) { newInstrument(t, root); });
+		connect(ui, &ADCInstrument::requestNewInstrument, this, [=]() { newInstrument(t, root); });
 
 		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [=]() {
 			ToolMenuEntry *t = nullptr;


### PR DESCRIPTION
Fixed bugs on ADC instrument : 
1) remove tool button will now not be available in first time and fft tool 
2) adding a new tool bug where add will always add a time tool 