### PR TITLE
gui/menusectioncollapsewidget: Changed the handling of the header.

### DIFF
--- a/gui/src/widgets/menucollapsesection.cpp
+++ b/gui/src/widgets/menucollapsesection.cpp
@@ -34,8 +34,8 @@ MenuCollapseHeader::MenuCollapseHeader(QString title, MenuCollapseSection::MenuH
 	case MenuCollapseSection::MHCW_ARROW:
 		m_ctrl = new QCheckBox(this);
 		StyleHelper::CollapseCheckbox(dynamic_cast<QCheckBox *>(m_ctrl), "menuCollapseButton");
-		connect(this, &QAbstractButton::toggled, this, [=](bool b) { m_ctrl->setChecked(!b); });
-		m_ctrl->setChecked(false);
+		connect(this, &QAbstractButton::toggled, this, [=](bool b) { m_ctrl->setChecked(b); });
+		m_ctrl->setChecked(true);
 		break;
 	case MenuCollapseSection::MHCW_ONOFF:
 		m_ctrl = new SmallOnOffSwitch(this);

--- a/gui/src/widgets/menusectionwidget.cpp
+++ b/gui/src/widgets/menusectionwidget.cpp
@@ -57,7 +57,7 @@ void MenuSectionCollapseWidget::add(QWidget *w) { m_collapse->contentLayout()->a
 
 void MenuSectionCollapseWidget::remove(QWidget *w) { m_collapse->contentLayout()->removeWidget(w); }
 
-bool MenuSectionCollapseWidget::collapsed() { return m_collapse->header()->isChecked(); }
+bool MenuSectionCollapseWidget::collapsed() { return !m_collapse->header()->isChecked(); }
 
 void MenuSectionCollapseWidget::setCollapsed(bool b) { m_collapse->header()->setChecked(!b); }
 


### PR DESCRIPTION
The menu is collapsed when the header is not checked. 
Collapse Checkbox must be handled as any other checkbox. (arrow)