### PR TITLE
resourcemanager: Append device uri to resource name.

### DIFF
--- a/plugins/adc/src/adcfftinstrumentcontroller.cpp
+++ b/plugins/adc/src/adcfftinstrumentcontroller.cpp
@@ -12,9 +12,9 @@
 using namespace scopy;
 using namespace adc;
 
-ADCFFTInstrumentController::ADCFFTInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree,
+ADCFFTInstrumentController::ADCFFTInstrumentController(ToolMenuEntry *tme, QString uri, QString name, AcqTreeNode *tree,
 						       QObject *parent)
-	: ADCInstrumentController(tme, name, tree, parent)
+	: ADCInstrumentController(tme, uri, name, tree, parent)
 {
 	m_defaultComplexCh = nullptr;
 	m_defaultRealCh = nullptr;

--- a/plugins/adc/src/adcfftinstrumentcontroller.h
+++ b/plugins/adc/src/adcfftinstrumentcontroller.h
@@ -11,7 +11,8 @@ class FFTPlotManagerSettings;
 class SCOPY_ADC_EXPORT ADCFFTInstrumentController : public ADCInstrumentController
 {
 public:
-	ADCFFTInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree, QObject *parent = nullptr);
+	ADCFFTInstrumentController(ToolMenuEntry *tme, QString uri, QString name, AcqTreeNode *tree,
+				   QObject *parent = nullptr);
 	~ADCFFTInstrumentController();
 	virtual void init() override;
 	virtual void addChannel(AcqTreeNode *node) override;

--- a/plugins/adc/src/adcinstrumentcontroller.cpp
+++ b/plugins/adc/src/adcinstrumentcontroller.cpp
@@ -8,13 +8,15 @@
 using namespace scopy;
 using namespace scopy::adc;
 
-ADCInstrumentController::ADCInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree, QObject *parent)
+ADCInstrumentController::ADCInstrumentController(ToolMenuEntry *tme, QString uri, QString name, AcqTreeNode *tree,
+						 QObject *parent)
 	: QObject(parent)
 	, m_refreshTimerRunning(false)
 	, m_plotComponentManager(nullptr)
 	, m_measureComponent(nullptr)
 	, m_started(false)
 	, m_tme(tme)
