### PR TITLE
m2kplugin: pass M2k* objects in the constructor rather than iio_context

### DIFF
--- a/plugins/m2k/include/m2k/m2kcontroller.h
+++ b/plugins/m2k/include/m2k/m2kcontroller.h
@@ -23,7 +23,7 @@ public:
 	void startTemperatureTask();
 	void stopTemperatureTask();
 
-	void connectM2k(iio_context *ctx);
+	void connectM2k(libm2k::context::M2k *m2k);
 	void disconnectM2k();
 
 public Q_SLOTS:
@@ -44,7 +44,6 @@ Q_SIGNALS:
 private:
 	M2kReadTemperatureTask *tempTask;
 	M2kIdentifyTask *identifyTask;
-	iio_context *m_iioctx;
 	QString uri;
 	libm2k::context::M2k *m_m2k;
 

--- a/plugins/m2k/include/m2k/m2kplugin.h
+++ b/plugins/m2k/include/m2k/m2kplugin.h
@@ -73,6 +73,8 @@ private:
 	m2k_iio_manager *m2k_man;
 	InfoPage *m_m2kInfoPage;
 
+	libm2k::context::M2k *m_m2k;
+
 	const int PING_PERIOD = 5000;
 	const int infoPageTimerTimeout = 1000;
 	const QStringList calibrationToolNames = {"Oscilloscope",     "Spectrum Analyzer", "Network Analyzer",

--- a/plugins/m2k/src/m2kcontroller.cpp
+++ b/plugins/m2k/src/m2kcontroller.cpp
@@ -39,10 +39,9 @@ void M2kController::stopTemperatureTask()
 	disconnect(tempTask, SIGNAL(newTemperature(double)), this, SIGNAL(newTemperature(double)));
 }
 
-void M2kController::connectM2k(iio_context *ctx)
+void M2kController::connectM2k(libm2k::context::M2k *m2k)
 {
-	m_iioctx = ctx;
-	m_m2k = m2kOpen(ctx, "");
+	m_m2k = m2k;
 	identify();
 }
 
@@ -55,11 +54,9 @@ void M2kController::disconnectM2k()
 		if(identifyTask && identifyTask->isRunning()) {
 			identifyTask->requestInterruption();
 		}
-		contextCloseAll();
 	} catch(std::exception &ex) {
 		qDebug(CAT_M2KPLUGIN) << ex.what();
 	}
-	m_iioctx = nullptr;
 	m_m2k = nullptr;
 }
 

--- a/plugins/m2k/src/old/calibration.hpp
+++ b/plugins/m2k/src/old/calibration.hpp
@@ -32,7 +32,6 @@
 
 extern "C"
 {
-	struct iio_context;
 	struct iio_device;
 	struct iio_channel;
 	struct iio_buffer;
@@ -64,7 +63,7 @@ public:
 		HIGH
 	};
 
-	Calibration(struct iio_context *ctx);
+	Calibration(libm2k::context::M2k *m2k);
 	~Calibration();
 
 	bool initialize();
@@ -88,7 +87,6 @@ private:
 	ApiObject *m_api;
 	volatile bool m_cancel;
 
-	struct iio_context *m_ctx;
 	libm2k::context::M2k *m_m2k;
 	bool m_initialized;
 };

--- a/plugins/m2k/src/old/digitalchannel_manager.cpp
+++ b/plugins/m2k/src/old/digitalchannel_manager.cpp
@@ -51,8 +51,8 @@ namespace scopy {
 
 void DIOManager::init() {}
 
-DIOManager::DIOManager(struct iio_context *ctx, Filter *filt)
-	: m_m2k_context(m2kOpen(ctx, ""))
+DIOManager::DIOManager(libm2k::context::M2k *m2k, Filter *filt)
+	: m_m2k_context(m2k)
 	, digital(m_m2k_context->getDigital())
 {
 	outputEnabled = false;

--- a/plugins/m2k/src/old/digitalchannel_manager.hpp
+++ b/plugins/m2k/src/old/digitalchannel_manager.hpp
@@ -57,7 +57,7 @@ class DIOManager : public QObject
 
 public:
 	void init();
-	DIOManager(struct iio_context *ctx, Filter *filt);
+	DIOManager(libm2k::context::M2k *m2k, Filter *filt);
 	~DIOManager();
 	bool getOutputEnabled();
 	void enableOutput(bool output);

--- a/plugins/m2k/src/old/digitalio.cpp
+++ b/plugins/m2k/src/old/digitalio.cpp
@@ -157,9 +157,9 @@ void DigitalIO::setOutput()
 	}
 }
 
