### PR TITLE
core: check if the uri already exists when adding a new device in browser

### DIFF
--- a/core/src/devicemanager.cpp
+++ b/core/src/devicemanager.cpp
@@ -67,6 +67,11 @@ void DeviceManager::addDevice(Device *d)
 
 QString DeviceManager::createDevice(QString category, QString param, bool async, QList<QString> plugins)
 {
+	for(Device *val : qAsConst(map)) {
+		if(val->param() == param) {
+			return "";
+		}
+	}
 	qInfo(CAT_DEVICEMANAGER) << category << "device with params" << param << "added";
 	Q_EMIT deviceAddStarted(param);
 


### PR DESCRIPTION
If the device was saved as selected for auto-connection from a previous session but the same device is also detected during scanning, the browser will have duplicate entries of the same device, allowing us to connect to both. This should not be possible in most cases: the best example is the ADALM2000 USB connection.