+	, m_uri(uri)
 {
 	chIdP = new ChannelIdProvider(this);
 	m_tree = tree;
@@ -84,7 +86,7 @@ void ADCInstrumentController::onStop()
 
 void ADCInstrumentController::start()
 {
-	ResourceManager::open("adc" + m_tme->param(), this);
+	ResourceManager::open("adc" + m_uri, this);
 	bool ret = m_dataProvider->start();
 	if(!ret) {
 		Q_EMIT requestDisconnect();
@@ -94,7 +96,7 @@ void ADCInstrumentController::start()
 void ADCInstrumentController::stop()
 {
 	m_dataProvider->stop();
-	ResourceManager::close("adc" + m_tme->param());
+	ResourceManager::close("adc" + m_uri);
 }
 
 void ADCInstrumentController::stopUpdates()

--- a/plugins/adc/src/adcinstrumentcontroller.cpp
+++ b/plugins/adc/src/adcinstrumentcontroller.cpp
@@ -14,6 +14,7 @@ ADCInstrumentController::ADCInstrumentController(ToolMenuEntry *tme, QString nam
 	, m_plotComponentManager(nullptr)
 	, m_measureComponent(nullptr)
 	, m_started(false)
+	, m_tme(tme)
 {
 	chIdP = new ChannelIdProvider(this);
 	m_tree = tree;
@@ -83,7 +84,7 @@ void ADCInstrumentController::onStop()
 
 void ADCInstrumentController::start()
 {
-	ResourceManager::open("adc", this);
+	ResourceManager::open("adc" + m_tme->param(), this);
 	bool ret = m_dataProvider->start();
 	if(!ret) {
 		Q_EMIT requestDisconnect();
@@ -93,7 +94,7 @@ void ADCInstrumentController::start()
 void ADCInstrumentController::stop()
 {
 	m_dataProvider->stop();
-	ResourceManager::close("adc");
+	ResourceManager::close("adc" + m_tme->param());
 }
 
 void ADCInstrumentController::stopUpdates()

--- a/plugins/adc/src/adcinstrumentcontroller.h
+++ b/plugins/adc/src/adcinstrumentcontroller.h
@@ -26,7 +26,8 @@ class SCOPY_ADC_EXPORT ADCInstrumentController : public QObject,
 {
 	Q_OBJECT
 public:
-	ADCInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree, QObject *parent = nullptr);
+	ADCInstrumentController(ToolMenuEntry *tme, QString uri, QString name, AcqTreeNode *tree,
+				QObject *parent = nullptr);
 	virtual ~ADCInstrumentController();
 
 	ChannelIdProvider *getChannelIdProvider();
@@ -94,6 +95,7 @@ protected:
 	bool m_isMainInstrument = false;
 
 	ToolMenuEntry *m_tme;
+	QString m_uri;
 };
 
 } // namespace adc

--- a/plugins/adc/src/adcinstrumentcontroller.h
+++ b/plugins/adc/src/adcinstrumentcontroller.h
@@ -92,6 +92,8 @@ protected:
 
 	bool m_refreshTimerRunning;
 	bool m_isMainInstrument = false;
+
+	ToolMenuEntry *m_tme;
 };
 
 } // namespace adc

--- a/plugins/adc/src/adcplugin.cpp
+++ b/plugins/adc/src/adcplugin.cpp
@@ -246,7 +246,7 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root, GRTopBlock
 		tme->setEnabled(true);
 		tme->setRunBtnVisible(true);
 
-		adc = new ADCTimeInstrumentController(tme, "adc" + QString::number(idx), root, this);
+		adc = new ADCTimeInstrumentController(tme, m_param, "adc" + QString::number(idx), root, this);
 		adc->init();
 
 		ui = adc->ui();
@@ -284,7 +284,7 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root, GRTopBlock
 		tme->setEnabled(true);
 		tme->setRunBtnVisible(true);
 
-		adc = new ADCFFTInstrumentController(tme, "adc" + QString::number(idx), root, this);
+		adc = new ADCFFTInstrumentController(tme, m_param, "adc" + QString::number(idx), root, this);
 		adc->init();
 		ui = adc->ui();
 		idx++;

--- a/plugins/adc/src/adctimeinstrumentcontroller.cpp
+++ b/plugins/adc/src/adctimeinstrumentcontroller.cpp
@@ -8,9 +8,9 @@
 using namespace scopy;
 using namespace adc;
 
-ADCTimeInstrumentController::ADCTimeInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree,
-							 QObject *parent)
-	: ADCInstrumentController(tme, name, tree, parent)
+ADCTimeInstrumentController::ADCTimeInstrumentController(ToolMenuEntry *tme, QString uri, QString name,
+							 AcqTreeNode *tree, QObject *parent)
+	: ADCInstrumentController(tme, uri, name, tree, parent)
 {
 	m_defaultCh = nullptr;
 }

--- a/plugins/adc/src/adctimeinstrumentcontroller.h
+++ b/plugins/adc/src/adctimeinstrumentcontroller.h
@@ -10,7 +10,8 @@ namespace adc {
 class SCOPY_ADC_EXPORT ADCTimeInstrumentController : public ADCInstrumentController
 {
 public:
-	ADCTimeInstrumentController(ToolMenuEntry *tme, QString name, AcqTreeNode *tree, QObject *parent = nullptr);
+	ADCTimeInstrumentController(ToolMenuEntry *tme, QString uri, QString name, AcqTreeNode *tree,
+				    QObject *parent = nullptr);
 	~ADCTimeInstrumentController();
 	virtual void init() override;
 	virtual void addChannel(AcqTreeNode *node) override;

--- a/plugins/m2k/src/m2kplugin.cpp
+++ b/plugins/m2k/src/m2kplugin.cpp
@@ -423,7 +423,7 @@ bool M2kPlugin::onConnect()
 		auto pgTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "m2kpattern");
 		m_adcBtnGrp = new QButtonGroup(this);
 
-		tools.insert("m2kdmm", new DMM(m_m2k, f, dmmTme, m2k_man));
+		tools.insert("m2kdmm", new DMM(m_m2k, m_param, f, dmmTme, m2k_man));
 		dmmTme->setTool(tools["m2kdmm"]);
 		tools.insert("m2kcal", new ManualCalibration(m_m2k, f, mancalTme, nullptr, calib));
 		mancalTme->setTool(tools["m2kcal"]);
@@ -431,13 +431,13 @@ bool M2kPlugin::onConnect()
 		dioTme->setTool(tools["m2kdio"]);
 		tools.insert("m2kpower", new PowerController(m_m2k, pwrTme, js, nullptr));
 		pwrTme->setTool(tools["m2kpower"]);
-		tools.insert("m2ksiggen", new SignalGenerator(m_m2k, f, siggenTme, js, nullptr));
+		tools.insert("m2ksiggen", new SignalGenerator(m_m2k, m_param, f, siggenTme, js, nullptr));
 		siggenTme->setTool(tools["m2ksiggen"]);
-		tools.insert("m2kspec", new SpectrumAnalyzer(m_m2k, f, specTme, m2k_man, js, nullptr));
+		tools.insert("m2kspec", new SpectrumAnalyzer(m_m2k, m_param, f, specTme, m2k_man, js, nullptr));
 		specTme->setTool(tools["m2kspec"]);
-		tools.insert("m2kosc", new Oscilloscope(m_m2k, f, oscTme, m2k_man, js, nullptr));
+		tools.insert("m2kosc", new Oscilloscope(m_m2k, m_param, f, oscTme, m2k_man, js, nullptr));
 		oscTme->setTool(tools["m2kosc"]);
-		tools.insert("m2knet", new NetworkAnalyzer(m_m2k, f, netTme, m2k_man, js, nullptr));
+		tools.insert("m2knet", new NetworkAnalyzer(m_m2k, m_param, f, netTme, m2k_man, js, nullptr));
 		netTme->setTool(tools["m2knet"]);
 		tools.insert("m2klogic", new logic::LogicAnalyzer(m_m2k, f, laTme, js, nullptr));
 		laTme->setTool(tools["m2klogic"]);

--- a/plugins/m2k/src/old/dmm.cpp
+++ b/plugins/m2k/src/old/dmm.cpp
@@ -494,7 +494,7 @@ void DMM::toggleTimer(bool start)
 {
 	enableDataLogging(start);
 	if(start) {
-		ResourceManager::open("m2k-adc", this);
+		ResourceManager::open("m2k-adc" + tme->param(), this);
 		manager->set_kernel_buffer_count(4);
 		writeAllSettingsToHardware();
 		manager->start(id_ch1);
@@ -509,7 +509,7 @@ void DMM::toggleTimer(bool start)
 		manager->stop(id_ch1);
 		manager->stop(id_ch2);
 		manager->set_kernel_buffer_count();
-		ResourceManager::close("m2k-adc");
+		ResourceManager::close("m2k-adc" + tme->param());
 	}
 
 	setDynamicProperty(ui->run_button, "running", start);

--- a/plugins/m2k/src/old/dmm.cpp
+++ b/plugins/m2k/src/old/dmm.cpp
@@ -64,7 +64,8 @@ using namespace scopy::m2k;
 using namespace libm2k;
 using namespace libm2k::context;
 
-DMM::DMM(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man, QWidget *parent)
+DMM::DMM(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
+	 QWidget *parent)
 	: M2kTool(tme, new DMM_API(this), "Voltmeter", parent)
 	, ui(new Ui::DMM)
 	, signal(std::make_shared<signal_sample>())
@@ -80,6 +81,7 @@ DMM::DMM(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_ma
 	, wheelEventGuard(nullptr)
 	, m_autoGainEnabled({true, true})
 	, m_gainHistorySize(25)
+	, m_uri(uri)
 {
 	ui->setupUi(this);
 
@@ -494,7 +496,7 @@ void DMM::toggleTimer(bool start)
 {
 	enableDataLogging(start);
 	if(start) {
-		ResourceManager::open("m2k-adc" + tme->param(), this);
+		ResourceManager::open("m2k-adc" + m_uri, this);
 		manager->set_kernel_buffer_count(4);
 		writeAllSettingsToHardware();
 		manager->start(id_ch1);
@@ -509,7 +511,7 @@ void DMM::toggleTimer(bool start)
 		manager->stop(id_ch1);
 		manager->stop(id_ch2);
 		manager->set_kernel_buffer_count();
-		ResourceManager::close("m2k-adc" + tme->param());
+		ResourceManager::close("m2k-adc" + m_uri);
 	}
 
 	setDynamicProperty(ui->run_button, "running", start);

--- a/plugins/m2k/src/old/dmm.hpp
+++ b/plugins/m2k/src/old/dmm.hpp
@@ -59,12 +59,13 @@ class DMM : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit DMM(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *toolMenuItem, m2k_iio_manager *m2k_man,
-		     QWidget *parent = nullptr);
+	explicit DMM(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *toolMenuItem,
+		     m2k_iio_manager *m2k_man, QWidget *parent = nullptr);
 	QPushButton *getRunButton();
 	~DMM();
 
 private:
+	QString m_uri;
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogIn *m_m2k_analogin;
 	unsigned int m_adc_nb_channels;

--- a/plugins/m2k/src/old/network_analyzer.cpp
+++ b/plugins/m2k/src/old/network_analyzer.cpp
@@ -1614,8 +1614,8 @@ void NetworkAnalyzer::startStop(bool pressed)
 	ui->spinBox_periods->setEnabled(!pressed);
 
 	if(pressed) {
-		ResourceManager::open("m2k-adc", this);
-		ResourceManager::open("m2k-dac", this);
+		ResourceManager::open("m2k-adc" + tme->param(), this);
+		ResourceManager::open("m2k-dac" + tme->param(), this);
 		m_m2k_analogin->setKernelBuffersCount(1);
 		if(shouldClear) {
 			m_dBgraph.reset();
@@ -1647,8 +1647,8 @@ void NetworkAnalyzer::startStop(bool pressed)
 		m_dBgraph.sweepDone();
 		m_phaseGraph.sweepDone();
 		ui->statusLabel->setText(tr("Stopped"));
-		ResourceManager::close("m2k-dac");
-		ResourceManager::close("m2k-adc");
+		ResourceManager::close("m2k-dac" + tme->param());
+		ResourceManager::close("m2k-adc" + tme->param());
 		try {
 			m_m2k_analogin->setKernelBuffersCount(KERNEL_BUFFERS_DEFAULT);
 		} catch(libm2k::m2k_exception &e) {

--- a/plugins/m2k/src/old/network_analyzer.cpp
+++ b/plugins/m2k/src/old/network_analyzer.cpp
@@ -171,8 +171,8 @@ void NetworkAnalyzer::_configureAdcFlowgraph(size_t buffer_size)
 	ui->btnHelp->setUrl("https://wiki.analog.com/university/tools/m2k/scopy/networkanalyzer");
 }
 
-NetworkAnalyzer::NetworkAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
-				 QJSEngine *engine, QWidget *parent)
+NetworkAnalyzer::NetworkAnalyzer(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+				 m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent)
 	: M2kTool(tme, new NetworkAnalyzer_API(this), "Network Analyzer", parent)
 	, ui(new Ui::NetworkAnalyzer)
 	, m_m2k_context(nullptr)
@@ -197,6 +197,7 @@ NetworkAnalyzer::NetworkAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMe
 	, m_importDataLoaded(false)
 	, m_nb_averaging(1)
 	, m_nb_periods(2)
+	, m_uri(uri)
 {
 	if(m2k) {
 		m_m2k_context = m2k;
@@ -1614,8 +1615,8 @@ void NetworkAnalyzer::startStop(bool pressed)
 	ui->spinBox_periods->setEnabled(!pressed);
 
 	if(pressed) {
-		ResourceManager::open("m2k-adc" + tme->param(), this);
-		ResourceManager::open("m2k-dac" + tme->param(), this);
+		ResourceManager::open("m2k-adc" + m_uri, this);
+		ResourceManager::open("m2k-dac" + m_uri, this);
 		m_m2k_analogin->setKernelBuffersCount(1);
 		if(shouldClear) {
 			m_dBgraph.reset();
@@ -1647,8 +1648,8 @@ void NetworkAnalyzer::startStop(bool pressed)
 		m_dBgraph.sweepDone();
 		m_phaseGraph.sweepDone();
 		ui->statusLabel->setText(tr("Stopped"));
-		ResourceManager::close("m2k-dac" + tme->param());
-		ResourceManager::close("m2k-adc" + tme->param());
+		ResourceManager::close("m2k-dac" + m_uri);
+		ResourceManager::close("m2k-adc" + m_uri);
 		try {
 			m_m2k_analogin->setKernelBuffersCount(KERNEL_BUFFERS_DEFAULT);
 		} catch(libm2k::m2k_exception &e) {

--- a/plugins/m2k/src/old/network_analyzer.hpp
+++ b/plugins/m2k/src/old/network_analyzer.hpp
@@ -75,7 +75,7 @@ class NetworkAnalyzer : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit NetworkAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *toolMenuItem,
+	explicit NetworkAnalyzer(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *toolMenuItem,
 				 m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent = nullptr);
 	~NetworkAnalyzer();
 	QPushButton *getRunButton();
@@ -83,6 +83,7 @@ public:
 
 private:
 	Ui::NetworkAnalyzer *ui;
+	QString m_uri;
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogOut *m_m2k_analogout;
 	libm2k::analog::M2kAnalogIn *m_m2k_analogin;

--- a/plugins/m2k/src/old/oscilloscope.cpp
+++ b/plugins/m2k/src/old/oscilloscope.cpp
@@ -105,8 +105,8 @@ using namespace std::placeholders;
 constexpr int MAX_BUFFER_SIZE_STREAM = 1024 * 1024;
 constexpr int MAX_KERNEL_BUFFERS = 64;
 
-Oscilloscope::Oscilloscope(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
-			   QJSEngine *engine, QWidget *parent)
+Oscilloscope::Oscilloscope(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+			   m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent)
 	: M2kTool(tme, new Oscilloscope_API(this), "Oscilloscope", parent)
 	, m_m2k_context(m2k)
 	, m_m2k_analogin(m_m2k_context->getAnalogIn())
@@ -161,6 +161,7 @@ Oscilloscope::Oscilloscope(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntr
 	, m_logicAnalyzer(nullptr)
 	, m_mixedSignalViewEnabled(false)
 	, logic_top_block(nullptr)
+	, m_uri(uri)
 {
 	ui->setupUi(this);
 	int triggers_panel = ui->stackedWidget->insertWidget(-1, &trigger_settings);
@@ -2718,7 +2719,7 @@ void Oscilloscope::runStopToggled(bool checked)
 	Q_EMIT activateExportButton();
 
 	if(checked) {
-		ResourceManager::open("m2k-adc" + tme->param(), this);
+		ResourceManager::open("m2k-adc" + m_uri, this);
 		periodicFlowRestart(true);
 		if(symmBufferMode->isEnhancedMemDepth()) {
 			onCmbMemoryDepthChanged(ch_ui->cmbMemoryDepth->currentText());
@@ -2754,7 +2755,7 @@ void Oscilloscope::runStopToggled(bool checked)
 		toggle_blockchain_flow(false);
 		resetStreamingFlag(symmBufferMode->isEnhancedMemDepth() || plot_samples_sequentially);
 		trigger_settings.setAdcRunningState(false);
-		ResourceManager::close("m2k-adc" + tme->param());
+		ResourceManager::close("m2k-adc" + m_uri);
 	}
 
 	// Update trigger status

--- a/plugins/m2k/src/old/oscilloscope.cpp
+++ b/plugins/m2k/src/old/oscilloscope.cpp
@@ -2718,7 +2718,7 @@ void Oscilloscope::runStopToggled(bool checked)
 	Q_EMIT activateExportButton();
 
 	if(checked) {
-		ResourceManager::open("m2k-adc", this);
+		ResourceManager::open("m2k-adc" + tme->param(), this);
 		periodicFlowRestart(true);
 		if(symmBufferMode->isEnhancedMemDepth()) {
 			onCmbMemoryDepthChanged(ch_ui->cmbMemoryDepth->currentText());
@@ -2754,7 +2754,7 @@ void Oscilloscope::runStopToggled(bool checked)
 		toggle_blockchain_flow(false);
 		resetStreamingFlag(symmBufferMode->isEnhancedMemDepth() || plot_samples_sequentially);
 		trigger_settings.setAdcRunningState(false);
-		ResourceManager::close("m2k-adc");
+		ResourceManager::close("m2k-adc" + tme->param());
 	}
 
 	// Update trigger status

--- a/plugins/m2k/src/old/oscilloscope.hpp
+++ b/plugins/m2k/src/old/oscilloscope.hpp
@@ -124,8 +124,8 @@ class Oscilloscope : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit Oscilloscope(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
-			      QJSEngine *engine, QWidget *parent = 0);
+	explicit Oscilloscope(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+			      m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent = 0);
 	~Oscilloscope();
 
 	QPushButton *getRunButton();
@@ -260,6 +260,7 @@ public Q_SLOTS:
 	void stop() override;
 
 private:
+	QString m_uri;
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogIn *m_m2k_analogin;
 	libm2k::digital::M2kDigital *m_m2k_digital;

--- a/plugins/m2k/src/old/signal_generator.cpp
+++ b/plugins/m2k/src/old/signal_generator.cpp
@@ -1315,7 +1315,7 @@ void SignalGenerator::start()
 		return;
 	}
 
-	ResourceManager::open("m2k-dac", this);
+	ResourceManager::open("m2k-dac" + tme->param(), this);
 	m_m2k_analogout->cancelBuffer();
 
 	for(auto it = channels.begin(); it != channels.end(); ++it) {
@@ -1397,7 +1397,7 @@ void SignalGenerator::stop()
 		HANDLE_EXCEPTION(e);
 		qDebug(CAT_M2K_SIGNAL_GENERATOR) << e.what();
 	}
-	ResourceManager::close("m2k-dac");
+	ResourceManager::close("m2k-dac" + tme->param());
 }
 
 void SignalGenerator::startStop(bool pressed)

--- a/plugins/m2k/src/old/signal_generator.cpp
+++ b/plugins/m2k/src/old/signal_generator.cpp
@@ -132,8 +132,8 @@ bool SignalGenerator::chunkCompare(chunk_header_t &ptr, const char *id2)
 	return true;
 }
 
-SignalGenerator::SignalGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
-				 QWidget *parent)
+SignalGenerator::SignalGenerator(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+				 QJSEngine *engine, QWidget *parent)
 	: M2kTool(tme, new SignalGenerator_API(this), "Signal Generator", parent)
 	, ui(new Ui::SignalGenerator)
 	, time_block_data(new struct time_block_data)
@@ -146,6 +146,7 @@ SignalGenerator::SignalGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMe
 	, nb_points(NB_POINTS)
 	, channels_group(new QButtonGroup(this))
 	, m_maxNbOfSamples(4 * 1024 * 1024)
+	, m_uri(uri)
 {
 	zoomT1 = 0;
 	zoomT2 = 1;
@@ -1315,7 +1316,7 @@ void SignalGenerator::start()
 		return;
 	}
 
-	ResourceManager::open("m2k-dac" + tme->param(), this);
+	ResourceManager::open("m2k-dac" + m_uri, this);
 	m_m2k_analogout->cancelBuffer();
 
 	for(auto it = channels.begin(); it != channels.end(); ++it) {
@@ -1397,7 +1398,7 @@ void SignalGenerator::stop()
 		HANDLE_EXCEPTION(e);
 		qDebug(CAT_M2K_SIGNAL_GENERATOR) << e.what();
 	}
-	ResourceManager::close("m2k-dac" + tme->param());
+	ResourceManager::close("m2k-dac" + m_uri);
 }
 
 void SignalGenerator::startStop(bool pressed)

--- a/plugins/m2k/src/old/signal_generator.hpp
+++ b/plugins/m2k/src/old/signal_generator.hpp
@@ -138,8 +138,8 @@ class SignalGenerator : public M2kTool
 	Q_OBJECT
 
 public:
-	explicit SignalGenerator(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, QJSEngine *engine,
-				 QWidget *parent);
+	explicit SignalGenerator(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+				 QJSEngine *engine, QWidget *parent);
 	~SignalGenerator();
 
 	static const size_t min_buffer_size = 1024;
@@ -152,6 +152,7 @@ public:
 
 private:
 	const size_t m_maxNbOfSamples;
+	QString m_uri;
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogOut *m_m2k_analogout;
 

--- a/plugins/m2k/src/old/spectrum_analyzer.cpp
+++ b/plugins/m2k/src/old/spectrum_analyzer.cpp
@@ -127,7 +127,7 @@ void SpectrumAnalyzer::initInstrumentStrings()
 	};
 }
 
-SpectrumAnalyzer::SpectrumAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme,
+SpectrumAnalyzer::SpectrumAnalyzer(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
 				   m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent)
 	: M2kTool(tme, new SpectrumAnalyzer_API(this), "Spectrum Analyzer", parent)
 	, ui(new Ui::SpectrumAnalyzer)
@@ -155,6 +155,7 @@ SpectrumAnalyzer::SpectrumAnalyzer(libm2k::context::M2k *m2k, Filter *filt, Tool
 	, fft_ids(nullptr)
 	, m_nb_overlapping_avg(1)
 	, use_float_sink(true)
+	, m_uri(uri)
 {
 	initInstrumentStrings();
 	// Get the list of names of the available channels
@@ -1978,7 +1979,7 @@ void SpectrumAnalyzer::runStopToggled(bool checked)
 	}
 
 	if(checked) {
-		ResourceManager::open("m2k-adc" + tme->param(), this);
+		ResourceManager::open("m2k-adc" + m_uri, this);
 
 		if(iio) {
 			writeAllSettingsToHardware();
@@ -1992,7 +1993,7 @@ void SpectrumAnalyzer::runStopToggled(bool checked)
 	} else {
 		stop_blockchain_flow();
 		sample_timer->stop();
-		ResourceManager::close("m2k-adc" + tme->param());
+		ResourceManager::close("m2k-adc" + m_uri);
 	}
 
 	if(!checked) {

--- a/plugins/m2k/src/old/spectrum_analyzer.cpp
+++ b/plugins/m2k/src/old/spectrum_analyzer.cpp
@@ -1978,7 +1978,7 @@ void SpectrumAnalyzer::runStopToggled(bool checked)
 	}
 
 	if(checked) {
-		ResourceManager::open("m2k-adc", this);
+		ResourceManager::open("m2k-adc" + tme->param(), this);
 
 		if(iio) {
 			writeAllSettingsToHardware();
@@ -1992,7 +1992,7 @@ void SpectrumAnalyzer::runStopToggled(bool checked)
 	} else {
 		stop_blockchain_flow();
 		sample_timer->stop();
-		ResourceManager::close("m2k-adc");
+		ResourceManager::close("m2k-adc" + tme->param());
 	}
 
 	if(!checked) {

--- a/plugins/m2k/src/old/spectrum_analyzer.hpp
+++ b/plugins/m2k/src/old/spectrum_analyzer.hpp
@@ -120,8 +120,8 @@ public:
 
 	typedef std::shared_ptr<SpectrumChannel> channel_sptr;
 
-	explicit SpectrumAnalyzer(libm2k::context::M2k *m2k, Filter *filt, ToolMenuEntry *tme, m2k_iio_manager *m2k_man,
-				  QJSEngine *engine, QWidget *parent);
+	explicit SpectrumAnalyzer(libm2k::context::M2k *m2k, QString uri, Filter *filt, ToolMenuEntry *tme,
+				  m2k_iio_manager *m2k_man, QJSEngine *engine, QWidget *parent);
 	~SpectrumAnalyzer();
 	QPushButton *getRunButton();
 	void setNativeDialogs(bool nativeDialogs) override;
@@ -249,6 +249,7 @@ private:
 	bool use_float_sink;
 
 private:
+	QString m_uri;
 	libm2k::context::M2k *m_m2k_context;
 	libm2k::analog::M2kAnalogIn *m_m2k_analogin;
 	Ui::SpectrumAnalyzer *ui;

--- a/plugins/pqm/include/pqm/harmonicsinstrument.h
+++ b/plugins/pqm/include/pqm/harmonicsinstrument.h
@@ -1,6 +1,7 @@
 #ifndef HARMONICSINSTRUMENT_H
 #define HARMONICSINSTRUMENT_H
 
+#include "pluginbase/toolmenuentry.h"
 #include <gui/widgets/menucombo.h>
 #include <scopy-pqm_export.h>
 #include <gui/plotwidget.h>
@@ -23,7 +24,7 @@ class SCOPY_PQM_EXPORT HarmonicsInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	HarmonicsInstrument(QWidget *parent = nullptr);
+	HarmonicsInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
 	~HarmonicsInstrument();
 
 	void showThdWidget(bool show);
@@ -33,7 +34,6 @@ public Q_SLOTS:
 	void onAttrAvailable(QMap<QString, QMap<QString, QString>> attr);
 Q_SIGNALS:
 	void enableTool(bool en, QString toolName = "harmonics");
-	void runTme(bool en);
 private Q_SLOTS:
 	void updateTable();
 	void onActiveChnlChannged(QString chnlId);
@@ -58,6 +58,7 @@ private:
 	QMap<QString, std::vector<double>> m_yValues;
 	QMap<QString, MeasurementLabel *> m_labels;
 	QMap<QString, PlotChannel *> m_plotChnls;
+	ToolMenuEntry *m_tme;
 	// keys - used for UI labels; values - context channels name
 	const QMap<QString, QString> m_chnls = {{"Ia", "ia"}, {"Ib", "ib"}, {"Ic", "ic"},
 						{"Ua", "ua"}, {"Ub", "ub"}, {"Uc", "uc"}};

--- a/plugins/pqm/include/pqm/harmonicsinstrument.h
+++ b/plugins/pqm/include/pqm/harmonicsinstrument.h
@@ -24,7 +24,7 @@ class SCOPY_PQM_EXPORT HarmonicsInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	HarmonicsInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
+	HarmonicsInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent = nullptr);
 	~HarmonicsInstrument();
 
 	void showThdWidget(bool show);
@@ -48,6 +48,7 @@ private:
 	QWidget *createSettingsMenu();
 	bool selectedFromSameCol(QModelIndexList list);
 
+	QString m_uri;
 	QString m_harmonicsType;
 	QWidget *m_thdWidget;
 	RunBtn *m_runBtn;

--- a/plugins/pqm/include/pqm/rmsinstrument.h
+++ b/plugins/pqm/include/pqm/rmsinstrument.h
@@ -8,6 +8,7 @@
 #include <gui/widgets/menucontrolbutton.h>
 #include <gui/widgets/toolbuttons.h>
 #include <pluginbase/resourcemanager.h>
+#include <pluginbase/toolmenuentry.h>
 
 #define DEVICE_NAME "pqm"
 
@@ -16,12 +17,11 @@ class SCOPY_PQM_EXPORT RmsInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	RmsInstrument(QWidget *parent = nullptr);
+	RmsInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
 	~RmsInstrument();
 
 Q_SIGNALS:
 	void enableTool(bool en, QString toolName = "rms");
-	void runTme(bool en);
 public Q_SLOTS:
 	void stop() override;
 	void toggleRms(bool en);
@@ -35,6 +35,7 @@ private:
 	void updatePlot(PolarPlotWidget *plot, QString type);
 	QVector<QwtPointPolar> getPolarPlotPoints(QString chnlType);
 
+	ToolMenuEntry *m_tme;
 	RunBtn *m_runBtn;
 	SingleShotBtn *m_singleBtn;
 	PolarPlotWidget *m_voltagePlot;

--- a/plugins/pqm/include/pqm/rmsinstrument.h
+++ b/plugins/pqm/include/pqm/rmsinstrument.h
@@ -17,7 +17,7 @@ class SCOPY_PQM_EXPORT RmsInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	RmsInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
+	RmsInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent = nullptr);
 	~RmsInstrument();
 
 Q_SIGNALS:
@@ -35,6 +35,7 @@ private:
 	void updatePlot(PolarPlotWidget *plot, QString type);
 	QVector<QwtPointPolar> getPolarPlotPoints(QString chnlType);
 
+	QString m_uri;
 	ToolMenuEntry *m_tme;
 	RunBtn *m_runBtn;
 	SingleShotBtn *m_singleBtn;

--- a/plugins/pqm/include/pqm/waveforminstrument.h
+++ b/plugins/pqm/include/pqm/waveforminstrument.h
@@ -12,6 +12,7 @@
 #include <gui/widgets/menucontrolbutton.h>
 #include <gui/widgets/toolbuttons.h>
 #include <pluginbase/resourcemanager.h>
+#include <pluginbase/toolmenuentry.h>
 
 #define ROLLING_MODE "rolling"
 #define TRIGGER_MODE "trigger"
@@ -21,7 +22,7 @@ class SCOPY_PQM_EXPORT WaveformInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	WaveformInstrument(QWidget *parent = nullptr);
+	WaveformInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
 	~WaveformInstrument();
 
 	void showOneBuffer(bool hasFwVers);
@@ -31,7 +32,6 @@ public Q_SLOTS:
 	void onBufferDataAvailable(QMap<QString, QVector<double>> data);
 Q_SIGNALS:
 	void enableTool(bool en, QString toolName = "waveform");
-	void runTme(bool en);
 
 private Q_SLOTS:
 	void onTriggeredChnlChanged(QString triggeredChnl);
@@ -59,6 +59,8 @@ private:
 	QMap<QString, PlotChannel *> m_plotChnls;
 	QVector<double> m_xTime;
 	PlottingStrategy *m_plottingStrategy = nullptr;
+
+	ToolMenuEntry *m_tme;
 
 	const double m_plotSampleRate = 5120;
 	const QMap<QString, QMap<QString, QString>> m_chnls = {

--- a/plugins/pqm/include/pqm/waveforminstrument.h
+++ b/plugins/pqm/include/pqm/waveforminstrument.h
@@ -22,7 +22,7 @@ class SCOPY_PQM_EXPORT WaveformInstrument : public QWidget, public ResourceUser
 {
 	Q_OBJECT
 public:
-	WaveformInstrument(ToolMenuEntry *tme, QWidget *parent = nullptr);
+	WaveformInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent = nullptr);
 	~WaveformInstrument();
 
 	void showOneBuffer(bool hasFwVers);
@@ -61,6 +61,7 @@ private:
 	PlottingStrategy *m_plottingStrategy = nullptr;
 
 	ToolMenuEntry *m_tme;
+	QString m_uri;
 
 	const double m_plotSampleRate = 5120;
 	const QMap<QString, QMap<QString, QString>> m_chnls = {

--- a/plugins/pqm/src/harmonicsinstrument.cpp
+++ b/plugins/pqm/src/harmonicsinstrument.cpp
@@ -10,9 +10,10 @@
 
 using namespace scopy::pqm;
 
-HarmonicsInstrument::HarmonicsInstrument(ToolMenuEntry *tme, QWidget *parent)
+HarmonicsInstrument::HarmonicsInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent)
 	: QWidget(parent)
 	, m_tme(tme)
+	, m_uri(uri)
 {
 	initData();
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -236,9 +237,9 @@ void HarmonicsInstrument::stop() { m_runBtn->setChecked(false); }
 void HarmonicsInstrument::toggleHarmonics(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm" + m_tme->param(), this);
+		ResourceManager::open("pqm" + m_uri, this);
 	} else {
-		ResourceManager::close("pqm" + m_tme->param());
+		ResourceManager::close("pqm" + m_uri);
 	}
 	Q_EMIT enableTool(en);
 }

--- a/plugins/pqm/src/harmonicsinstrument.cpp
+++ b/plugins/pqm/src/harmonicsinstrument.cpp
@@ -10,8 +10,9 @@
 
 using namespace scopy::pqm;
 
-HarmonicsInstrument::HarmonicsInstrument(QWidget *parent)
+HarmonicsInstrument::HarmonicsInstrument(ToolMenuEntry *tme, QWidget *parent)
 	: QWidget(parent)
+	, m_tme(tme)
 {
 	initData();
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -56,7 +57,8 @@ HarmonicsInstrument::HarmonicsInstrument(QWidget *parent)
 	tool->addWidgetToTopContainerHelper(m_singleBtn, TTA_RIGHT);
 	tool->addWidgetToTopContainerHelper(settingsMenuBtn, TTA_RIGHT);
 
-	connect(this, &HarmonicsInstrument::runTme, m_runBtn, &QAbstractButton::setChecked);
+	connect(m_tme, &ToolMenuEntry::runClicked, m_runBtn, &QAbstractButton::setChecked);
+	connect(this, &HarmonicsInstrument::enableTool, m_tme, &ToolMenuEntry::setRunning);
 	connect(m_runBtn, &QAbstractButton::toggled, m_singleBtn, &QAbstractButton::setDisabled);
 	connect(m_runBtn, SIGNAL(toggled(bool)), this, SLOT(toggleHarmonics(bool)));
 	connect(m_singleBtn, &QAbstractButton::toggled, m_runBtn, &QAbstractButton::setDisabled);
@@ -234,9 +236,9 @@ void HarmonicsInstrument::stop() { m_runBtn->setChecked(false); }
 void HarmonicsInstrument::toggleHarmonics(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm", this);
+		ResourceManager::open("pqm" + m_tme->param(), this);
 	} else {
-		ResourceManager::close("pqm");
+		ResourceManager::close("pqm" + m_tme->param());
 	}
 	Q_EMIT enableTool(en);
 }

--- a/plugins/pqm/src/pqmplugin.cpp
+++ b/plugins/pqm/src/pqmplugin.cpp
@@ -108,14 +108,14 @@ bool PQMPlugin::onConnect()
 	bool hasFwVers = m_acqManager->hasFwVers();
 
 	ToolMenuEntry *rmsTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmrms");
-	RmsInstrument *rms = new RmsInstrument(rmsTme);
+	RmsInstrument *rms = new RmsInstrument(rmsTme, m_param);
 	rmsTme->setTool(rms);
 	rmsTme->setEnabled(true);
 	rmsTme->setRunBtnVisible(true);
 	connect(m_acqManager, &AcquisitionManager::pqmAttrsAvailable, rms, &RmsInstrument::onAttrAvailable);
 
 	ToolMenuEntry *harmonicsTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmharmonics");
-	HarmonicsInstrument *harmonics = new HarmonicsInstrument(harmonicsTme);
+	HarmonicsInstrument *harmonics = new HarmonicsInstrument(harmonicsTme, m_param);
 	harmonics->showThdWidget(hasFwVers);
 	harmonicsTme->setTool(harmonics);
 	harmonicsTme->setEnabled(true);
@@ -123,7 +123,7 @@ bool PQMPlugin::onConnect()
 	connect(m_acqManager, &AcquisitionManager::pqmAttrsAvailable, harmonics, &HarmonicsInstrument::onAttrAvailable);
 
 	ToolMenuEntry *waveformTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmwaveform");
-	WaveformInstrument *waveform = new WaveformInstrument(waveformTme);
+	WaveformInstrument *waveform = new WaveformInstrument(waveformTme, m_param);
 	waveform->showOneBuffer(hasFwVers);
 	waveformTme->setTool(waveform);
 	waveformTme->setEnabled(true);

--- a/plugins/pqm/src/pqmplugin.cpp
+++ b/plugins/pqm/src/pqmplugin.cpp
@@ -107,24 +107,27 @@ bool PQMPlugin::onConnect()
 	m_acqManager = new AcquisitionManager(ctx, m_pingTask, this);
 	bool hasFwVers = m_acqManager->hasFwVers();
 
-	RmsInstrument *rms = new RmsInstrument();
-	m_toolList[0]->setTool(rms);
-	m_toolList[0]->setEnabled(true);
-	m_toolList[0]->setRunBtnVisible(true);
+	ToolMenuEntry *rmsTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmrms");
+	RmsInstrument *rms = new RmsInstrument(rmsTme);
+	rmsTme->setTool(rms);
+	rmsTme->setEnabled(true);
+	rmsTme->setRunBtnVisible(true);
 	connect(m_acqManager, &AcquisitionManager::pqmAttrsAvailable, rms, &RmsInstrument::onAttrAvailable);
 
-	HarmonicsInstrument *harmonics = new HarmonicsInstrument();
+	ToolMenuEntry *harmonicsTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmharmonics");
+	HarmonicsInstrument *harmonics = new HarmonicsInstrument(harmonicsTme);
 	harmonics->showThdWidget(hasFwVers);
-	m_toolList[1]->setTool(harmonics);
-	m_toolList[1]->setEnabled(true);
-	m_toolList[1]->setRunBtnVisible(true);
+	harmonicsTme->setTool(harmonics);
+	harmonicsTme->setEnabled(true);
+	harmonicsTme->setRunBtnVisible(true);
 	connect(m_acqManager, &AcquisitionManager::pqmAttrsAvailable, harmonics, &HarmonicsInstrument::onAttrAvailable);
 
-	WaveformInstrument *waveform = new WaveformInstrument();
+	ToolMenuEntry *waveformTme = ToolMenuEntry::findToolMenuEntryById(m_toolList, "pqmwaveform");
+	WaveformInstrument *waveform = new WaveformInstrument(waveformTme);
 	waveform->showOneBuffer(hasFwVers);
-	m_toolList[2]->setTool(waveform);
-	m_toolList[2]->setEnabled(true);
-	m_toolList[2]->setRunBtnVisible(true);
+	waveformTme->setTool(waveform);
+	waveformTme->setEnabled(true);
+	waveformTme->setRunBtnVisible(true);
 	connect(m_acqManager, &AcquisitionManager::bufferDataAvailable, waveform,
 		&WaveformInstrument::onBufferDataAvailable, Qt::QueuedConnection);
 
@@ -137,10 +140,6 @@ bool PQMPlugin::onConnect()
 	connect(settings, &SettingsInstrument::setAttributes, m_acqManager, &AcquisitionManager::setConfigAttr);
 
 	for(auto &tool : m_toolList) {
-		if(tool->runBtnVisible()) {
-			connect(tool, SIGNAL(runClicked(bool)), tool->tool(), SIGNAL(runTme(bool)));
-			connect(tool->tool(), SIGNAL(enableTool(bool)), tool, SLOT(setRunning(bool)));
-		}
 		connect(tool->tool(), SIGNAL(enableTool(bool, QString)), m_acqManager,
 			SLOT(toolEnabled(bool, QString)));
 	}

--- a/plugins/pqm/src/rmsinstrument.cpp
+++ b/plugins/pqm/src/rmsinstrument.cpp
@@ -14,9 +14,10 @@ Q_LOGGING_CATEGORY(CAT_PQM_RMS, "PqmRms")
 
 using namespace scopy::pqm;
 
-RmsInstrument::RmsInstrument(ToolMenuEntry *tme, QWidget *parent)
+RmsInstrument::RmsInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent)
 	: QWidget(parent)
 	, m_tme(tme)
+	, m_uri(uri)
 {
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	QHBoxLayout *instrumentLayout = new QHBoxLayout(this);
@@ -198,9 +199,9 @@ void RmsInstrument::stop() { m_runBtn->setChecked(false); }
 void RmsInstrument::toggleRms(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm" + m_tme->param(), this);
+		ResourceManager::open("pqm" + m_uri, this);
 	} else {
-		ResourceManager::close("pqm" + m_tme->param());
+		ResourceManager::close("pqm" + m_uri);
 	}
 	Q_EMIT enableTool(en);
 }

--- a/plugins/pqm/src/rmsinstrument.cpp
+++ b/plugins/pqm/src/rmsinstrument.cpp
@@ -14,8 +14,9 @@ Q_LOGGING_CATEGORY(CAT_PQM_RMS, "PqmRms")
 
 using namespace scopy::pqm;
 
-RmsInstrument::RmsInstrument(QWidget *parent)
+RmsInstrument::RmsInstrument(ToolMenuEntry *tme, QWidget *parent)
 	: QWidget(parent)
+	, m_tme(tme)
 {
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	QHBoxLayout *instrumentLayout = new QHBoxLayout(this);
@@ -80,7 +81,8 @@ RmsInstrument::RmsInstrument(QWidget *parent)
 	tool->addWidgetToTopContainerHelper(m_runBtn, TTA_RIGHT);
 	tool->addWidgetToTopContainerHelper(m_singleBtn, TTA_RIGHT);
 
-	connect(this, &RmsInstrument::runTme, m_runBtn, &QAbstractButton::setChecked);
+	connect(m_tme, &ToolMenuEntry::runClicked, m_runBtn, &QAbstractButton::setChecked);
+	connect(this, &RmsInstrument::enableTool, m_tme, &ToolMenuEntry::setRunning);
 	connect(m_runBtn, &QAbstractButton::toggled, m_singleBtn, &QAbstractButton::setDisabled);
 	connect(m_runBtn, SIGNAL(toggled(bool)), this, SLOT(toggleRms(bool)));
 	connect(m_singleBtn, &QAbstractButton::toggled, m_runBtn, &QAbstractButton::setDisabled);
@@ -196,9 +198,9 @@ void RmsInstrument::stop() { m_runBtn->setChecked(false); }
 void RmsInstrument::toggleRms(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm", this);
+		ResourceManager::open("pqm" + m_tme->param(), this);
 	} else {
-		ResourceManager::close("pqm");
+		ResourceManager::close("pqm" + m_tme->param());
 	}
 	Q_EMIT enableTool(en);
 }

--- a/plugins/pqm/src/waveforminstrument.cpp
+++ b/plugins/pqm/src/waveforminstrument.cpp
@@ -14,9 +14,10 @@
 
 using namespace scopy::pqm;
 
-WaveformInstrument::WaveformInstrument(ToolMenuEntry *tme, QWidget *parent)
+WaveformInstrument::WaveformInstrument(ToolMenuEntry *tme, QString uri, QWidget *parent)
 	: QWidget(parent)
 	, m_tme(tme)
+	, m_uri(uri)
 {
 	initData();
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -175,9 +176,9 @@ void WaveformInstrument::stop() { m_runBtn->setChecked(false); }
 void WaveformInstrument::toggleWaveform(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm" + m_tme->param(), this);
+		ResourceManager::open("pqm" + m_uri, this);
 	} else {
-		ResourceManager::close("pqm" + m_tme->param());
+		ResourceManager::close("pqm" + m_uri);
 	}
 	m_plottingStrategy->clearSamples();
 	Q_EMIT enableTool(en);

--- a/plugins/pqm/src/waveforminstrument.cpp
+++ b/plugins/pqm/src/waveforminstrument.cpp
@@ -14,8 +14,9 @@
 
 using namespace scopy::pqm;
 
-WaveformInstrument::WaveformInstrument(QWidget *parent)
+WaveformInstrument::WaveformInstrument(ToolMenuEntry *tme, QWidget *parent)
 	: QWidget(parent)
+	, m_tme(tme)
 {
 	initData();
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -55,7 +56,8 @@ WaveformInstrument::WaveformInstrument(QWidget *parent)
 	tool->addWidgetToTopContainerHelper(m_singleBtn, TTA_RIGHT);
 	tool->addWidgetToTopContainerHelper(m_settBtn, TTA_RIGHT);
 
-	connect(this, &WaveformInstrument::runTme, m_runBtn, &QAbstractButton::setChecked);
+	connect(m_tme, &ToolMenuEntry::runClicked, m_runBtn, &QAbstractButton::setChecked);
+	connect(this, &WaveformInstrument::enableTool, m_tme, &ToolMenuEntry::setRunning);
 	connect(m_runBtn, &QAbstractButton::toggled, m_singleBtn, &QAbstractButton::setDisabled);
 	connect(m_runBtn, SIGNAL(toggled(bool)), this, SLOT(toggleWaveform(bool)));
 	connect(m_singleBtn, &QAbstractButton::toggled, m_runBtn, &QAbstractButton::setDisabled);
@@ -173,9 +175,9 @@ void WaveformInstrument::stop() { m_runBtn->setChecked(false); }
 void WaveformInstrument::toggleWaveform(bool en)
 {
 	if(en) {
-		ResourceManager::open("pqm", this);
+		ResourceManager::open("pqm" + m_tme->param(), this);
 	} else {
-		ResourceManager::close("pqm");
+		ResourceManager::close("pqm" + m_tme->param());
 	}
 	m_plottingStrategy->clearSamples();
 	Q_EMIT enableTool(en);


### PR DESCRIPTION
In the previous version, only the name of the resource was used, which caused some problems when we had multiple devices connected. The resource was opened from one device and closed from another, for example.