### PR TITLE
generic: menu spinbox update

### DIFF
--- a/gui/include/gui/widgets/incrementstrategy.h
+++ b/gui/include/gui/widgets/incrementstrategy.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef INCREMENTSTRATEGY_H
+#define INCREMENTSTRATEGY_H
+
+#include <plot_utils.hpp>
+#include <scopy-gui_export.h>
+
+namespace scopy {
+namespace gui {
+
+class SCOPY_GUI_EXPORT IncrementStrategy
+{
+public:
+	virtual ~IncrementStrategy() {}
+	virtual double increment(double val) = 0;
+	virtual double decrement(double val) = 0;
+	virtual void setScale(double scale) = 0;
+};
+
+class SCOPY_GUI_EXPORT IncrementStrategy125 : public IncrementStrategy
+{
+public:
+	NumberSeries m_steps;
+
+	IncrementStrategy125()
+		: m_steps(1e-9, 1e9, 10)
+	{}
+	~IncrementStrategy125() {}
+	virtual double increment(double val) override { return m_steps.getNumberAfter(val); }
+	virtual double decrement(double val) override { return m_steps.getNumberBefore(val); }
+
+	double m_scale;
+	void setScale(double scale) override { m_scale = scale; }
+};
+
+class SCOPY_GUI_EXPORT IncrementStrategyPower2 : public IncrementStrategy
+{
+public:
+	QList<double> m_steps;
+	IncrementStrategyPower2()
+	{
+		for(int i = 30; i >= 0; i--) {
+			m_steps.append(-(1 << i));
+		}
+		for(int i = 0; i < 31; i++) {
+			m_steps.append(1 << i);
+		}
+	}
+	~IncrementStrategyPower2() {}
+	virtual double increment(double val) override
+	{
+		int i = 0;
+		val = val + 1;
+		while(val > m_steps[i]) {
+			i++;
+		}
+		return m_steps[i];
+	}
+	virtual double decrement(double val) override
+	{
+		int i = m_steps.count() - 1;
+		val = val - 1;
+		while(val < m_steps[i]) {
+			i--;
+		}
+		return m_steps[i];
+	}
+	double m_scale;
+
+	void setScale(double scale) override { m_scale = scale; }
+};
+class SCOPY_GUI_EXPORT IncrementStrategyFixed : public IncrementStrategy
+{
+public:
+	IncrementStrategyFixed(double k = 1)
+	{
+		m_k = k;
+		m_scale = 1;
+	}
+	~IncrementStrategyFixed() {}
+	virtual double increment(double val) override
+	{
+		val = val + m_k * m_scale;
+		return val;
+	}
+	virtual double decrement(double val) override
+	{
+		val = val - m_k * m_scale;
+		return val;
+	}
+	void setK(double val) { m_k = val; }
+	double k() { return m_k; }
+
+private:
+	double m_k;
+	double m_scale;
+
+	void setScale(double scale) override { m_scale = scale; }
+};
+
+class SCOPY_GUI_EXPORT IncrementStrategyTest : public IncrementStrategy
+{
+public:
+	IncrementStrategyTest() { m_scale = 1; }
+	~IncrementStrategyTest() {}
+	virtual double increment(double val) override
+	{
+		val = val + m_scale;
+		return val;
+	}
+	virtual double decrement(double val) override
+	{
+		val = val - m_scale;
+		return val;
+	}
+
+private:
+	double m_scale;
+
+	void setScale(double scale) override { m_scale = scale; }
+};
+} // namespace gui
+} // namespace scopy
+#endif // INCREMENTSTRATEGY_H

--- a/gui/include/gui/widgets/menuspinbox.h
+++ b/gui/include/gui/widgets/menuspinbox.h
@@ -28,111 +28,15 @@
 #include <cmath>
 #include <scopy-gui_export.h>
 #include <QWidget>
-#include <QLineEdit>
 #include <QComboBox>
 #include <QPushButton>
 #include <QLabel>
 #include <QBoxLayout>