-DigitalIO::DigitalIO(struct iio_context *ctx, Filter *filt, ToolMenuEntry *toolMenuItem, DIOManager *diom,
-		     QJSEngine *engine, QWidget *parent, bool offline_mode)
-	: M2kTool(ctx, toolMenuItem, new DigitalIO_API(this), "Digital IO", parent)
+DigitalIO::DigitalIO(Filter *filt, ToolMenuEntry *toolMenuItem, DIOManager *diom, QJSEngine *engine, QWidget *parent,
+		     bool offline_mode)
+	: M2kTool(toolMenuItem, new DigitalIO_API(this), "Digital IO", parent)
 	, ui(new Ui::DigitalIO)
 	, offline_mode(offline_mode)
 	, diom(diom)

--- a/plugins/m2k/src/old/digitalio.hpp
+++ b/plugins/m2k/src/old/digitalio.hpp
@@ -104,8 +104,8 @@ private Q_SLOTS:
 	void readPreferences() override;
 
 public:
-	explicit DigitalIO(struct iio_context *ctx, Filter *filt, ToolMenuEntry *toolMenuItem, DIOManager *diom,
-			   QJSEngine *engine, QWidget *parent, bool offline_mode = 0);
+	explicit DigitalIO(Filter *filt, ToolMenuEntry *toolMenuItem, DIOManager *diom, QJSEngine *engine,
+			   QWidget *parent, bool offline_mode = 0);
 	~DigitalIO();
 	void setDirection(int ch, int direction);
 	void setOutput(int ch, int out);

--- a/plugins/m2k/src/old/dmm.cpp
+++ b/plugins/m2k/src/old/dmm.cpp
@@ -64,12 +64,12 @@ using namespace scopy::m2k;
 using namespace libm2k;
 using namespace libm2k::context;
 
-DMM::DMM(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man, QWidget *parent)
-	: M2kTool(ctx, tme, new DMM_API(this), "Voltmeter", parent)
+DMM::DMM(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man, QWidget *parent)
+	: M2kTool(tme, new DMM_API(this), "Voltmeter", parent)
 	, ui(new Ui::DMM)
 	, signal(std::make_shared<signal_sample>())
-	, manager(m2k_man->get_instance(ctx, filt->device_name(TOOL_DMM)))
-	, m_m2k_context(m2kOpen(ctx, ""))
+	, manager(m2k_man->get_instance(m2k, filt->device_name(TOOL_DMM)))
+	, m_m2k_context(m2k)
 	, m_m2k_analogin(m_m2k_context->getAnalogIn())
 	, m_adc_nb_channels(m_m2k_analogin->getNbChannels())
 	, interrupt_data_logging(false)

