### PR TITLE
bugfix: adc bugs on compatible function and hover menu overlap

### DIFF
--- a/plugins/adc/src/adcfftinstrumentcontroller.cpp
+++ b/plugins/adc/src/adcfftinstrumentcontroller.cpp
@@ -50,7 +50,8 @@ void ADCFFTInstrumentController::init()
 	tmp = m_plotComponentManager->addPlot("Frequency Plot");
 	m_fftPlotSettingsComponent->addPlot(dynamic_cast<FFTPlotComponent *>(m_plotComponentManager->plot(tmp)));
 
-	m_measureComponent = new MeasureComponent(m_ui->getToolTemplate(), m_plotComponentManager, this);
+	m_measureComponent = new MeasureComponent(m_ui->getToolTemplate(), m_ui->getHoverMenuBtnGroup(),
+						  m_plotComponentManager, this);
 	m_measureComponent->measureSettings()->getMeasureSection()->setVisible(false);
 	// m_measureComponent->addPlotComponent(m_plotComponentManager);
 

--- a/plugins/adc/src/adcinstrument.cpp
+++ b/plugins/adc/src/adcinstrument.cpp
@@ -65,6 +65,7 @@ void ADCInstrument::setupToolLayout()
 
 	channelsBtn = new MenuControlButton(this);
 
+	hoverMenuGroup = new SemiExclusiveButtonGroup(this);
 	m_cursor = new MenuControlButton(this);
 	setupCursorButtonHelper(m_cursor);
 
@@ -219,6 +220,8 @@ ToolTemplate *ADCInstrument::getToolTemplate() { return tool; }
 
 MapStackedWidget *ADCInstrument::getRightStack() { return rightStack; }
 
+QButtonGroup *ADCInstrument::getHoverMenuBtnGroup() { return hoverMenuGroup; }
+
 void ADCInstrument::setupCursorButtonHelper(MenuControlButton *cursor)
 {
 	cursor->setName("Cursors");
@@ -226,4 +229,5 @@ void ADCInstrument::setupCursorButtonHelper(MenuControlButton *cursor)
 	cursor->setDoubleClickToOpenMenu(true);
 	cursor->checkBox()->setVisible(false);
 	cursor->setCheckBoxStyle(MenuControlButton::CS_SQUARE);
+	hoverMenuGroup->addButton(cursor->button());
 }

--- a/plugins/adc/src/adcinstrument.h
+++ b/plugins/adc/src/adcinstrument.h
@@ -34,6 +34,7 @@ public:
 
 	ToolTemplate *getToolTemplate();
 	MapStackedWidget *getRightStack();
+	QButtonGroup *getHoverMenuBtnGroup();
 
 	int uuid = 0;
 	const QString channelsMenuId = "channels";
@@ -45,7 +46,6 @@ public:
 	VerticalChannelManager *vcm() const;
 
 	QPushButton *sync() const;
-
 public Q_SLOTS:
 	void stopped();
 	void started();
@@ -68,6 +68,7 @@ private:
 	MapStackedWidget *rightStack;
 	QButtonGroup *rightMenuBtnGrp;
 	QButtonGroup *channelGroup;
+	QButtonGroup *hoverMenuGroup;
 
 	AddBtn *addBtn;
 	RemoveBtn *removeBtn;

--- a/plugins/adc/src/adcplugin.cpp
+++ b/plugins/adc/src/adcplugin.cpp
@@ -37,7 +37,7 @@ bool ADCPlugin::compatible(QString m_param, QString category)
 		iio_device *dev = iio_context_get_device(conn->context(), i);
 		for(int j = 0; j < iio_device_get_channels_count(dev); j++) {
 			struct iio_channel *chn = iio_device_get_channel(dev, j);
-			if(iio_channel_is_scan_element(chn)) {
+			if(!iio_channel_is_output(chn) && iio_channel_is_scan_element(chn)) {
 				ret = true;
 				goto finish;
 			}

--- a/plugins/adc/src/adctimeinstrumentcontroller.cpp
+++ b/plugins/adc/src/adctimeinstrumentcontroller.cpp
@@ -49,7 +49,8 @@ void ADCTimeInstrumentController::init()
 	// m_cursorComponent = new CursorComponent(m_plotComponentManager, m_tool->getToolTemplate(), this);
 	// addComponent(m_cursorComponent);
 
-	m_measureComponent = new MeasureComponent(m_ui->getToolTemplate(), m_plotComponentManager, this);
+	m_measureComponent = new MeasureComponent(m_ui->getToolTemplate(), m_ui->getHoverMenuBtnGroup(),
+						  m_plotComponentManager, this);
 	// m_measureComponent->addPlotComponent(m_plotComponentManager);
 
 	addComponent(m_measureComponent);

--- a/plugins/adc/src/measurecomponent.cpp
+++ b/plugins/adc/src/measurecomponent.cpp
@@ -1,13 +1,15 @@
 #include "measurecomponent.h"
 #include "menucontrolbutton.h"
 #include "measurementsettings.h"
-
+#include <QButtonGroup>
 using namespace scopy;
 using namespace scopy::adc;
 
-MeasureComponent::MeasureComponent(ToolTemplate *tool, MeasurementPanelInterface *p, QObject *parent)
+MeasureComponent::MeasureComponent(ToolTemplate *tool, QButtonGroup *btngroup, MeasurementPanelInterface *p,
+				   QObject *parent)
 	: QObject(parent)
 	, ToolComponent()
+	, hoverBtnGroup(btngroup)
 {
 
 	m_measurementPanelInterface = p;
@@ -70,6 +72,7 @@ void MeasureComponent::setupMeasureButtonHelper(MenuControlButton *btn)
 	btn->setOpenMenuChecksThis(true);
 	btn->setDoubleClickToOpenMenu(true);
 	btn->checkBox()->setVisible(false);
+	hoverBtnGroup->addButton(btn->button());
 }
 
 MeasurementSettings *MeasureComponent::measureSettings() { return m_measureSettings; }

--- a/plugins/adc/src/measurecomponent.h
+++ b/plugins/adc/src/measurecomponent.h
@@ -12,12 +12,13 @@ namespace adc {
 class SCOPY_ADC_EXPORT MeasureComponent : public QObject, public ToolComponent
 {
 public:
-	MeasureComponent(ToolTemplate *tool, MeasurementPanelInterface *p, QObject *parent);
+	MeasureComponent(ToolTemplate *tool, QButtonGroup *btngroup, MeasurementPanelInterface *p, QObject *parent);
 	MeasurementSettings *measureSettings();
 
 private:
 	void setupMeasureButtonHelper(MenuControlButton *);
 	MeasurementSettings *m_measureSettings;
+	QButtonGroup *hoverBtnGroup;
 
 	QString measureMenuId = "measure";
 	QString statsMenuId = "stats";


### PR DESCRIPTION
- Fix ADC plugin compat function by checking if the channel is input besides scan elem.
- Fix overlapping hover menus for cursors and measurements by adding a button group.