+#include <incrementstrategy.h>
+#include <scale.h>
 
 namespace scopy {
 namespace gui {
-
-class SCOPY_GUI_EXPORT IncrementStrategy
-{
-public:
-	virtual ~IncrementStrategy(){};
-	virtual double increment(double val) = 0;
-	virtual double decrement(double val) = 0;
-	virtual void setScale(double scale) = 0;
-};
-
-class SCOPY_GUI_EXPORT IncrementStrategy125 : public IncrementStrategy
-{
-public:
-	NumberSeries m_steps;
-
-	IncrementStrategy125()
-		: m_steps(1e-9, 1e9, 10){};
-	~IncrementStrategy125(){};
-	virtual double increment(double val) override { return m_steps.getNumberAfter(val); }
-	virtual double decrement(double val) override { return m_steps.getNumberBefore(val); }
-
-	double m_scale;
-	void setScale(double scale) override { m_scale = scale; }
-};
-
-class SCOPY_GUI_EXPORT IncrementStrategyPower2 : public IncrementStrategy
-{
-public:
-	QList<double> m_steps;
-	IncrementStrategyPower2()
-	{
-		for(int i = 30; i >= 0; i--) {
-			m_steps.append(-(1 << i));
-		}
-		for(int i = 0; i < 31; i++) {
-			m_steps.append(1 << i);
-		}
-	};
-	~IncrementStrategyPower2(){};
-	virtual double increment(double val) override
-	{
-		int i = 0;
-		val = val + 1;
-		while(val > m_steps[i]) {
-			i++;
-		}
-		return m_steps[i];
-	}
-	virtual double decrement(double val) override
-	{
-		int i = m_steps.count() - 1;
-		val = val - 1;
-		while(val < m_steps[i]) {
-			i--;
-		}
-		return m_steps[i];
-	}
-	double m_scale;
-
-	void setScale(double scale) override { m_scale = scale; }
-};
-class SCOPY_GUI_EXPORT IncrementStrategyFixed : public IncrementStrategy
-{
-public:
-	IncrementStrategyFixed(double k = 1)
-	{
-		m_k = k;
-		m_scale = 1;
-	};
-	~IncrementStrategyFixed(){};
-	virtual double increment(double val) override
-	{
-		val = val + m_k * m_scale;
-		return val;
-	}
-	virtual double decrement(double val) override
-	{
-		val = val - m_k * m_scale;
-		return val;
-	}
-	void setK(double val) { m_k = val; }
-	double k() { return m_k; }
-
-private:
-	double m_k;
-	double m_scale;
-
-	void setScale(double scale) override { m_scale = scale; }
-};
-
-class SCOPY_GUI_EXPORT UnitPrefix
-{
-public:
-	QString prefix;
-	double scale;
-	// enum type - metric, hour, logarithmic, etc
-};
 
 class SCOPY_GUI_EXPORT MenuSpinbox : public QWidget
 {
@@ -157,7 +61,11 @@ public:
 	IncrementStrategy *incrementStrategy() const;
 	QString name() const;
 
-	void setScaleRange(double min, double max);
+	Scale *scale() const;
+	void setScale(Scale *newScale);
+
+	int precision() const;
+	void setPrecision(int newPrecision);
 
 public Q_SLOTS:
 	void setName(const QString &newName);
@@ -169,6 +77,7 @@ public Q_SLOTS:
 	void setValue(double newValue);
 	void setIncrementMode(IncrementMode is);
 	void setScalingEnabled(bool en);
+	bool scallingEnabled();
 
 Q_SIGNALS:
 	void nameChanged(QString);
@@ -184,10 +93,10 @@ private:
 	void layoutVertically(bool left);
 	void layoutHorizontally(bool left);
 	double clamp(double val, double min, double max);
+	void minMaxReached(double val);
 
 	QLabel *m_label;
 	QLineEdit *m_edit;
-	QComboBox *m_scaleCb;
 	QPushButton *m_plus;
 	QPushButton *m_minus;
 	MouseWheelWidgetGuard *m_mouseWheelGuard;
@@ -195,20 +104,16 @@ private:
 	IncrementStrategy *m_incrementStrategy;
 	IncrementMode m_im;
 
+	Scale *m_scale;
+
 	Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
 	Q_PROPERTY(double value READ value WRITE setValue NOTIFY valueChanged)
-	Q_PROPERTY(QString unit READ unit WRITE setUnit NOTIFY unitChanged)
 
 	QString m_name;
 	double m_value, m_min, m_max;
-	double m_scaleMin, m_scaleMax;
-	QString m_unit;
-	bool m_large_widget;
 
-	QList<UnitPrefix> m_scales;
-	// QMap<QString, double> m_scaleMap;
-	double getScaleForPrefix(QString prefix, Qt::CaseSensitivity s = Qt::CaseSensitive);
-	bool m_scalingEnabled;
+	bool m_large_widget;
+	int m_precision = 0;
 };
 } // namespace gui
 } // namespace scopy

