### PR TITLE
CI: Enforce license headers in source files 

### DIFF
--- a/.github/contributing/project-structure.md
+++ b/.github/contributing/project-structure.md
@@ -31,6 +31,7 @@ git checkout -b <new_branch_name>
 
 - Implement feature – commit and push work as needed – refer to commit message structure
 - Apply code styling - (usually done by running `./tools/format.sh`)
+- Run license header completion - (usually done by running `./tools/license.sh`)
 - Resynchronize with latest changes to starting point and push again. Example
 ```bash
 git fetch

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,0 +1,24 @@
+name: license-headers
+
+on: [push, pull_request]
+
+env:
+  BUILD_HOST: ubuntu-22.04
+  USERNAME: github-actions
+
+jobs:
+  check-license-headers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Validate Scopy GPL License
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            set-safe-directory: 'true'
+      - name: Run License Scanner Utility
+        shell: bash
+        run: |
+          export CI_SCRIPT=ON
+          cd $GITHUB_WORKSPACE
+          ./tools/license.sh

--- a/core/include/core/deviceautoconnect.h
+++ b/core/include/core/deviceautoconnect.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef DEVICEAUTOCONNECT_H
 #define DEVICEAUTOCONNECT_H
 

--- a/core/src/deviceautoconnect.cpp
+++ b/core/src/deviceautoconnect.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "deviceautoconnect.h"
 
 #include <pluginbase/preferences.h>

--- a/plugins/m2k/m2k-gui/include/m2k-gui/qtgui_types.h
+++ b/plugins/m2k/m2k-gui/include/m2k-gui/qtgui_types.h
@@ -19,6 +19,25 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // copy of gnuradio/qtgui/qtgui_types.h file
 // used in waterfall plot

--- a/plugins/m2k/m2k-gui/src/oscilloscope_plot.cpp
+++ b/plugins/m2k/m2k-gui/src/oscilloscope_plot.cpp
@@ -1,5 +1,5 @@
 /*
- * CopQwtAxis::YRight (c) 2019 Analog Devices Inc.
+ * Copyright (c) 2019 Analog Devices Inc.
  *
  * This file is part of Scopy
  * (see http://www.github.com/analogdevicesinc/scopy).

--- a/plugins/m2k/src/old/frequency_compensation_filter.h
+++ b/plugins/m2k/src/old/frequency_compensation_filter.h
@@ -1,21 +1,22 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2019 Analog Devices Inc.
+ * Copyright (c) 2019 Analog Devices Inc.
  *
- * This is free software; you can redistribute it and/or modify
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3, or (at your option)
- * any later version.
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this software; see the file COPYING.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street,
- * Boston, MA 02110-1301, USA.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef INCLUDED_BLOCKS_OVERSHOOT_FILTER_H

--- a/plugins/m2k/src/old/frequency_compensation_filter_impl.cc
+++ b/plugins/m2k/src/old/frequency_compensation_filter_impl.cc
@@ -1,21 +1,22 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2019 Analog Devices Inc.
+ * Copyright (c) 2019 Analog Devices Inc.
  *
- * This is free software; you can redistribute it and/or modify
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3, or (at your option)
- * any later version.
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this software; see the file COPYING.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street,
- * Boston, MA 02110-1301, USA.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "frequency_compensation_filter_impl.h"

--- a/plugins/m2k/src/old/frequency_compensation_filter_impl.h
+++ b/plugins/m2k/src/old/frequency_compensation_filter_impl.h
@@ -1,21 +1,22 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2019 Analog Devices Inc.
+ * Copyright (c) 2019 Analog Devices Inc.
  *
- * This is free software; you can redistribute it and/or modify
+ * This file is part of Scopy
+ * (see http://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3, or (at your option)
- * any later version.
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this software; see the file COPYING.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street,
- * Boston, MA 02110-1301, USA.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef OVERSHOOT_FILTER_HPP

--- a/plugins/pqm/include/pqm/pqmdatalogger.h
+++ b/plugins/pqm/include/pqm/pqmdatalogger.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef PQMDATALOGGER_H
 #define PQMDATALOGGER_H
 

--- a/plugins/pqm/src/pqmdatalogger.cpp
+++ b/plugins/pqm/src/pqmdatalogger.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "pqmdatalogger.h"
 
 #include <QFile>
@@ -126,3 +147,5 @@ void PqmDataLogger::createHeader()
 		qWarning(CAT_PQMLOG) << m_filePath << "cannot be opened!";
 	}
 }
+
+#include "moc_pqmdatalogger.cpp"

--- a/tools/exclude_list.sh
+++ b/tools/exclude_list.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# NOTE: paths containing * are treated as regex => escape them with \ (ex: \*)
+
+OMIT_DIRS_LIST=(
+    .\*
+    .git\*
+    .vscode
+    android
+    apple
+    build
+    ci/\*
+    docs
+    tmp
+    tools
+    windows
+    # Directories specific to your local environment that are not part of the repository
+    venv
+)
+OMIT_DIRS_LIST=("${OMIT_DIRS_LIST[@]/#/*\/}") # */ prefix to each element
+GITIGNORE_DIRS_LIST=(
+    # .gitinore
+    CMakeFiles
+    build\*
+    deps
+    iio-emu
+    html/\*
+    build_arm64-v8a/\*
+    .cache/\*
+    build/\*
+    .vscode/\*
+    windows/\*
+    bin/\*
+    lib/\*
+    docs/_build/\*
+    share/\*
+    # ci/flatpak/.gitinore
+    ci/flatpak/build
+    ci/flatpak/repo
+)
+GITIGNORE_DIRS_LIST=("${GITIGNORE_DIRS_LIST[@]/#/*\/}") # */ prefix to each element
+
+OMIT_FILES_LIST=(
+    .clang-format
+    .clangformatignore
+    .cmake-format
+    .gitignore
+    .gitmodules
+    LICENSE
+    \*.md
+    \*.png
+    \*.rst
+    azure-pipelines.yml
+    requirements.txt
+    \*.html
+    \*.svg
+    \*.icns
+    \*.ico
+    \*.qmodel
+    \*.ui
+    \*.json
+    \*.qrc
+    \*.ts
+    \*.gif
+    \*.theme
+    \*.ttf
+    \*.zip
+    \*.csv
+    \*.bin
+    \*.xml
+    \*.cmakein
+    # Files specific to your local environment that are not part of the repository
+    \*.build
+    \*.git
+    \*.gitrepo
+    \*.mat
+    \*.user
+)
+OMIT_FILES_LIST=("${OMIT_FILES_LIST[@]/#/*\/}")
+GITINORE_FILES_LIST=(
+    # .gitinore
+    CMakeLists.txt.user
+    CMakeCache.txt
+    cmake_install.cmake
+    Makefile
+    moc_\*.cpp
+    \*_automoc.cpp
+    ui_\*.h
+    resources/scopy_osp.html
+    resources/stylesheets/default.qss
+    resources/stylesheets/light.qss
+    resources/credits.html
+    resources/scopy_home.html
+    resources/about.html
+    \*qt.conf
+    \*.swp
+    \*.DS_Store
+    android-build
+    android\*.sh
+    \*.apk
+    \*.aab
+    ci/general/gh-actions.envs
+    core/include/scopy-core_config.h
+    core/include/scopy-core_export.h
+    core/include/core/scopy-core_config.h
+    core/include/core/scopy-core_export.h
+    common/include/common/scopy-common_config.h
+    common/include/common/scopy-common_export.h
+    gr-util/include/gr-util/scopy-gr-util_export.h
+    gui/include/gui/scopy-gui_export.h
+    gui/include/gui/scopy-gui_config.h
+    iio-widgets/include/iio-widgets/scopy-iio-widgets_export.h
+    iioutil/include/iioutil/scopy-iioutil_export.h
+    pluginbase/include/pluginbase/scopy-pluginbase_config.h
+    pluginbase/include/pluginbase/scopy-pluginbase_export.h
+    # gui/res/.gitinore
+    gui/res/about.html
+    gui/res/scopy_osp.html
+    gui/res/buildinfo.html
+    gui/res/credits.html
+    # ci/flatpak/.gitinore
+    ci/flatpak/Scopy.flatpak
+    ci/flatpak/.flatpak-builder
+    ci/flatpak/org.adi.Scopy.json
+    ci/flatpak/tmp.json
+    # plugins/adc/.gitinore
+    plugins/adc/include/adc/scopy-adc_export.h
+    plugins/adc/include/adc/scopy-adc_config.h
+    # plugins/dac/.gitinore
+    plugins/dac/include/dac/scopy-dac_export.h
+    plugins/dac/include/dac/scopy-dac_config.h
+    # plugins/m2k/.gitinore
+    plugins/m2k/include/m2k/scopy-m2k_export.h
+    plugins/m2k/include/m2k/scopy-m2k_config.h
+    # plugins/pqm/.gitinore
+    plugins/pqm/include/pqm/scopy-pqm_export.h
+    plugins/pqm/include/pqm/scopy-pqm_config.h
+    # plugins/test/.gitinore
+    plugins/test/include/test/scopy-test_export.h
+    # plugins/swiot/.gitinore
+    plugins/swiot/include/swiot/scopy-swiot_export.h
+    plugins/swiot/include/swiot/scopy-swiot_config.h
+    # plugins/test2/.gitinore
+    plugins/test2/include/test2/scopy-test2_export.h
+    # plugins/guitest/.gitinore
+    plugins/guitest/include/guitest/scopy-guitest_export.h
+    # plugins/debugger/.gitinore
+    plugins/debugger/include/debugger/scopy-debugger_export.h
+    plugins/debugger/include/debugger/scopy-debugger_config.h
+    # plugins/datalogger/.gitinore
+    plugins/datalogger/include/datalogger/scopy-datalogger_export.h
+    plugins/datalogger/include/datalogger/scopy-datalogger_config.h
+    # plugins/bareminimum/.gitinore
+    plugins/bareminimum/include/bareminimum/scopy-bareminimum_export.h
+    # plugins/m2k/m2k-gui/.gitinore
+    plugins/m2k/m2k-gui/include/m2k-gui/scopy-m2k-gui_export.h
+    plugins/m2k/m2k-gui/include/m2k-gui/scopy-m2k-gui_config.h
+    plugins/m2k/m2k-gui/gr-gui/include/gr-gui/scopy-gr-gui_export.h
+    plugins/m2k/m2k-gui/gr-gui/include/gr-gui/scopy-gr-gui_config.h
+    plugins/m2k/m2k-gui/sigrok-gui/include/sigrok-gui/scopy-sigrok-gui_export.h
+    plugins/m2k/m2k-gui/sigrok-gui/include/sigrok-gui/scopy-sigrok-gui_config.h
+    # plugins/regmap/.gitinore
+    plugins/regmap/include/regmap/scopy-regmap_export.h
+    plugins/regmap/include/regmap/scopy-regmap_config.h
+)
+GITINORE_FILES_LIST=("${GITINORE_FILES_LIST[@]/#/*\/}")

--- a/tools/license-header/add_license_header.sh
+++ b/tools/license-header/add_license_header.sh
@@ -240,9 +240,10 @@ function main() {
     
     FILE_EXTENSION="${FILE##*.}"
 
-    COMMENT_STYLE=${COMMENT_STYLES[$FILE_EXTENSION]}
+    COMMENT_STYLE=${COMMENT_STYLES[$FILE_EXTENSION]:-}
     if [[ -z "$COMMENT_STYLE" ]]; then
-        echo "Unsupported file extension: $FILE_EXTENSION" >&2
+        echo "Error: Unsupported file extension '${FILE_EXTENSION}' found in file '${FILE}'" >&2
+        echo "Define 'COMMENT_STYLE' for '$FILE_EXTENSION' in .comment_styles.conf" >&2
         exit 1
     fi
 

--- a/tools/license-header/batch_add_license_headers.sh
+++ b/tools/license-header/batch_add_license_headers.sh
@@ -97,6 +97,7 @@ function main() {
     fi
 
     process_files "$FILE_LIST"
+    exit 0
 }
 
 main "$@"

--- a/tools/license-header/batch_add_license_headers.sh
+++ b/tools/license-header/batch_add_license_headers.sh
@@ -81,6 +81,10 @@ function process_files() {
         "$add_license_header" "$file" \
             --template "$TEMPLATE_FILE" \
             --params "$PARAMS_FILE"
+        if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to add license header to $file"
+            exit 1
+        fi
     done <"$file_list"
 }
 

--- a/tools/license-header/scan_missing_headers.sh
+++ b/tools/license-header/scan_missing_headers.sh
@@ -269,7 +269,6 @@ function identify_license() {
     local unknown=true
 
     # Search for license headers
-
     if has_ADI_disclaimer "$header"; then
         if is_GPL "$header"; then
             if is_Scopy_GPL "$header"; then
@@ -322,6 +321,18 @@ function identify_license() {
 
         # Update the echo command to use the joined string
         echo -e "${indent}${color}├── $relative_path (${joined_licenses})${NC}"
+    fi
+
+    local found=false
+    for license in "${found_licenses_list[@]}"; do
+        if [[ "$license" == "Scopy_GPL" ]]; then
+            found=true
+            break
+        fi
+    done
+
+    if ! $found; then
+        FILES_WITHOUT_LICENSE+=("$relative_path")
     fi
 }
 

--- a/tools/license.sh
+++ b/tools/license.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# set -x
+
+CI_SCRIPT=${CI_SCRIPT:-"OFF"}
+
+REPOSTORY=$(git rev-parse --show-toplevel)
+PATH_OPTION=" --path $REPOSTORY"
+OMIT_DIRS_OPTION=" --dirs .git*,build,.vscode,android,apple,ci,docs,tmp,tools,windows"
+OMIT_FILES_OPTION=" --files .clang-format,.clangformatignore,.cmake-format,.gitignore,.gitmodules,*.md,LICENSE,*.png,*.rst,azure-pipelines.yml,requirements.txt,*.html,*.svg,*.icns,*.ico,*.qmodel,*.ui,*.json,*.qrc,*.ts,*.gif,*.theme,*.ttf,*.zip,*.csv,*.bin,*.xml,*.cmakein"
+
+VERBOSE=""
+CLEANUP="true"
+# VERBOSE: Increasese processing time but provides detailed output. Use for manual inspection
+# VERBOSE="--verbose"
+# CLEANUP="" # true
+
+LICENSE_UTILS_PATH=$REPOSTORY/tools/license-header
+RESULTS_PATH=$LICENSE_UTILS_PATH/results
+
+cleanup() {
+    if [ "$CLEANUP" == "true" ] && [ -d "$RESULTS_PATH" ]; then
+        rm -rf "$RESULTS_PATH"
+    fi
+}
+
+main() {
+    mkdir -p "$RESULTS_PATH"
+    if [ -f "$RESULTS_PATH/scan.txt" ]; then
+        rm "$RESULTS_PATH/scan.txt"
+    fi
+    touch "$RESULTS_PATH"/scan.txt
+
+    echo "# Running license scanner utility ..."
+    $LICENSE_UTILS_PATH/scan_missing_headers.sh \
+        $PATH_OPTION \
+        $OMIT_DIRS_OPTION \
+        $OMIT_FILES_OPTION \
+        $VERBOSE \
+        >$RESULTS_PATH/scan.txt
+    EXIT_CODE=$?
+    echo "## Stored results under: $RESULTS_PATH/scan.txt"
+
+    # CI should fail if missing headers are detected
+    if [ "$CI_SCRIPT" == "ON" ]; then
+        echo "## Report results:"
+        cat "$RESULTS_PATH"/scan.txt
+        exit $EXIT_CODE
+    fi
+
+    if [ $EXIT_CODE -ne 0 ] && [ "$VERBOSE" != "--verbose" ]; then
+        pushd "$LICENSE_UTILS_PATH" || exit 1
+        echo "### Warning: Missing headers found"
+
+        TEMPLATE_OPTION=" --template $LICENSE_UTILS_PATH/templates/Scopy/LICENSE"
+        PARAMS_OPTION=" --params $LICENSE_UTILS_PATH/templates/Scopy/params.conf"
+        $LICENSE_UTILS_PATH/batch_add_license_headers.sh $RESULTS_PATH/scan.txt $TEMPLATE_OPTION $PARAMS_OPTION
+        ERROR_CODE=$?
+        popd || exit 1
+
+        if [ $ERROR_CODE -ne 0 ]; then
+            echo "### Error: Failed to add missing headers"
+            exit 1
+        else
+            echo "### Success: Missing headers added"
+        fi
+
+        echo "# Formatting files ..."
+        "$REPOSTORY"/tools/format.sh >/dev/null 2>&1
+        exit 0
+    else
+        echo "### Success: All scanned files contain license headers"
+    fi
+}
+
+trap cleanup EXIT
+main "$@"

--- a/tools/license.sh
+++ b/tools/license.sh
@@ -6,57 +6,92 @@ CI_SCRIPT=${CI_SCRIPT:-"OFF"}
 
 REPOSTORY=$(git rev-parse --show-toplevel)
 PATH_OPTION=" --path $REPOSTORY"
-OMIT_DIRS_OPTION=" --dirs .git*,build,.vscode,android,apple,ci,docs,tmp,tools,windows"
-OMIT_FILES_OPTION=" --files .clang-format,.clangformatignore,.cmake-format,.gitignore,.gitmodules,*.md,LICENSE,*.png,*.rst,azure-pipelines.yml,requirements.txt,*.html,*.svg,*.icns,*.ico,*.qmodel,*.ui,*.json,*.qrc,*.ts,*.gif,*.theme,*.ttf,*.zip,*.csv,*.bin,*.xml,*.cmakein"
-
-VERBOSE=""
-CLEANUP="true"
-# VERBOSE: Increasese processing time but provides detailed output. Use for manual inspection
-# VERBOSE="--verbose"
-# CLEANUP="" # true
-
 LICENSE_UTILS_PATH=$REPOSTORY/tools/license-header
 RESULTS_PATH=$LICENSE_UTILS_PATH/results
 
-cleanup() {
-    if [ "$CLEANUP" == "true" ] && [ -d "$RESULTS_PATH" ]; then
-        rm -rf "$RESULTS_PATH"
-    fi
-}
+source $REPOSTORY/tools/exclude_list.sh
+
+# Build options
+OMIT_DIRS_OPTION=""
+if [ ${#OMIT_DIRS_LIST[@]} -gt 0 ] && [ ${#GITIGNORE_DIRS_LIST[@]} -gt 0 ]; then
+    OMIT_DIRS_OPTION=" --dirs $(
+        IFS=,
+        echo "${OMIT_DIRS_LIST[*]},${GITIGNORE_DIRS_LIST[*]}"
+    )"
+elif [ ${#OMIT_DIRS_LIST[@]} -gt 0 ]; then
+    OMIT_DIRS_OPTION=" --dirs $(
+        IFS=,
+        echo "${OMIT_DIRS_LIST[*]}"
+    )"
+elif [ ${#GITIGNORE_DIRS_LIST[@]} -gt 0 ]; then
+    OMIT_DIRS_OPTION=" --dirs $(
+        IFS=,
+        echo "${GITIGNORE_DIRS_LIST[*]}"
+    )"
+fi
+
+OMIT_FILES_OPTION=""
+if [ ${#OMIT_FILES_LIST[@]} -gt 0 ] && [ ${#GITINORE_FILES_LIST[@]} -gt 0 ]; then
+    OMIT_FILES_OPTION=" --files $(
+        IFS=,
+        echo "${OMIT_FILES_LIST[*]},${GITINORE_FILES_LIST[*]}"
+    )"
+elif [ ${#OMIT_FILES_LIST[@]} -gt 0 ]; then
+    OMIT_FILES_OPTION=" --files $(
+        IFS=,
+        echo "${OMIT_FILES_LIST[*]}"
+    )"
+elif [ ${#GITINORE_FILES_LIST[@]} -gt 0 ]; then
+    OMIT_FILES_OPTION=" --files $(
+        IFS=,
+        echo "${GITINORE_FILES_LIST[*]}"
+    )"
+fi
 
 main() {
     mkdir -p "$RESULTS_PATH"
-    if [ -f "$RESULTS_PATH/scan.txt" ]; then
-        rm "$RESULTS_PATH/scan.txt"
-    fi
-    touch "$RESULTS_PATH"/scan.txt
+    [ -f "$RESULTS_PATH/scan_output.txt" ] && rm "$RESULTS_PATH/scan_output.txt"
+    touch "$RESULTS_PATH"/scan_output.txt
+
+    [ -f "$RESULTS_PATH/log.txt" ] && rm "$RESULTS_PATH/log.txt"
+    touch "$RESULTS_PATH"/log.txt
 
     echo "# Running license scanner utility ..."
     $LICENSE_UTILS_PATH/scan_missing_headers.sh \
         $PATH_OPTION \
         $OMIT_DIRS_OPTION \
         $OMIT_FILES_OPTION \
-        $VERBOSE \
-        >$RESULTS_PATH/scan.txt
+        >$RESULTS_PATH/scan_output.txt 2>$RESULTS_PATH/log.txt
     EXIT_CODE=$?
-    echo "## Stored results under: $RESULTS_PATH/scan.txt"
+
+    echo "## Missing header scan paths: $RESULTS_PATH/scan_output.txt"
+    echo "## Missing headers (detailed logs): $RESULTS_PATH/log.txt"
 
     # CI should fail if missing headers are detected
     if [ "$CI_SCRIPT" == "ON" ]; then
+        echo "## CI mode: Exiting with scan results"
+        echo "## Log results:"
+        cat "$RESULTS_PATH"/log.txt
         echo "## Report results:"
-        cat "$RESULTS_PATH"/scan.txt
+        cat "$RESULTS_PATH"/scan_output.txt
+
+        if [ $EXIT_CODE -ne 0 ]; then
+            echo "### Error: Missing headers found"
+        else
+            echo "### Success: All scanned files contain license headers"
+        fi
         exit $EXIT_CODE
     fi
 
-    if [ $EXIT_CODE -ne 0 ] && [ "$VERBOSE" != "--verbose" ]; then
-        pushd "$LICENSE_UTILS_PATH" || exit 1
+    if [ $EXIT_CODE -ne 0 ]; then
+        pushd "$LICENSE_UTILS_PATH" || exit 1 >/dev/null
         echo "### Warning: Missing headers found"
-
+        echo "# Adding missing headers ..."
         TEMPLATE_OPTION=" --template $LICENSE_UTILS_PATH/templates/Scopy/LICENSE"
         PARAMS_OPTION=" --params $LICENSE_UTILS_PATH/templates/Scopy/params.conf"
-        $LICENSE_UTILS_PATH/batch_add_license_headers.sh $RESULTS_PATH/scan.txt $TEMPLATE_OPTION $PARAMS_OPTION
+        $LICENSE_UTILS_PATH/batch_add_license_headers.sh $RESULTS_PATH/scan_output.txt $TEMPLATE_OPTION $PARAMS_OPTION
         ERROR_CODE=$?
-        popd || exit 1
+        popd || exit 1 >/dev/null
 
         if [ $ERROR_CODE -ne 0 ]; then
             echo "### Error: Failed to add missing headers"
@@ -64,14 +99,15 @@ main() {
         else
             echo "### Success: Missing headers added"
         fi
-
-        echo "# Formatting files ..."
-        "$REPOSTORY"/tools/format.sh >/dev/null 2>&1
-        exit 0
+    elif [ $EXIT_CODE -eq 0 ]; then
+        echo "### All scanned files contain license headers ... no action required"
     else
-        echo "### Success: All scanned files contain license headers"
+        echo "### Erorr: Unknown error"
+        exit 1
     fi
+    echo "# Formatting files ..."
+    "$REPOSTORY"/tools/format.sh >/dev/null 2>&1
+    exit 0
 }
 
-trap cleanup EXIT
 main "$@"


### PR DESCRIPTION
## Description

- **CI Job**: Adds a step that fails if files not excluded by the default filters lack a valid Scopy license header as defined in `tools/license-header/templates/Scopy/LICENSE`.
- **Utility**: Introduces `tools/license.sh`, a script that scans the repository for missing license headers, adds them based on file extensions, and supports a verbose mode for detailed output and troubleshooting.

### Developer Workflow
If the CI step fails due to missing headers, run the `./tools/license.sh` utility to fix the missing headers locally. Then, commit and push the changes.

**NOTE:** The utility will also run `./tools/format.sh` automatically.