--- a/plugins/m2k/src/old/dmm.hpp
+++ b/plugins/m2k/src/old/dmm.hpp
@@ -59,7 +59,7 @@ class DMM : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit DMM(struct iio_context *ctx, Filter *filt, ToolMenuEntry *toolMenuItem, m2k_iio_manager *m2k_man,
+	explicit DMM(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *toolMenuItem, m2k_iio_manager *m2k_man,
 		     QWidget *parent = nullptr);
 	QPushButton *getRunButton();
 	~DMM();

--- a/plugins/m2k/src/old/iio_manager.hpp
+++ b/plugins/m2k/src/old/iio_manager.hpp
@@ -53,7 +53,7 @@ public:
 	typedef gr::blocks::copy::sptr port_id;
 
 	const unsigned id;
-	iio_manager(unsigned int id, struct iio_context *ctx, QString dev, unsigned long buffer_size);
+	iio_manager(unsigned int id, libm2k::context::M2k *ctx, QString dev, unsigned long buffer_size);
 	~iio_manager();
 
 	/* Connect a block to one of the channels of the IIO source.
@@ -180,7 +180,7 @@ public:
 
 	/* Get a shared pointer to the instance of iio_manager that
 	 * manages the requested device */
-	std::shared_ptr<iio_manager> get_instance(struct iio_context *ctx, QString dev,
+	std::shared_ptr<iio_manager> get_instance(libm2k::context::M2k *ctx, QString dev,
 						  unsigned long buffer_size = IIO_BUFFER_SIZE);
 
 private:

--- a/plugins/m2k/src/old/logicanalyzer/logic_analyzer.cpp
+++ b/plugins/m2k/src/old/logicanalyzer/logic_analyzer.cpp
@@ -72,9 +72,9 @@ static gint sort_pds(gconstpointer a, gconstpointer b)
 	return strcmp(sda->id, sdb->id);
 }
 
-LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
+LogicAnalyzer::LogicAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
 			     QWidget *parent, bool offline_mode_)
-	: M2kTool(nullptr, tme, new LogicAnalyzer_API(this), "Logic Analyzer", parent)
+	: M2kTool(tme, new LogicAnalyzer_API(this), "Logic Analyzer", parent)
 	, ui(new Ui::LogicAnalyzer)
 	, m_plot(this, false, 16, 10, new TimePrefixFormatter, new MetricPrefixFormatter)
 	, m_bufferPreviewer(new DigitalBufferPreviewer(40, this))
@@ -97,7 +97,7 @@ LogicAnalyzer::LogicAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenuEntr
 	, m_sampleRate(1000000)
 	, m_bufferSize(1000)
 	, m_lastCapturedSample(0)
-	, m_m2k_context(m2kOpen(ctx, ""))
+	, m_m2k_context(m2k)
 	, m_m2kDigital(m_m2k_context->getDigital())
 	, m_nbChannels(DIGITAL_NR_CHANNELS)
 	, m_horizOffset(0.0)

--- a/plugins/m2k/src/old/logicanalyzer/logic_analyzer.h
+++ b/plugins/m2k/src/old/logicanalyzer/logic_analyzer.h
@@ -77,7 +77,7 @@ class LogicAnalyzer : public M2kTool
 	friend class LogicAnalyzer_API;
 
 public:
-	explicit LogicAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenuEntry *toolMenuItem, QJSEngine *engine,
+	explicit LogicAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *toolMenuItem, QJSEngine *engine,
 			       QWidget *parent, bool offline_mode_ = 0);
 	~LogicAnalyzer();
 	void setNativeDialogs(bool nativeDialogs) override;

--- a/plugins/m2k/src/old/m2ktool.cpp
+++ b/plugins/m2k/src/old/m2ktool.cpp
@@ -25,9 +25,8 @@
 using namespace scopy;
 using namespace scopy::m2k;
 
-M2kTool::M2kTool(struct iio_context *ctx, ToolMenuEntry *tme, ApiObject *api, const QString &name, QWidget *parent)
+M2kTool::M2kTool(ToolMenuEntry *tme, ApiObject *api, const QString &name, QWidget *parent)
 	: QWidget(parent)
-	, ctx(ctx)
 	, api(api)
 	, name(name)
 	, saveOnExit(true)

--- a/plugins/m2k/src/old/m2ktool.hpp
+++ b/plugins/m2k/src/old/m2ktool.hpp
@@ -52,8 +52,7 @@ class M2kTool : public QWidget, public ResourceUser
 	Q_OBJECT
 
 public:
-	explicit M2kTool(struct iio_context *ctx, ToolMenuEntry *tme, ApiObject *api, const QString &name,
-			 QWidget *parent);
+	explicit M2kTool(ToolMenuEntry *tme, ApiObject *api, const QString &name, QWidget *parent);
 	~M2kTool();
 
 	const QString &getName();
@@ -76,7 +75,6 @@ public Q_SLOTS:
 	virtual void readPreferences();
 
 protected:
-	struct iio_context *ctx;
 	ApiObject *api;
 	QString name;
 	bool saveOnExit;