--- a/gui/include/gui/widgets/scale.h
+++ b/gui/include/gui/widgets/scale.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SCALE_H
+#define SCALE_H
+
+#include <QComboBox>
+#include <QList>
+#include <QString>
+#include <scopy-gui_export.h>
+#include <QObject>
+
+namespace scopy {
+namespace gui {
+
+class SCOPY_GUI_EXPORT UnitPrefix
+{
+public:
+	QString prefix;
+	double scale;
+	// enum type - metric, hour, logarithmic, etc
+};
+
+class SCOPY_GUI_EXPORT ScaleOption
+{
+public:
+	QString option;
+	double scale;
+	// enum type - metric, hour, logarithmic, etc
+};
+
+class SCOPY_GUI_EXPORT Scale : public QObject
+{
+	Q_OBJECT
+public:
+	Scale(QString unit, double min, double max, bool hasPrefix = true);
+	~Scale();
+
+	double getScaleForPrefix(QString prefix, Qt::CaseSensitivity s);
+	double getScaleForUnit(QString unit, Qt::CaseSensitivity s);
+	double getScaleForSymbol(QString symbol);
+
+	QList<UnitPrefix> scalePrefixes() const;
+	void setScalePrefixes(const QList<UnitPrefix> &newScalePrefixes);
+
+	QList<ScaleOption> scaleOptions() const;
+	void setScaleOptions(const QList<ScaleOption> &newScaleOptions);
+
+	bool scalingEnabled() const;
+	void setScalingEnabled(bool newScalingEnabled);
+
+	QComboBox *scaleCb() const;
+
+	QString unit() const;
+	void setUnit(const QString &newUnit);
+
+	void computeScale(double val);
+
+	bool hasPrefix() const;
+	void setHasPrefix(bool newHasPrefix);
+
+Q_SIGNALS:
+	void scaleUpdated();
+	void unitChanged(QString unit);
+	void scaleDown(int newScaleIndex);
+
+private:
+	bool m_hasPrefix;
+	bool m_scalingEnabled = true;
+	double m_min, m_max;
+	QString m_unit;
+	QList<ScaleOption> m_scaleOptions;
+	QList<UnitPrefix> m_scalePrefixes;
+	QComboBox *m_scaleCb;
+	void populateScaleCb();
+
+	Q_PROPERTY(QString unit READ unit WRITE setUnit NOTIFY unitChanged)
+};
+
+} // namespace gui
+} // namespace scopy
+#endif // SCALE_H

--- a/gui/src/style.cpp
+++ b/gui/src/style.cpp
@@ -394,3 +394,5 @@ QString Style::adjustForScaling(QString key, QString value, float scale)
 
 	return value;
 }
+
+#include "moc_style.cpp"

