### PR TITLE
logic analyzer: fix annotation empty string causing infinite loop

### DIFF
--- a/src/logicanalyzer/annotationcurve.cpp
+++ b/src/logicanalyzer/annotationcurve.cpp
@@ -700,16 +700,27 @@ uint64_t AnnotationCurve::getMaxAnnotationCount(int index)
 
 QString AnnotationCurve::shortenAnnotationText(const QString text, const double maxWidth, QPainter *painter) const
 {
-    const int padding = 12;
-    const QString extension = "...";
-    int count = 0;
+	const int PADDING = 12;
+	const QString EXTENSION = "...";
+	int count = 0;
 
-    // find maximum number of characters that fit
-    while(QSizeF(QwtText(text.left(count) + extension).textSize(painter->font())).width() <= maxWidth - padding) {
-	count++;
-    }
+	bool isWithinTextLength = true;
+	bool isWithinMaxWidth = true;
 
-    return count ? text.left(count) + extension : "";
+	// Empty text or maxWidth is too small to even fit the extension
+	if(text.isEmpty() || maxWidth <= PADDING + painter->fontMetrics().horizontalAdvance(EXTENSION)) {
+		return EXTENSION;
+	}
+
+	// find maximum number of characters that fit
+	while(isWithinTextLength && isWithinMaxWidth) {
+		count++;
+		isWithinTextLength = count < text.length();
+		isWithinMaxWidth = QSizeF(QwtText(text.left(count) + EXTENSION).textSize(painter->font())).width() <=
+			maxWidth - PADDING;
+	}
+
+	return isWithinTextLength ? text.left(count) + EXTENSION : "";
 }
 
 


### PR DESCRIPTION
- Handle the edge case where an empty string passed to the shortenAnnotationText function causes an infinite loop.
- This fix ensures that the function returns the extension ("...") when the text is empty or the maxWidth is too small to fit the extension.