--- a/plugins/m2k/src/old/manualcalibration.h
+++ b/plugins/m2k/src/old/manualcalibration.h
@@ -102,7 +102,7 @@ class ManualCalibration : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit ManualCalibration(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, QWidget *parent = 0,
+	explicit ManualCalibration(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QWidget *parent = 0,
 				   Calibration *cal = 0);
 
 	~ManualCalibration();
@@ -155,7 +155,6 @@ private:
 	QJSEngine *eng;
 
 	Calibration *calib;
-	iio_context *ctx;
 
 	struct stCalibStory stCalibrationStory;
 	struct stCalibParam stParameters;

--- a/plugins/m2k/src/old/network_analyzer.cpp
+++ b/plugins/m2k/src/old/network_analyzer.cpp
@@ -171,9 +171,9 @@ void NetworkAnalyzer::_configureAdcFlowgraph(size_t buffer_size)
 	ui->btnHelp->setUrl("https://wiki.analog.com/university/tools/m2k/scopy/networkanalyzer");
 }
 
-NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
+NetworkAnalyzer::NetworkAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
 				 QJSEngine *engine, QWidget *parent)
-	: M2kTool(ctx, tme, new NetworkAnalyzer_API(this), "Network Analyzer", parent)
+	: M2kTool(tme, new NetworkAnalyzer_API(this), "Network Analyzer", parent)
 	, ui(new Ui::NetworkAnalyzer)
 	, m_m2k_context(nullptr)
 	, m_m2k_analogin(nullptr)