--- a/gui/src/widgets/menuplotaxisrangecontrol.cpp
+++ b/gui/src/widgets/menuplotaxisrangecontrol.cpp
@@ -32,13 +32,17 @@ MenuPlotAxisRangeControl::MenuPlotAxisRangeControl(PlotAxis *m_plotAxis, QWidget
 	setLayout(minMaxLayout);
 	minMaxLayout->setMargin(0);
 	minMaxLayout->setSpacing(10);
-	QString unit = m_plotAxis->getUnits();
 
 	m_min = new MenuSpinbox("Min", 0, "counts", -1e9, 1e9, true, false, this);
 	m_max = new MenuSpinbox("Max", 0, "counts", -1e9, 1e9, true, false, this);
 
-	m_min->setScaleRange(1, 1e9);
-	m_max->setScaleRange(1, 1e9);
+	m_min->setIncrementMode(MenuSpinbox::IS_POW2);
+	m_max->setIncrementMode(MenuSpinbox::IS_POW2);
+
+	m_min->scale()->setScalePrefixes(
+		{{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}, {QString("G"), 1e9}});
+	m_max->scale()->setScalePrefixes(
+		{{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}, {QString("G"), 1e9}});
 
 	addAxis(m_plotAxis);
 	minMaxLayout->addWidget(m_min);

--- a/gui/src/widgets/scale.cpp
+++ b/gui/src/widgets/scale.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "scale.h"
+
+namespace scopy {
+namespace gui {
+
+Scale::Scale(QString unit, double min, double max, bool hasPrefix)
+	: m_unit(unit)
+	, m_min(min)
+	, m_max(max)
+	, m_hasPrefix(hasPrefix)
+{
+	m_scaleCb = new QComboBox();
+
+	if(hasPrefix) {
+		// PRESET METRIC PREFIX
+		m_scalePrefixes.append({QString("n"), 1e-9});
+		m_scalePrefixes.append({QString("u"), 1e-6});
+		m_scalePrefixes.append({QString("m"), 1e-3});
+		m_scalePrefixes.append({QString(""), 1e0});
+		m_scalePrefixes.append({QString("k"), 1e3});
+		m_scalePrefixes.append({QString("M"), 1e6});
+		m_scalePrefixes.append({QString("G"), 1e9});
+	}
+
+	m_scaleOptions.append({m_unit, 1e0});
+	populateScaleCb();
+	m_scaleCb->setCurrentIndex(0);
+}
+
+Scale::~Scale()
+{
+	m_scaleOptions.clear();
+	m_scalePrefixes.clear();
+}
+
+double Scale::getScaleForPrefix(QString prefix, Qt::CaseSensitivity s)
+{
+	for(int i = 0; i < m_scalePrefixes.count(); i++) {
+
+		if(s == Qt::CaseSensitive) {
+			if(m_scalePrefixes[i].prefix == prefix) {
+				return m_scalePrefixes[i].scale;
+			}
+		} else {
+			if(m_scalePrefixes[i].prefix.toLower() == prefix.toLower()) {
+				return m_scalePrefixes[i].scale;
+			}
+		}
+	}
+	return -1;
+}
+
+double Scale::getScaleForUnit(QString unit, Qt::CaseSensitivity s)
+{
+	for(int i = 0; i < m_scaleOptions.count(); i++) {
+		if(s == Qt::CaseSensitive) {
+			if(m_scaleOptions[i].option == unit) {
+				return m_scaleOptions[i].scale;
+			}
+		} else {
+			if(m_scaleOptions[i].option.toLower() == unit.toLower()) {
+				return m_scaleOptions[i].scale;
+			}
+		}
+	}
+	return -1;
+}
+
+double Scale::getScaleForSymbol(QString symbol)
+{
+	if(m_hasPrefix) {
+		// TODO apply some filters for unit of measure ??
+		double value = getScaleForPrefix(symbol.mid(0, 1), Qt::CaseSensitive);
+		if(value == -1) {
+			value = getScaleForPrefix(symbol.mid(0, 1), Qt::CaseInsensitive);
+		}
+		return value;
+	} else {
+		double value = getScaleForUnit(symbol, Qt::CaseSensitive);
+		if(value == -1) {
+			value = getScaleForUnit(symbol, Qt::CaseInsensitive);
+		}
+		return value;
+	}
+}
+
+bool Scale::scalingEnabled() const { return m_scalingEnabled; }
+
+void Scale::setScalingEnabled(bool newScalingEnabled)
+{
+	m_scalingEnabled = newScalingEnabled;
+	m_scaleCb->setVisible(newScalingEnabled);
+}
+
+QComboBox *Scale::scaleCb() const { return m_scaleCb; }
+
+QString Scale::unit() const { return m_unit; }
+
+void Scale::setUnit(const QString &newUnit)
+{
+	m_unit = newUnit;
+	// when using custom scales changing the unit also resets the scale
+	if(!m_hasPrefix) {
+		// reset scale options to new unit
+		m_scaleOptions.clear();
+		m_scaleOptions.append({m_unit, 1e0});
+	}
+	populateScaleCb();
+}
+
+void Scale::computeScale(double value)
+{
+	// if there is only one option in the scale use that
+	if(m_scaleCb->count() == 0) {
+		return;
+	}
+	// use absolute value when computing scale
+	double val = abs(value);
+	// check if value can be upscaled or downscaled if scaled is changed update scale
+	int curretnScaleIndex = m_scaleCb->currentIndex();
+	// value is bigger than current scale
+	if(val > m_scaleCb->itemData(curretnScaleIndex).toDouble()) {
+		if(curretnScaleIndex != m_scaleCb->count() - 1) {
+			int i = 0;
+			// find coresponding upper scale
+			while((val >= m_scaleCb->itemData(curretnScaleIndex + i).toDouble()) &&
+			      ((curretnScaleIndex + i) <= m_scaleCb->count() - 1)) {
+				i++;
+			}
+			m_scaleCb->setCurrentIndex(curretnScaleIndex + i - 1);
+		}
+	} else {
+		// value is lower than current scale
+		int i = curretnScaleIndex;
+		// find coresponding lower scale
+		while((val < m_scaleCb->itemData(i).toDouble()) && (i > 0)) {
+			i--;
+		}
+		m_scaleCb->setCurrentIndex(i);
+	}
+}
+
+bool Scale::hasPrefix() const { return m_hasPrefix; }
+
+void Scale::setHasPrefix(bool newHasPrefix)
+{
+	m_hasPrefix = newHasPrefix;
+	populateScaleCb();
+}
+
+void Scale::populateScaleCb()
+{
+	m_scaleCb->clear();
+	if(m_hasPrefix) {
+		for(int i = 0; i < m_scalePrefixes.count(); i++) {
+			auto scale = m_scalePrefixes[i].scale;
+			m_scaleCb->addItem(m_scalePrefixes[i].prefix + m_unit, scale);
+		}
+	} else {
+		for(int i = 0; i < m_scaleOptions.count(); i++) {
+			m_scaleCb->addItem(m_scaleOptions[i].option, m_scaleOptions[i].scale);
+		}
+	}
+
+	Q_EMIT scaleUpdated();
+}
+
+QList<UnitPrefix> Scale::scalePrefixes() const { return m_scalePrefixes; }
+
+void Scale::setScalePrefixes(const QList<UnitPrefix> &newScalePrefixes)
+{
+	m_scalePrefixes = newScalePrefixes;
+	populateScaleCb();
+}
+
+QList<ScaleOption> Scale::scaleOptions() const { return m_scaleOptions; }
+
+void Scale::setScaleOptions(const QList<ScaleOption> &newScaleOptions)
+{
+	m_scaleOptions = newScaleOptions;
+	populateScaleCb();
+}
+
+} // namespace gui
+} // namespace scopy
+
+#include "moc_scale.cpp"

--- a/iio-widgets/src/guistrategy/rangeguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/rangeguistrategy.cpp
@@ -40,7 +40,6 @@ RangeAttrUi::RangeAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget 
 
 	m_spinBox = new gui::MenuSpinbox(m_recipe.data, 0, "", 0, 1, true, false, false, m_ui);
 	m_spinBox->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
-	m_spinBox->setScaleRange(1, 1);
 	m_spinBox->setScalingEnabled(false);
 	m_ui->layout()->addWidget(m_spinBox);
 

--- a/plugins/adc/src/freq/fftplotcomponentsettings.cpp
+++ b/plugins/adc/src/freq/fftplotcomponentsettings.cpp
@@ -68,6 +68,8 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 									 MenuCollapseSection::MHW_BASEWIDGET, parent);
 
 	m_yCtrl = new MenuPlotAxisRangeControl(m_plotComponent->fftPlot()->yAxis(), this);
