### PR TITLE
M2K: logic analyzer tooltip fix

### DIFF
--- a/plugins/m2k/src/old/logicanalyzer/logic_analyzer.cpp
+++ b/plugins/m2k/src/old/logicanalyzer/logic_analyzer.cpp
@@ -1973,7 +1973,7 @@ HoverWidget *LogicAnalyzer::createHoverToolTip(QString info, QPoint position)
 	QWidget *content = new QWidget(this);
 	StyleHelper::HoverToolTip(content, info);
 
-	HoverWidget *toolTip = new scopy::HoverWidget(content, &m_plot, QApplication::activeWindow());
+	HoverWidget *toolTip = new scopy::HoverWidget(content, &m_plot, this);
 	toolTip->setAnchorPos(scopy::HoverPosition::HP_TOPLEFT);
 	toolTip->setContentPos(scopy::HoverPosition::HP_TOPLEFT);
 	toolTip->setAnchorOffset(position);


### PR DESCRIPTION
- crashes activeWindow was null and created hoverWidget with no parent