### PR TITLE
Add optional fast compile using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Default build type: RelWithDebInfo" FORCE)
 endif()
 
+find_program(CCACHE_FOUND ccache)
+if(NOT DEFINED ENV{BUILD_HOST} AND CCACHE_FOUND)
+	message(STATUS "Using ccache.")
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+else()
+	message(STATUS "Not using ccache.")
+endif()
+
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${PROJECT_SOURCE_DIR}/cmake/Modules)
 


### PR DESCRIPTION
### What is it and how it works?
This option allows users to build the application faster then normally. It works by caching the object files in `${HOME}/.cache/ccache` the first time c/c++ file is compiled so that the next time the file is encountered (e.g. during a clean build) it can just copy the cached object file, instead of compiling it again. This provides a very significant speedup to the build process. Read more: https://ccache.dev/

### How to enable it?
This feature will not work just by having this commit, you also have to install the `ccache` program (e.g. apt install). It will not work on the CI builds for Scopy (it would be useless there anyways). To clean the cache memory you can just run `ccache -C`. If you do not want this feature at all, uninstalling `ccache` will suffice. 
 
### How to test it?
On this branch, install the `ccache` program and perform a clean Scopy build (approx 3 mins). After that, delete/clean the build folder and build again (approx 30 sec)

### <sup><sub>Special thanks to Dragos for the recomandation</sub></sup>