+	m_yCtrl->minSpinbox()->scale()->setHasPrefix(false);
+	m_yCtrl->maxSpinbox()->scale()->setHasPrefix(false);
 	m_yCtrl->minSpinbox()->setIncrementMode(MenuSpinbox::IS_FIXED);
 	m_yCtrl->maxSpinbox()->setIncrementMode(MenuSpinbox::IS_FIXED);
 	m_yCtrl->minSpinbox()->setUnit("dB");
@@ -76,8 +78,6 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_yCtrl->maxSpinbox()->setMinValue(-1000);
 	m_yCtrl->minSpinbox()->setMaxValue(1000);
 	m_yCtrl->maxSpinbox()->setMaxValue(1000);
-	m_yCtrl->minSpinbox()->setScaleRange(1, 1);
-	m_yCtrl->maxSpinbox()->setScaleRange(1, 1);
 
 	MenuOnOffSwitch *m_autoscaleBtn = new MenuOnOffSwitch(tr("AUTOSCALE"), plotMenu, false);
 	m_autoscaler = new PlotAutoscaler(this);
@@ -96,8 +96,7 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_plotComponent->fftPlot()->yAxis()->getFormatter()->setTwoDecimalMode(false);
 
 	m_yPwrOffset = new MenuSpinbox("Power Offset", 0, "dB", -300, 300, true, false, yaxis);
-	m_yPwrOffset->setScaleRange(1, 1);
-	m_yPwrOffset->setIncrementMode(MenuSpinbox::IS_FIXED);
+	m_yPwrOffset->scale()->setHasPrefix(false);
 
 	m_windowCb = new MenuCombo("Window", yaxis);
 

--- a/plugins/adc/src/freq/fftplotmanagersettings.cpp
+++ b/plugins/adc/src/freq/fftplotmanagersettings.cpp
@@ -108,7 +108,8 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 									   MenuCollapseSection::MHW_BASEWIDGET, parent);
 
 	m_bufferSizeSpin = new MenuSpinbox("Buffer Size", 16, "samples", 0, 4000000, true, false, section);