@@ -198,18 +198,15 @@ NetworkAnalyzer::NetworkAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenu
 	, m_nb_averaging(1)
 	, m_nb_periods(2)
 {
-	if(ctx) {
-		iio = m2k_man->get_instance(ctx, filt->device_name(TOOL_NETWORK_ANALYZER, 2));
-
-		m_m2k_context = m2kOpen(ctx, "");
-		if(m_m2k_context) {
-			m_m2k_analogin = m_m2k_context->getAnalogIn();
-			m_m2k_analogout = m_m2k_context->getAnalogOut();
-			m_adc_nb_channels = m_m2k_analogin->getNbChannels();
-			m_dac_nb_channels = m_m2k_analogout->getNbChannels();
-			m_m2k_analogout->setKernelBuffersCount(0, 1);
-			m_m2k_analogout->setKernelBuffersCount(1, 1);
-		}
+	if(m2k) {
+		m_m2k_context = m2k;
+		iio = m2k_man->get_instance(m_m2k_context, filt->device_name(TOOL_NETWORK_ANALYZER, 2));
+		m_m2k_analogin = m_m2k_context->getAnalogIn();
+		m_m2k_analogout = m_m2k_context->getAnalogOut();
+		m_adc_nb_channels = m_m2k_analogin->getNbChannels();
+		m_dac_nb_channels = m_m2k_analogout->getNbChannels();
+		m_m2k_analogout->setKernelBuffersCount(0, 1);
+		m_m2k_analogout->setKernelBuffersCount(1, 1);
 	}
 
 	ui->setupUi(this);

--- a/plugins/m2k/src/old/network_analyzer.hpp
+++ b/plugins/m2k/src/old/network_analyzer.hpp
@@ -56,11 +56,6 @@
 #include <QStackedWidget>
 #include <QtConcurrentRun>
 
-extern "C"
-{
-	struct iio_context;
-}
-
 namespace Ui {
 class NetworkAnalyzer;
 }
@@ -80,7 +75,7 @@ class NetworkAnalyzer : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit NetworkAnalyzer(struct iio_context *ctx, Filter *filt, ToolMenuEntry *toolMenuItem,
+	explicit NetworkAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *toolMenuItem,
 				 m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent = nullptr);
 	~NetworkAnalyzer();
 	QPushButton *getRunButton();

--- a/plugins/m2k/src/old/oscilloscope.cpp
+++ b/plugins/m2k/src/old/oscilloscope.cpp
@@ -105,10 +105,10 @@ using namespace std::placeholders;
 constexpr int MAX_BUFFER_SIZE_STREAM = 1024 * 1024;
 constexpr int MAX_KERNEL_BUFFERS = 64;
 
-Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
+Oscilloscope::Oscilloscope(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
 			   QJSEngine *engine, QWidget *parent)
-	: M2kTool(ctx, tme, new Oscilloscope_API(this), "Oscilloscope", parent)
-	, m_m2k_context(m2kOpen(ctx, ""))
+	: M2kTool(tme, new Oscilloscope_API(this), "Oscilloscope", parent)
+	, m_m2k_context(m2k)
 	, m_m2k_analogin(m_m2k_context->getAnalogIn())
 	, m_m2k_digital(m_m2k_context->getDigital())
 	, nb_channels(m_m2k_analogin->getNbChannels())
@@ -223,7 +223,7 @@ Oscilloscope::Oscilloscope(struct iio_context *ctx, Filter *filt, ToolMenuEntry 
 	for(uint i = 0; i < nb_channels; i++)
 		fft_plot.setYaxisMouseGesturesEnabled(i, false);
 
-	iio = m2k_man->get_instance(ctx, filt->device_name(TOOL_OSCILLOSCOPE));
+	iio = m2k_man->get_instance(m2k, filt->device_name(TOOL_OSCILLOSCOPE));
 	gr::hier_block2_sptr hier = iio->to_hier_block2();
 	qDebug(CAT_M2K_OSCILLOSCOPE) << "Manager created:\n" << gr::dot_graph(hier).c_str();
 

--- a/plugins/m2k/src/old/oscilloscope.hpp
+++ b/plugins/m2k/src/old/oscilloscope.hpp
@@ -124,7 +124,7 @@ class Oscilloscope : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit Oscilloscope(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
+	explicit Oscilloscope(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
 			      QJSEngine *engine, QWidget *parent = 0);
 	~Oscilloscope();
 

--- a/plugins/m2k/src/old/patterngenerator/pattern_generator.cpp
+++ b/plugins/m2k/src/old/patterngenerator/pattern_generator.cpp
@@ -73,16 +73,16 @@ int lcm(int a, int b)
 
 } // namespace detail
 
-PatternGenerator::PatternGenerator(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
+PatternGenerator::PatternGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
 				   DIOManager *diom, QWidget *parent)
-	: M2kTool(nullptr, tme, new PatternGenerator_API(this), "Pattern Generator", parent)
+	: M2kTool(tme, new PatternGenerator_API(this), "Pattern Generator", parent)
 	, m_ui(new Ui::PatternGenerator)
 	, m_plot(this, false, 16, 10, new TimePrefixFormatter, new MetricPrefixFormatter)
 	, m_plotScrollBar(new QScrollBar(Qt::Vertical, this))
 	, m_selectedChannel(-1)
 	, m_nbChannels(DIGITAL_NR_CHANNELS)
 	, m_currentGroupMenu(nullptr)
-	, m_m2k_context(m2kOpen(ctx, ""))
+	, m_m2k_context(m2k)
 	, m_m2kDigital(m_m2k_context->getDigital())
 	, m_bufferSize(1)
 	, m_sampleRate(1)

--- a/plugins/m2k/src/old/patterngenerator/pattern_generator.h
+++ b/plugins/m2k/src/old/patterngenerator/pattern_generator.h
@@ -67,7 +67,7 @@ class PatternGenerator : public M2kTool
 	friend class PatternGenerator_API;
 
 public:
-	explicit PatternGenerator(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
+	explicit PatternGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
 				  DIOManager *diom, QWidget *parent);
 	~PatternGenerator();
 	void setNativeDialogs(bool nativeDialogs) override;

--- a/plugins/m2k/src/old/power_controller.cpp
+++ b/plugins/m2k/src/old/power_controller.cpp
@@ -46,11 +46,11 @@ using namespace libm2k::analog;
 #include <QLoggingCategory>
 Q_LOGGING_CATEGORY(CAT_M2K_POWERCONTROL, "M2KPowerController");
 
-PowerController::PowerController(struct iio_context *ctx, ToolMenuEntry *tme, QJSEngine *engine, QWidget *parent)
-	: M2kTool(ctx, tme, new PowerController_API(this), "Power Supply", parent)
+PowerController::PowerController(libm2k::context::M2k *m2k, ToolMenuEntry *tme, QJSEngine *engine, QWidget *parent)
+	: M2kTool(tme, new PowerController_API(this), "Power Supply", parent)
 	, ui(new Ui::PowerController)
 	, in_sync(false)
-	, m_m2k_context(m2kOpen(ctx, ""))
+	, m_m2k_context(m2k)
 	, m_m2k_powersupply(m_m2k_context->getPowerSupply())
 {
 	ui->setupUi(this);

--- a/plugins/m2k/src/old/power_controller.hpp
+++ b/plugins/m2k/src/old/power_controller.hpp
@@ -62,7 +62,7 @@ class PowerController : public M2kTool
 public:
 	const int AVERAGE_COUNT = 5;
 
-	explicit PowerController(struct iio_context *ctx, ToolMenuEntry *tme, QJSEngine *engine, QWidget *parent = 0);
+	explicit PowerController(libm2k::context::M2k *m2k, ToolMenuEntry *tme, QJSEngine *engine, QWidget *parent = 0);
 	~PowerController();
 
 public Q_SLOTS:

--- a/plugins/m2k/src/old/signal_generator.cpp
+++ b/plugins/m2k/src/old/signal_generator.cpp
@@ -132,12 +132,12 @@ bool SignalGenerator::chunkCompare(chunk_header_t &ptr, const char *id2)
 	return true;
 }
 
-SignalGenerator::SignalGenerator(struct iio_context *_ctx, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
+SignalGenerator::SignalGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
 				 QWidget *parent)
-	: M2kTool(_ctx, tme, new SignalGenerator_API(this), "Signal Generator", parent)
+	: M2kTool(tme, new SignalGenerator_API(this), "Signal Generator", parent)
 	, ui(new Ui::SignalGenerator)
 	, time_block_data(new struct time_block_data)
-	, m_m2k_context(m2kOpen(ctx, ""))
+	, m_m2k_context(m2k)
 	, m_m2k_analogout(m_m2k_context->getAnalogOut())
 	, nr_of_periods(2)
 	, currentChannel(0)

--- a/plugins/m2k/src/old/signal_generator.hpp
+++ b/plugins/m2k/src/old/signal_generator.hpp
@@ -46,11 +46,6 @@
 #include <libm2k/analog/m2kanalogout.hpp>
 #include <libm2k/m2k.hpp>
 
-extern "C"
-{
-	struct iio_context;
-}
-
 namespace Ui {
 class SignalGenerator;
 }
@@ -143,7 +138,7 @@ class SignalGenerator : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit SignalGenerator(struct iio_context *ctx, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
+	explicit SignalGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
 				 QWidget *parent);
 	~SignalGenerator();
 

--- a/plugins/m2k/src/old/spectrum_analyzer.hpp
+++ b/plugins/m2k/src/old/spectrum_analyzer.hpp
@@ -56,7 +56,6 @@ extern "C"
 {
 	struct iio_buffer;
 	struct iio_channel;
-	struct iio_context;
 	struct iio_device;
 }
 
@@ -121,7 +120,7 @@ public:
 
 	typedef std::shared_ptr<SpectrumChannel> channel_sptr;
 
-	explicit SpectrumAnalyzer(struct iio_context *iio, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
+	explicit SpectrumAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
 				  QJSEngine *engine, QWidget *parent);
 	~SpectrumAnalyzer();
 	QPushButton *getRunButton();
@@ -252,8 +251,6 @@ private:
 private:
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogIn *m_m2k_analogin;
-	libm2k::context::Generic *m_generic_context;
-	libm2k::analog::GenericAnalogIn *m_generic_analogin;
 	Ui::SpectrumAnalyzer *ui;
 	scopy::SmallOnOffSwitch *btnSyncPlotCursors;
 	QHBoxLayout *horizontalLockLayout;


### PR DESCRIPTION
This is related to the libm2k 0.9.0 context ownership changes. This was better described in the following pull request:
https://github.com/analogdevicesinc/scopy/pull/1553 All m2kOpen calls are removed and the only one opening and closing libm2k contexts is the M2kPlugin object.