-	m_bufferSizeSpin->setScaleRange(1, 1e6);
+	m_bufferSizeSpin->setIncrementMode(MenuSpinbox::IS_POW2);
+	m_bufferSizeSpin->scale()->setScalePrefixes({{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setBufferSize((uint32_t)val); });
 
 	QWidget *xMinMax = new QWidget(section);
@@ -118,10 +119,7 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 	xMinMax->setLayout(xMinMaxLayout);
 
 	m_xmin = new MenuSpinbox("XMin", 0, "samples", -DBL_MAX, DBL_MAX, true, false, xMinMax);
-	m_xmin->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
-
 	m_xmax = new MenuSpinbox("XMax", 0, "samples", -DBL_MAX, DBL_MAX, true, false, xMinMax);
-	m_xmax->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
 
 	connect(m_xmin, &MenuSpinbox::valueChanged, this,
 		[=](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
@@ -194,6 +192,7 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_sampleRateSpin = new MenuSpinbox("Sample Rate", 1, "Hz", 0, DBL_MAX, true, false, section);
 	m_sampleRateSpin->setIncrementMode(MenuSpinbox::IS_125);
+	m_sampleRateSpin->scale()->setHasPrefix(false);
 
 	m_sampleRateSpin->setValue(10);
 	m_sampleRateSpin->setEnabled(false);

--- a/plugins/adc/src/freq/grfftchannelcomponent.cpp
+++ b/plugins/adc/src/freq/grfftchannelcomponent.cpp
@@ -239,8 +239,7 @@ QWidget *GRFFTChannelComponent::createMarkerMenu(QWidget *parent)
 	fixedMarkerEditBtn->setVisible(false);
 
 	MenuSpinbox *markerCnt = new MenuSpinbox("Marker count", 5, "markers", 0, 9, true, false, section);
-	markerCnt->setIncrementMode(MenuSpinbox::IS_FIXED);
-	markerCnt->setScaleRange(1, 10);
+	markerCnt->scale()->setHasPrefix(false);
 	markerCnt->setValue(5);
 
 	connect(markerCnt, &MenuSpinbox::valueChanged, this, [=](double cnt) {

--- a/plugins/adc/src/time/grtimechannelcomponent.cpp
+++ b/plugins/adc/src/time/grtimechannelcomponent.cpp
@@ -274,8 +274,8 @@ void GRTimeChannelComponent::setYModeHelper(YMode mode)
 		}
 		scale = 1.0 / ((float)((uint64_t)1 << fmt->bits));
 		if(fmt->is_signed) {
-			ymin = -0.5;
-			ymax = 0.5;
+			ymin = -1;
+			ymax = 1;
 		} else {
 			ymin = 0;
 			ymax = 1;

--- a/plugins/adc/src/time/timeplotcomponentsettings.cpp
+++ b/plugins/adc/src/time/timeplotcomponentsettings.cpp
@@ -306,6 +306,11 @@ void TimePlotComponentSettings::updateYAxis()
 			min = s->yMin();
 		}
 	}
+	m_yCtrl->minSpinbox()->setMinValue(min);
+	m_yCtrl->minSpinbox()->setMaxValue(max);
+	m_yCtrl->maxSpinbox()->setMinValue(min);
+	m_yCtrl->maxSpinbox()->setMaxValue(max);
+
 	m_yCtrl->setMin(min);
 	m_yCtrl->setMax(max);
 

--- a/plugins/adc/src/time/timeplotmanagersettings.cpp
+++ b/plugins/adc/src/time/timeplotmanagersettings.cpp
@@ -109,7 +109,8 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	bufferPlotSize->setLayout(bufferPlotSizeLayout);
 
 	m_bufferSizeSpin = new MenuSpinbox("Buffer Size", 16, "samples", 16, 4000000, true, false, bufferPlotSize);
-	m_bufferSizeSpin->setScaleRange(1, 1e6);
+	m_bufferSizeSpin->setIncrementMode(MenuSpinbox::IS_POW2);
+	m_bufferSizeSpin->scale()->setScalePrefixes({{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 
 	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) {
 		if(m_plotSizeSpin->value() < val) {
@@ -122,7 +123,8 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	connect(this, &TimePlotManagerSettings::bufferSizeChanged, m_bufferSizeSpin, &MenuSpinbox::setValue);
 
 	m_plotSizeSpin = new MenuSpinbox("Plot Size", 16, "samples", 0, 4000000, true, false, bufferPlotSize);
-	m_plotSizeSpin->setScaleRange(1, 1e6);
+	m_plotSizeSpin->setIncrementMode(MenuSpinbox::IS_POW2);
+	m_plotSizeSpin->scale()->setScalePrefixes({{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 
 	connect(m_plotSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setPlotSize((uint32_t)val); });
 
@@ -153,10 +155,7 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	xMinMax->setLayout(xMinMaxLayout);
 
 	m_xmin = new MenuSpinbox("XMin", -1, "samples", -DBL_MAX, DBL_MAX, true, false, xMinMax);
-	m_xmin->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
-
 	m_xmax = new MenuSpinbox("XMax", -1, "samples", -DBL_MAX, DBL_MAX, true, false, xMinMax);
-	m_xmax->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
 
 	connect(m_xmin, &MenuSpinbox::valueChanged, this,
 		[=](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
@@ -177,9 +176,14 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 		if(xcb->itemData(idx) == XMODE_SAMPLES) {
 			m_sampleRateSpin->setValue(1);
 			m_xmin->setUnit("samples");
-			m_xmin->setScaleRange(1, 1e6);
+			m_xmin->scale()->setHasPrefix(true);
+			m_xmin->scale()->setScalePrefixes(
+				{{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
+
 			m_xmax->setUnit("samples");
-			m_xmax->setScaleRange(1, 1e6);
+			m_xmax->scale()->setHasPrefix(true);
+			m_xmax->scale()->setScalePrefixes(
+				{{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 			m_plotManager->setXUnit("samples");
 			for(PlotComponent *plt : m_plotManager->plots()) {
 				auto p = dynamic_cast<TimePlotComponent *>(plt);
@@ -191,10 +195,21 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 			m_sampleRateSpin->setVisible(true);
 			m_sampleRateSpin->setEnabled(false);
 			m_sampleRateSpin->setValue(readSampleRate());
+
 			m_xmin->setUnit("s");
-			m_xmin->setScaleRange(0, 1);
+			m_xmin->scale()->setHasPrefix(false);
+			m_xmin->scale()->setScaleOptions({{QString("ns"), 1e-9},
+							  {QString("us"), 1e-6},
+							  {QString("ms"), 1e-3},
+							  {QString("s"), 1}});
+
 			m_xmax->setUnit("s");
-			m_xmax->setScaleRange(0, 1);
+			m_xmax->scale()->setHasPrefix(false);
+			m_xmax->scale()->setScaleOptions({{QString("ns"), 1e-9},
+							  {QString("us"), 1e-6},
+							  {QString("ms"), 1e-3},
+							  {QString("s"), 1}});
+
 			m_plotManager->setXUnit("s");
 
 			for(PlotComponent *plt : m_plotManager->plots()) {
@@ -209,9 +224,19 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 			m_sampleRateSpin->setEnabled(true);
 
 			m_xmin->setUnit("s");
-			m_xmin->setScaleRange(0, 1);
+			m_xmin->scale()->setHasPrefix(false);
+			m_xmin->scale()->setScaleOptions({{QString("ns"), 1e-9},
+							  {QString("us"), 1e-6},
+							  {QString("ms"), 1e-3},
+							  {QString("s"), 1}});
+
 			m_xmax->setUnit("s");
-			m_xmax->setScaleRange(0, 1);
+			m_xmax->scale()->setHasPrefix(false);
+			m_xmax->scale()->setScaleOptions({{QString("ns"), 1e-9},
+							  {QString("us"), 1e-6},
+							  {QString("ms"), 1e-3},
+							  {QString("s"), 1}});
+
 			m_plotManager->setXUnit("s");
 			for(PlotComponent *plt : m_plotManager->plots()) {
 				auto p = dynamic_cast<TimePlotComponent *>(plt);

--- a/plugins/dac/src/bufferdacaddon.cpp
+++ b/plugins/dac/src/bufferdacaddon.cpp
@@ -80,6 +80,7 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 	buffersizeContainer->setProperty("tutorial_name", "BUFFERSIZE");
 	m_bufferSizeSpin =
 		new MenuSpinbox("Buffer size", 0, "samples", 16, 16 * 1024 * 1024, true, false, buffersizeContainer);
+	m_bufferSizeSpin->scale()->setScalePrefixes({{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 	StyleHelper::BackgroundWidget(m_bufferSizeSpin);
 	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this,
 		[&](double value) { m_model->setBuffersize(value); });
@@ -91,7 +92,7 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 	MenuSectionWidget *kernelContainer = new MenuSectionWidget(this);
 	kernelContainer->setProperty("tutorial_name", "KERNEL_BUFFERS");
 	m_kernelCountSpin = new MenuSpinbox("Kernel buffers", 0, "", 1, 64, true, false, buffersizeContainer);
-	m_kernelCountSpin->setIncrementMode(MenuSpinbox::IS_FIXED);
+	m_kernelCountSpin->setScalingEnabled(false);
 	StyleHelper::BackgroundWidget(m_kernelCountSpin);
 	connect(m_kernelCountSpin, &MenuSpinbox::valueChanged, this,
 		[&](double value) { m_model->setKernelBuffersCount(value); });
@@ -101,6 +102,7 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 
 	// Decimation section - hidden for now
 	MenuSpinbox *decimationSpin = new MenuSpinbox("Decimation", 0, "", 1, 1000, true, false, bufferConfigSection);
+	decimationSpin->setIncrementMode(MenuSpinbox::IS_POW2);
 	StyleHelper::BackgroundWidget(decimationSpin);
 	connect(decimationSpin, &MenuSpinbox::valueChanged, this, [&](double value) { m_model->setDecimation(value); });
 	decimationSpin->setValue(1);
@@ -162,12 +164,11 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 	filesizeContainer->setProperty("tutorial_name", "FILESIZE");
 	m_fileSizeSpin =
 		new MenuSpinbox("File size", 0, "samples", 16, 16 * 1024 * 1024, false, false, filesizeContainer);
-	m_fileSizeSpin->setIncrementMode(MenuSpinbox::IS_FIXED);
 	StyleHelper::BackgroundWidget(m_fileSizeSpin);
 	connect(
 		m_fileSizeSpin, &MenuSpinbox::valueChanged, this, [&](double value) { m_model->setFilesize(value); },
 		Qt::QueuedConnection);
-	m_fileSizeSpin->setScaleRange(1, 16 * 1024 * 1024);
+	m_fileSizeSpin->scale()->setScalePrefixes({{QString(""), 1e0}, {QString("k"), 1e3}, {QString("M"), 1e6}});
 	m_fileSizeSpin->setValue(16);
 	filesizeContainer->contentLayout()->addWidget(m_fileSizeSpin);
 	filesizeContainer->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);

--- a/plugins/datalogger/src/menus/datamonitorsettings.cpp
+++ b/plugins/datalogger/src/menus/datamonitorsettings.cpp
@@ -129,7 +129,6 @@ QWidget *DataMonitorSettings::generateYAxisSettings(QWidget *parent)
 	plotAutoscaler->setTolerance(10);
 
 	MenuOnOffSwitch *autoscale = new MenuOnOffSwitch(tr("AUTOSCALE"), yAxisSection, false);
-	autoscale->onOffswitch()->setChecked(true);
 
 	connect(autoscale->onOffswitch(), &QAbstractButton::toggled, this, [=, this](bool toggled) {
 		plotYAxisController->setEnabled(!toggled);
@@ -139,6 +138,8 @@ QWidget *DataMonitorSettings::generateYAxisSettings(QWidget *parent)
 			plotAutoscaler->stop();
 		}
 	});
+
+	autoscale->onOffswitch()->setChecked(true);
 
 	auto &&timeTracker = TimeManager::GetInstance();
 

--- a/plugins/datalogger/src/menus/plottimeaxiscontroller.cpp
+++ b/plugins/datalogger/src/menus/plottimeaxiscontroller.cpp
@@ -61,8 +61,8 @@ PlotTimeAxisController::PlotTimeAxisController(MonitorPlot *m_plot, QWidget *par
 
 	m_xdelta = new gui::MenuSpinbox("Delta", DataMonitorUtils::getAxisDefaultMaxValue(), "s", 0, DBL_MAX, false,
 					false, xAxisContainer);
-	m_xdelta->setScaleRange(1, 1);
-	m_xdelta->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
+	m_xdelta->scale()->setHasPrefix(false);
+	m_xdelta->scale()->setScaleOptions({{QString("s"), 1}, {QString("min"), 60}, {QString("h"), 3600}});
 	m_xdelta->setValue(DataMonitorUtils::getAxisDefaultMaxValue());
 
 	auto &&timeTracker = TimeManager::GetInstance();

--- a/plugins/pqm/src/waveforminstrument.cpp
+++ b/plugins/pqm/src/waveforminstrument.cpp
@@ -182,7 +182,6 @@ QWidget *WaveformInstrument::createMenuPlotSection(QWidget *parent)
 
 	// timespan
 	m_timespanSpin = new gui::MenuSpinbox(tr("Timespan"), 1, "s", 0.02, 10, true, false, plotSection);
-	m_timespanSpin->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
 	m_timespanSpin->setValue(1);
 	connect(m_timespanSpin, &gui::MenuSpinbox::valueChanged, this, [=, this](double value) {
 		m_voltagePlot->xAxis()->setMin(-value);

--- a/plugins/swiot/src/ad74413r/ad74413r.cpp
+++ b/plugins/swiot/src/ad74413r/ad74413r.cpp
@@ -700,7 +700,7 @@ QWidget *Ad74413r::createSettingsMenu(QWidget *parent)
 
 	// timespan
 	m_timespanSpin = new MenuSpinbox(tr("Timespan"), 1, "s", 0.1, 10, true, false, plotTimespanSection);
-	m_timespanSpin->setIncrementMode(MenuSpinbox::IS_FIXED);
+	m_timespanSpin->scale()->setHasPrefix(false);
 	connect(m_timespanSpin, &MenuSpinbox::valueChanged, this,
 		[=, this](double value) { m_plot->xAxis()->setMin(-value); });
 

--- a/plugins/swiot/src/ad74413r/buffermenuview.cpp
+++ b/plugins/swiot/src/ad74413r/buffermenuview.cpp
@@ -140,11 +140,7 @@ QWidget *BufferMenuView::createVerticalSettingsMenu(QString unit, double yMin, d
 		"Y-AXIS", MenuCollapseSection::MHCW_NONE, MenuCollapseSection::MHW_BASEWIDGET, verticalContainer);
 
 	auto m_yMin = new MenuSpinbox("YMin", yMin, unit, -DBL_MAX, DBL_MAX, true, false, verticalContainer);
-	m_yMin->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
-
 	auto m_yMax = new MenuSpinbox("YMax", yMax, unit, -DBL_MAX, DBL_MAX, true, false, verticalContainer);
-	m_yMax->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
-
 	layout->addWidget(m_yMin);
 	layout->addWidget(m_yMax);
 

--- a/plugins/swiot/src/max14906/diosettingstab.cpp
+++ b/plugins/swiot/src/max14906/diosettingstab.cpp
@@ -51,8 +51,7 @@ DioSettingsTab::DioSettingsTab(QWidget *parent)
 
 	// timespan
 	m_maxSpinButton = new MenuSpinbox(tr("Timespan"), 10, "s", 1, 300, true, false, this);
-	m_maxSpinButton->setIncrementMode(MenuSpinbox::IS_FIXED);
-	m_maxSpinButton->setScaleRange(1, 1);
+	m_maxSpinButton->scale()->setHasPrefix(false);
 
 	connect(m_maxSpinButton, &MenuSpinbox::valueChanged, this,
 		[this]() { Q_EMIT timeValueChanged(m_maxSpinButton->value()); });


### PR DESCRIPTION
This is an rework on current menu spinbox
the main issues this fixes are :

- allowing custom prefix scales ( replacing setScaleRange)
- allowing custom scales
- option to have scales with no prefix
- fixed some issues with user input
  - if wrong value is introduces reset to previous value
  - introducing a number value followed by random text will not update scale to the value
- automatic upscale and downscale updates
    - will no longer scale down on value 10
    - updated decrement result to consider scale down option ( scale up on increment was automatically done )
- having scaling disabled will not scale values