### PR TITLE
preferences: add description to preferences and autogenerate the docs

### DIFF
--- a/.github/workflows/generate_doc.yml
+++ b/.github/workflows/generate_doc.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Build doc
       working-directory: docs
       run: |
+        python3 extract_macros.py ../ user_guide/preferences_table.rst
         make html SPHINXOPTS='-W --keep-going'
 
     - name: Store the generated doc

--- a/core/src/scopypreferencespage.cpp
+++ b/core/src/scopypreferencespage.cpp
@@ -158,8 +158,10 @@ QWidget *ScopyPreferencesPage::buildSaveSessionPreference()
 	QHBoxLayout *lay = new QHBoxLayout(w);
 	lay->setMargin(0);
 
-	lay->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "general_save_session", "Save/Load Scopy session", this));
+	lay->addWidget(PREFERENCE_CHECK_BOX(p, "general_save_session", "Save/Load Scopy session",
+					    "Allow Scopy to automatically save/load the session "
+					    "using .ini files into a predefined location.",
+					    this));
 	lay->addSpacerItem(new QSpacerItem(40, 40, QSizePolicy::Expanding, QSizePolicy::Fixed));
 	lay->addWidget(new QLabel("Settings files location ", this));
 	QPushButton *navigateBtn = new QPushButton("Open", this);
@@ -242,41 +244,96 @@ QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 	lay->addWidget(generalWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_save_attached", "Save/Load tool attached state", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_doubleclick_attach", "Doubleclick to attach/detach tool", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_doubleclick_ctrl_opens_menu", "Doubleclick control buttons to open menu", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_opengl", "Enable OpenGL plotting", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_animations", "Enable menu animations", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_check_online_version", "Enable automatic online check for updates.", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_save_attached", "Save/Load tool attached state",
+				     "Allow Scopy to save the state of all instruments, whether they were "
+				     "detached/attached when the application was closed, and load this "
+				     "state accordingly when the application restarts.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_doubleclick_attach", "Doubleclick to attach/detach tool",
+				     "Indicates whether double-clicking attaches instruments in the application. "
+				     "Enabling this option allows the user to quickly attach instruments by "
+				     "double-clicking on them.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "general_doubleclick_ctrl_opens_menu", "Doubleclick control buttons to open menu",
+		"Enable the double click action for menu opening.", generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_use_opengl", "Enable OpenGL plotting",
+				     "Use OpenGL accelerated plotting in order to speed-up the process and "
+				     "avoid blocking the application while large numbers of samples are "
+				     "displayed. This feature may not be supported on all systems.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_use_animations", "Enable menu animations",
+				     "Enable a smooth sliding transition effect for menus when they are "
+				     "opened or closed.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_check_online_version", "Enable automatic online check for updates.",
+				     "Indicates whether the application should check for online version updates. "
+				     "Enabling this option allows the application to automatically check for and "
+				     "notify the user of available updates at startup.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
 		p, "general_show_status_bar", "Enable the status bar for displaying important messages.",
+		"Indicates whether the status bar should be displayed in the application. This setting "
+		"allows the user to enable or disable the status bar, which provides information about "
+		"the current state of the application. "
+		"Important messages such as connection done or alerts are displayed here.",
 		generalSection));
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "show_grid", "Show Grid", generalSection));
+		PREFERENCE_CHECK_BOX(p, "show_grid", "Show Grid",
+				     "Indicates whether the plot grid is visible across the application. "
+				     "The user can enable or disable this in order to configure the ",
+				     generalSection));
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "show_graticule", "Show Graticule", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "iiowidgets_use_lazy_loading", "Use Lazy Loading", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_native_dialogs", "Use native dialogs", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "font_scale", "Font scale (EXPERIMENTAL)", {"1", "1.15", "1.3", "1.45", "1.6", "1.75", "1.9"},
+		PREFERENCE_CHECK_BOX(p, "show_graticule", "Show Graticule",
+				     "This setting allows the user to enable or disable the display of the graticule "
+				     "on all the plots in the application for better signal visualization.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "iiowidgets_use_lazy_loading", "Use Lazy Loading",
+				     "Indicates whether lazy loading should be used for IIO widgets. "
+				     "Enabling this option allows the application to load IIO widgets only "
+				     "when they are needed, improving startup performance.",
+				     generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "general_use_native_dialogs", "Use native dialogs",
+				     "Indicates whether native dialogs should be used in the application. "
+				     "This setting allows the user to enable or disable the use of native file "
+				     "dialogs and other system dialogs within the application.",
+				     generalSection));
+
+	QStringList font_scale_options = {"1", "1.15", "1.3", "1.45", "1.6", "1.75", "1.9"};
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "font_scale", "Font scale (EXPERIMENTAL)",
+				 "Scale factor for the font size used across the application, suitable for "
+				 "different display settings.",
+				 font_scale_options, generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "general_theme", "Theme",
+				 "Theme setting for the application interface. "
+				 "The user can choose between Harmonic style (light or dark) or Scopy style.",
+				 Style::GetInstance()->getThemeList(), generalSection));
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "general_language", "Language",
+				 "Language setting for the application interface. "
+				 "Multiple options available, check out the documentation if a new language is needed.",
+				 t->getLanguages(), generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "general_connect_to_multiple_devices", "Connect to multiple devices (EXPERIMENTAL)",
+		"Allows the application to connect to multiple devices simultaneously, providing a mechanism "
+		"to handle them separately using different sections in the left side menu. "
+		"Due to not being tested using enough scenarios it is still marked as an experimental feature.",
 		generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "general_theme", "Theme", Style::GetInstance()->getThemeList(), generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "general_language", "Language", t->getLanguages(), generalSection));
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "general_connect_to_multiple_devices",
-							 "Connect to multiple devices (EXPERIMENTAL)", generalSection));
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_scan_for_devices", "Regularly scan for new devices", generalSection));
+		PREFERENCE_CHECK_BOX(p, "general_scan_for_devices", "Regularly scan for new devices",
+				     "Select whether Scopy should be able to search for new devices periodically, "
+				     "allowing the application to automatically populate the device list with connected"
+				     "devices. Otherwise, all devices need to be added manually from the Add page.",
+				     generalSection));
 
 	// Auto-connect
 	m_autoConnectWidget = new MenuSectionCollapseWidget("Session ", MenuCollapseSection::MHCW_NONE,
@@ -287,8 +344,11 @@ QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 	lay->addWidget(m_autoConnectWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	QWidget *autoConnectCb = PreferencesHelper::addPreferenceCheckBox(
-		p, "autoconnect_previous", "Auto-connect to previous session", generalSection);
+	QWidget *autoConnectCb = PREFERENCE_CHECK_BOX(p, "autoconnect_previous", "Auto-connect to previous session",
+						      "Automatically use the saved URI to connect to previous devices, "
+						      "if available, when the application starts. This speeds up the "
+						      "connection process and reduces the number of necessary steps.",
+						      generalSection);
 	m_autoConnectWidget->contentLayout()->addWidget(autoConnectCb);
 
 	m_autoConnectWidget->contentLayout()->addWidget(buildSaveSessionPreference());
@@ -317,9 +377,16 @@ QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
 	debugSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "general_show_plot_fps", "Show plot FPS", debugSection));
-	debugSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "general_plot_target_fps", "Plot target FPS", {"15", "20", "30", "60"}, debugSection));
+		PREFERENCE_CHECK_BOX(p, "general_show_plot_fps", "Show plot FPS",
+				     "Indicates whether the frames per second should be displayed in plots "
+				     "across the entire application.",
+				     debugSection));
+
+	QStringList fps_options = {"15", "20", "30", "60"};
+	debugSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "general_plot_target_fps", "Plot target FPS",
+				 "Select the Frames per second value for rendering plots in the entire application.",
+				 fps_options, debugSection));
 	debugSection->contentLayout()->addWidget(buildResetScopyDefaultButton());
 
 	return page;

--- a/docs/extract_macros.py
+++ b/docs/extract_macros.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import re
+
+def split_arguments(args):
+    arg_lst = []
+    current = []
+    inside_string = False
+    for char in args:
+        if char == '"' and (not current or current[-1] != '\\'):
+            inside_string = not inside_string
+        if char == ',' and not inside_string:
+            arg_lst.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    arg_lst.append(''.join(current).strip())
+    return arg_lst
+
+def parse_file(file_path, macro_name):
+    macros = []
+    with open(file_path, "r") as file:
+        content = file.read()
+        match_lst = re.findall(re.escape(macro_name) + r'\s*\((.*?)\)', content, re.DOTALL)
+        for match in match_lst:
+            args = split_arguments(match)
+            if len(args) >= 4 and args[1] != "id":
+                id_arg = args[1].replace('"', '')
+                title_arg = args[2].replace('"', '')
+                description_arg = args[3].replace('"', '')
+                description_arg = description_arg.replace('\n', '')
+                description_arg = description_arg.replace('\t', '')
+                description_arg.strip()
+                macros.append((id_arg, title_arg, description_arg))
+    return macros
+
+def search_files_in_path(search_path):
+    all_macros = []
+    macro_pattern = ['PREFERENCE_CHECK_BOX', 'PREFERENCE_EDIT', 'PREFERENCE_COMBO', 'PREFERENCE_COMBO_LIST']
+    for root, _, files in os.walk(search_path):
+        for file in files:
+            if file.endswith(('.cpp', '.h')):
+                for macro in macro_pattern:
+                    macros_in_file = parse_file(os.path.join(root, file), macro)
+                    all_macros.extend(macros_in_file)
+    return all_macros
+
+def output_to_rst_table(macros, output_rst_file):
+    with open(output_rst_file, "w") as file:
+        file.write(".. list-table::\n")
+        file.write("   :header-rows: 1\n")
+        file.write("   :widths: 20 40 50\n\n")
+        file.write("   * - ID\n")
+        file.write("     - Title\n")
+        file.write("     - Description\n")
+        for macro in macros:
+            file.write(f"   * - {macro[0]}\n")
+            file.write(f"     - {macro[1]}\n")
+            file.write(f"     - {macro[2]}\n")
+
+if len(sys.argv) != 3:
+    print("python extract_macros.py <search_path> <output_rst_file>")
+    sys.exit(1)
+
+search_path = sys.argv[1]
+output_rst_file = sys.argv[2]
+macros = search_files_in_path(search_path)
+output_to_rst_table(macros, output_rst_file)

--- a/docs/user_guide/preferences.rst
+++ b/docs/user_guide/preferences.rst
@@ -8,10 +8,13 @@ Scopy Preferences
     :align: center
 ..
 
+.. image:: https://raw.githubusercontent.com/analogdevicesinc/scopy/doc_resources/resources/scopy-general-prefs2.png
+    :align: center
+..
+
   Scopy Preferences can be accessed using the bottom left side **preferences
   button**. On the right side of the page, preferences for each plugin
-  are available. More details can be found in their specific plugin
-  documentation section.
+  are available. 
 
   The **Open** button will try to open the specific OS explorer in 
   order to find the preference storage file.
@@ -20,7 +23,8 @@ Scopy Preferences
   configuration.
 
   Changing some of the listed preferences will require an application
-  restart. More details on each preference are listed below.
+  restart. More details on each preference, as well as their ID - used to 
+  identify them in the .ini files, can be found in the table below.
 
-
-
+.. include:: preferences_table.rst
+  

--- a/docs/user_guide/preferences_table.rst
+++ b/docs/user_guide/preferences_table.rst
@@ -1,0 +1,133 @@
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 50
+
+   * - ID
+     - Title
+     - Description
+   * - general_save_session
+     - Save/Load Scopy session
+     - Allow Scopy to automatically save/load the session     using .ini files into a predefined location.
+   * - general_save_attached
+     - Save/Load tool attached state
+     - Allow Scopy to save the state of all instruments, whether they were      detached/attached when the application was closed, and load this      state accordingly when the application restarts.
+   * - general_doubleclick_attach
+     - Doubleclick to attach/detach tool
+     - Indicates whether double-clicking attaches instruments in the application.      Enabling this option allows the user to quickly attach instruments by      double-clicking on them.
+   * - general_doubleclick_ctrl_opens_menu
+     - Doubleclick control buttons to open menu
+     - Enable the double click action for menu opening.
+   * - general_use_opengl
+     - Enable OpenGL plotting
+     - Use OpenGL accelerated plotting in order to speed-up the process and      avoid blocking the application while large numbers of samples are      displayed. This feature may not be supported on all systems.
+   * - general_use_animations
+     - Enable menu animations
+     - Enable a smooth sliding transition effect for menus when they are      opened or closed.
+   * - general_check_online_version
+     - Enable automatic online check for updates.
+     - Indicates whether the application should check for online version updates.      Enabling this option allows the application to automatically check for and      notify the user of available updates at startup.
+   * - general_show_status_bar
+     - Enable the status bar for displaying important messages.
+     - Indicates whether the status bar should be displayed in the application. This setting allows the user to enable or disable the status bar, which provides information about the current state of the application.Important messages such as connection done or alerts are displayed here.
+   * - show_grid
+     - Show Grid
+     - Indicates whether the plot grid is visible across the application.     The user can enable or disable this in order to configure the 
+   * - show_graticule
+     - Show Graticule
+     - This setting allows the user to enable or disable the display of the graticule      on all the plots in the application for better signal visualization.
+   * - iiowidgets_use_lazy_loading
+     - Use Lazy Loading
+     - Indicates whether lazy loading should be used for IIO widgets.      Enabling this option allows the application to load IIO widgets only      when they are needed, improving startup performance.
+   * - general_use_native_dialogs
+     - Use native dialogs
+     - Indicates whether native dialogs should be used in the application.     This setting allows the user to enable or disable the use of native file      dialogs and other system dialogs within the application.
+   * - general_scan_for_devices
+     - Regularly scan for new devices
+     - Select whether Scopy should be able to search for new devices periodically,      allowing the application to automatically populate the device list with connected     devices. Otherwise, all devices need to be added manually from the Add page.
+   * - autoconnect_previous
+     - Auto-connect to previous session
+     - Automatically use the saved URI to connect to previous devices,       if available, when the application starts. This speeds up the       connection process and reduces the number of necessary steps.
+   * - general_show_plot_fps
+     - Show plot FPS
+     - Indicates whether the frames per second should be displayed in plots      across the entire application.
+   * - general_theme
+     - Theme
+     - Theme setting for the application interface. The user can choose between Harmonic style (light or dark
+   * - general_language
+     - Language
+     - Language setting for the application interface. Multiple options available, check out the documentation if a new language is needed
+   * - general_plot_target_fps
+     - Plot target FPS
+     - Select the Frames per second value for rendering plots in the entire application.
+   * - regmap_color_by_value
+     - Use color to reflect value
+     - Select from various configurations available which elements in the Register Map  are color coded for better visual interpretation.
+   * - adc_acquisition_timeout
+     - ADC Acquisition timeout
+     - Select the timeout for the I/O operation. A valid value is a positive integer representing the time in milliseconds after which a timeout should occur. 
+   * - adc_plot_xaxis_label_position
+     - Plot X-Axis scale position
+     - Select whether the X-Axis labels are displayed on the top or bottom of the plot. Only applied after restart.
+   * - adc_plot_yaxis_label_position
+     - Plot Y-Axis scale position
+     - Select whether the Y-Axis labels are displayed on the left or right side of the       plot. Only applied after restart.
+   * - adc_plot_yaxis_handle_position
+     - Plot channel Y-handle position
+     - Select whether the Y-Axis handle is located on the left or right side of the plot.Only applied after restart.
+   * - adc_plot_xcursor_position
+     - Plot X-Cursor position
+     - Select whether the X-Axis cursor handles are located on the top or bottom of the plot.Only applied after restart.
+   * - adc_plot_ycursor_position
+     - Plot Y-Cursor position
+     - Select whether the Y-Axis cursor handles are located on the left or right side of the plot.Only applied after restart.
+   * - adc_default_y_mode
+     - ADC Default Y-Mode
+     - Select the Y-Axis default mode, can be either ADC Counts or %Full Scale. This is also controllable while running, from the instrument settings.Only applied after restart.
+   * - m2k_instrument_notes_active
+     - Instrument Notes
+     - Enable or disable a text section at the bottom of each ADALM2000 instrument, allowing the user to take notes. Disabled by default.
+   * - m2k_show_adc_filters
+     - Show ADC digital filter config
+     - Enable/disable the configuration panel for ADC digital filters.     This allows manual control over the parameters of the filters.
+   * - m2k_show_graticule
+     - Enable graticule
+     - Select whether the plot backbone (graticule
+   * - m2k_mini_histogram
+     - Enable mini histogram
+     - Select whether the Oscilloscope plot displays a histogram on the right side.
+   * - m2k_osc_filtering
+     - Enable sample rate filters
+     - Enable or disable the ADALM2000 ADC filters for all samplerates less than      100 MHz.
+   * - m2k_osc_label
+     - Enable labels on the plot
+     - Enable or disable the plot labels in the Oscilloscope instrument.
+   * - m2k_spectrum_visible_peak_search
+     - Only search marker peaks in visible domain
+     - Enabled by default, this control allows the Spectrum Analyzer to search for marker peaks outside the visible frequency range.
+   * - m2k_na_show_zero
+     - Always display 0db value on the graph
+     - Select whether the 0dB value is displayed as a reference point on the     Network Analyzer plot. This control is disabled by default.
+   * - m2k_logic_separate_annotations
+     - Separate decoder annotations when exporting
+     - Select whether to export decoder annotations and data separately from the      Logic Analyzer instrument. Disabled by default.
+   * - m2k_logic_display_sampling_points
+     - Display sampling points when zoomed
+     - Select whether to display each sampling point when zoomed in on the Logic Analyzer.Disabled by default.
+   * - m2k_logic_display_sample_time
+     - Show sample and time info in decoder table
+     - Select whether the sample and time detailed information is shown in the      decoder table of the Logic Analyzer. Enabled by default.
+   * - m2k_siggen_periods
+     - Number of displayed periods
+     - Select the number of displayed signal periods in the Signal Generator.Default value is 2.
+   * - plugins_use_debugger_v2
+     - Use Debugger V2 plugin
+     - Switch between the old style debugger instrument, having     just basic controls over attributes or the new instrument     type, IIO Explorer, having a tree-like structure.
+   * - debugger_v2_include_debugfs
+     - Include debug attributes in IIO Explorer
+     - Enable/disable the use of advanced debug attributes in the instrument.
+   * - dataloggerplugin_date_time_format
+     - DateTime format :
+     - Select the date time format of the instrument. Default value is: hh:mm:ss
+   * - dataloggerplugin_data_storage_size
+     - Maximum data stored for each monitor
+     - Select the maximum data storage size for each monitor in the datalogger.

--- a/gui/include/gui/preferenceshelper.h
+++ b/gui/include/gui/preferenceshelper.h
@@ -29,6 +29,18 @@
 
 #include <pluginbase/preferences.h>
 
+#define PREFERENCE_CHECK_BOX(p, id, title, description, parent)                                                        \
+	PreferencesHelper::addPreferenceCheckBox(p, id, title, description, parent)
+
+#define PREFERENCE_EDIT(p, id, title, description, parent)                                                             \
+	PreferencesHelper::addPreferenceEdit(p, id, title, description, parent)
+
+#define PREFERENCE_COMBO(p, id, title, description, options, parent)                                                   \
+	PreferencesHelper::addPreferenceCombo(p, id, title, description, options, parent)
+
+#define PREFERENCE_COMBO_LIST(p, id, title, description, options, parent)                                              \
+	PreferencesHelper::addPreferenceComboList(p, id, title, description, options, parent)
+
 namespace scopy {
 
 class SmallOnOffSwitch;
@@ -40,13 +52,15 @@ class SCOPY_GUI_EXPORT PreferencesHelper
 {
 
 public:
-	static QWidget *addPreferenceCheckBox(Preferences *p, QString id, QString description,
+	static QWidget *addPreferenceCheckBox(Preferences *p, QString id, QString title, QString description,
 					      QObject *parent = nullptr);
-	static QWidget *addPreferenceEdit(Preferences *p, QString id, QString description, QObject *parent = nullptr);
-	static QWidget *addPreferenceCombo(Preferences *p, QString id, QString description, QStringList options,
-					   QObject *parent = nullptr);
-	static QWidget *addPreferenceComboList(Preferences *p, QString id, QString description,
+	static QWidget *addPreferenceEdit(Preferences *p, QString id, QString title, QString description,
+					  QObject *parent = nullptr);
+	static QWidget *addPreferenceCombo(Preferences *p, QString id, QString title, QString description,
+					   QStringList options, QObject *parent = nullptr);
+	static QWidget *addPreferenceComboList(Preferences *p, QString id, QString title, QString description,
 					       QList<QPair<QString, QVariant>> options, QObject *parent);
+	static QWidget *setupDescriptionButton(QString id, QString description, QObject *parent);
 };
 } // namespace scopy
 #endif // PREFERENCESHELPER_H

--- a/pluginbase/include/pluginbase/preferences.h
+++ b/pluginbase/include/pluginbase/preferences.h
@@ -52,6 +52,18 @@ public:
 	 */
 	static void init(QString, QVariant);
 	void _init(QString, QVariant);
+
+	/**
+	 * @brief initDescription
+	 * Initialize a map with title and description for each preference
+	 * to be later used in docs and hover widgets in the Scopy prefs page.
+	 * @param k
+	 * @param title
+	 * @param description
+	 */
+	void initDescription(QString k, QString title, QString description);
+	void _initDescription(QString k, QString title, QString description);
+
 	/**
 	 * @brief clear
 	 * clears preferences table
@@ -109,6 +121,7 @@ Q_SIGNALS:
 
 private:
 	QMap<QString, QVariant> p;
+	QMap<QString, QVector<QString>> pDescriptions;
 	QSettings *s;
 	static Preferences *pinstance_;
 };

--- a/pluginbase/src/preferences.cpp
+++ b/pluginbase/src/preferences.cpp
@@ -47,6 +47,13 @@ void Preferences::_init(QString k, QVariant v)
 	// else - map contains key so it is already initialized to the correct value, nothing to do
 }
 
+void Preferences::_initDescription(QString k, QString title, QString description)
+{
+	if(!pDescriptions.contains(k)) {
+		pDescriptions.insert(k, QVector<QString>{title, description});
+	}
+}
+
 QVariant Preferences::_get(QString k)
 {
 	QVariant v = QVariant();
@@ -112,5 +119,10 @@ Preferences *Preferences::GetInstance()
 }
 
 void Preferences::init(QString k, QVariant v) { return Preferences::GetInstance()->_init(k, v); }
+
+void Preferences::initDescription(QString k, QString title, QString description)
+{
+	return Preferences::GetInstance()->_initDescription(k, title, description);
+}
 
 #include "moc_preferences.cpp"

--- a/plugins/adc/src/adcplugin.cpp
+++ b/plugins/adc/src/adcplugin.cpp
@@ -80,7 +80,6 @@ void ADCPlugin::initPreferences()
 	p->init("adc_plot_yaxis_handle_position", HandlePos::NORTH_OR_WEST);
 	p->init("adc_plot_xcursor_position", HandlePos::SOUTH_OR_EAST);
 	p->init("adc_plot_ycursor_position", HandlePos::NORTH_OR_WEST);
-	p->init("adc_plot_show_buffer_previewer", true);
 	p->init("adc_default_y_mode", 0);
 	p->init("adc_add_remove_plot", false);
 	p->init("adc_add_remove_instrument", false);
@@ -102,39 +101,75 @@ bool ADCPlugin::loadPreferencesPage()
 	lay->setMargin(0);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	auto adc_plot_xaxis_label_position = PreferencesHelper::addPreferenceComboList(
+	QList<QPair<QString, QVariant>> xaxis_lbl_pos_options = {{"Top", QwtAxis::XTop}, {"Bottom", QwtAxis::XBottom}};
+	auto adc_plot_xaxis_label_position = PREFERENCE_COMBO_LIST(
 		p, "adc_plot_xaxis_label_position", "Plot X-Axis scale position",
-		{{"Top", QwtAxis::XTop}, {"Bottom", QwtAxis::XBottom}}, generalSection);
-	auto adc_plot_yaxis_label_position = PreferencesHelper::addPreferenceComboList(
-		p, "adc_plot_yaxis_label_position", "Plot Y-Axis scale position",
-		{{"Left", QwtAxis::YLeft}, {"Right", QwtAxis::YRight}}, generalSection);
-	auto adc_plot_yaxis_handle_position = PreferencesHelper::addPreferenceComboList(
-		p, "adc_plot_yaxis_handle_position", "Plot channel Y-handle position",
-		{{"Left", HandlePos::NORTH_OR_WEST}, {"Right", HandlePos::SOUTH_OR_EAST}}, generalSection);
-	auto adc_plot_xcursor_position = PreferencesHelper::addPreferenceComboList(
-		p, "adc_plot_xcursor_position", "Plot X-Cursor position",
-		{{"Top", HandlePos::NORTH_OR_WEST}, {"Bottom", HandlePos::SOUTH_OR_EAST}}, generalSection);
-	auto adc_plot_ycursor_position = PreferencesHelper::addPreferenceComboList(
-		p, "adc_plot_ycursor_position", "Plot Y-Curosr position",
-		{{"Left", HandlePos::NORTH_OR_WEST}, {"Right", HandlePos::SOUTH_OR_EAST}}, generalSection);
-	auto adc_plot_show_buffer_previewer = PreferencesHelper::addPreferenceCheckBox(
-		p, "adc_plot_show_buffer_previewer", "Show buffer previewer", m_preferencesPage);
+		"Select whether the X-Axis labels are displayed on the top or bottom of the plot. "
+		"Only applied after restart.",
+		xaxis_lbl_pos_options, generalSection);
 
-	auto adc_default_y_mode = PreferencesHelper::addPreferenceComboList(
-		p, "adc_default_y_mode", "ADC Default Y-Mode", {{"ADC Count", 0}, {"% Full Scale", 1}}, generalSection);
-	auto adc_acquisition_timeout = PreferencesHelper::addPreferenceEdit(
-		p, "adc_acquisition_timeout", "ADC Acquisition timeout", m_preferencesPage);
-	auto adc_add_remove_plot = PreferencesHelper::addPreferenceCheckBox(
-		p, "adc_add_remove_plot", "Add/Remove plot feature (EXPERIMENTAL)", m_preferencesPage);
-	auto adc_add_remove_instrument = PreferencesHelper::addPreferenceCheckBox(
-		p, "adc_add_remove_instrument", "Add/Remove instrument feature (EXPERIMENTAL)", m_preferencesPage);
+	QList<QPair<QString, QVariant>> yaxis_lbl_pos_options = {{"Left", QwtAxis::YLeft}, {"Right", QwtAxis::YRight}};
+	auto adc_plot_yaxis_label_position =
+		PREFERENCE_COMBO_LIST(p, "adc_plot_yaxis_label_position", "Plot Y-Axis scale position",
+				      "Select whether the Y-Axis labels are displayed on the left or right side of the "
+				      "plot. Only applied after restart.",
+				      yaxis_lbl_pos_options, generalSection);
+
+	QList<QPair<QString, QVariant>> yaxis_hdl_pos_options = {{"Left", HandlePos::NORTH_OR_WEST},
+								 {"Right", HandlePos::SOUTH_OR_EAST}};
+	auto adc_plot_yaxis_handle_position = PREFERENCE_COMBO_LIST(
+		p, "adc_plot_yaxis_handle_position", "Plot channel Y-handle position",
+		"Select whether the Y-Axis handle is located on the left or right side of the plot. "
+		"Only applied after restart.",
+		yaxis_hdl_pos_options, generalSection);
+
+	QList<QPair<QString, QVariant>> xcursor_pos_options = {{"Top", HandlePos::NORTH_OR_WEST},
+							       {"Bottom", HandlePos::SOUTH_OR_EAST}};
+	auto adc_plot_xcursor_position = PREFERENCE_COMBO_LIST(
+		p, "adc_plot_xcursor_position", "Plot X-Cursor position",
+		"Select whether the X-Axis cursor handles are located on the top or bottom of the plot. "
+		"Only applied after restart.",
+		xcursor_pos_options, generalSection);
+
+	QList<QPair<QString, QVariant>> ycursor_pos_options = {{"Left", HandlePos::NORTH_OR_WEST},
+							       {"Right", HandlePos::SOUTH_OR_EAST}};
+	auto adc_plot_ycursor_position = PREFERENCE_COMBO_LIST(
+		p, "adc_plot_ycursor_position", "Plot Y-Cursor position",
+		"Select whether the Y-Axis cursor handles are located on the left or right side of the plot. "
+		"Only applied after restart.",
+		ycursor_pos_options, generalSection);
+
+	QList<QPair<QString, QVariant>> y_mode_options = {{"ADC Count", 0}, {"% Full Scale", 1}};
+	auto adc_default_y_mode = PREFERENCE_COMBO_LIST(
+		p, "adc_default_y_mode", "ADC Default Y-Mode",
+		"Select the Y-Axis default mode, can be either ADC Counts or "
+		"%Full Scale. This is also controllable while running, from the instrument settings. "
+		"Only applied after restart.",
+		y_mode_options, generalSection);
+	auto adc_acquisition_timeout =
+		PREFERENCE_EDIT(p, "adc_acquisition_timeout", "ADC Acquisition timeout",
+				"Select the timeout for the I/O operation. A valid value is "
+				"a positive integer representing the time in milliseconds after which a timeout "
+				"should occur. ",
+				m_preferencesPage);
+	auto adc_add_remove_plot =
+		PREFERENCE_CHECK_BOX(p, "adc_add_remove_plot", "Add/Remove plot feature (EXPERIMENTAL)",
+				     "Experimental feature allowing the user to create multiple time or frequency plots"
+				     "within the ADC instrument. Any channel can be moved between plots to provide "
+				     "visual clarity and separation.",
+				     m_preferencesPage);
+	auto adc_add_remove_instrument =
+		PREFERENCE_CHECK_BOX(p, "adc_add_remove_instrument", "Add/Remove instrument feature (EXPERIMENTAL)",
+				     "Experimental feature allowing the user to create multiple time or frequency "
+				     "instruments, providing an easy way to switch between different run scenarios "
+				     "without affecting previous settings.",
+				     m_preferencesPage);
 
 	generalSection->contentLayout()->addWidget(adc_plot_xaxis_label_position);
 	generalSection->contentLayout()->addWidget(adc_plot_yaxis_label_position);
 	generalSection->contentLayout()->addWidget(adc_plot_yaxis_handle_position);
 	generalSection->contentLayout()->addWidget(adc_plot_xcursor_position);
 	generalSection->contentLayout()->addWidget(adc_plot_ycursor_position);
-	generalSection->contentLayout()->addWidget(adc_plot_show_buffer_previewer);
 	generalSection->contentLayout()->addWidget(adc_default_y_mode);
 	generalSection->contentLayout()->addWidget(adc_acquisition_timeout);
 	generalSection->contentLayout()->addWidget(adc_add_remove_plot);

--- a/plugins/datalogger/src/dataloggerplugin.cpp
+++ b/plugins/datalogger/src/dataloggerplugin.cpp
@@ -277,15 +277,19 @@ bool DataLoggerPlugin::loadPreferencesPage()
 	lay->addWidget(generalWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "dataloggerplugin_data_storage_size", "Maximum data stored for each monitor", {"10 Kb", "1 Mb"},
-		generalSection));
+	QStringList storage_options = {"10 Kb", "1 Mb"};
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "dataloggerplugin_data_storage_size", "Maximum data stored for each monitor",
+				 "Select the maximum data storage size for each monitor in the datalogger.",
+				 storage_options, generalSection));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceEdit(
-		p, "dataloggerplugin_read_interval", "Read interval (seconds) ", generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_EDIT(
+		p, "dataloggerplugin_read_interval", "Read interval (seconds) ",
+		"Select the time interval, in seconds, for data polling in the instrument.", generalSection));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceEdit(
-		p, "dataloggerplugin_date_time_format", "DateTime format :", generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_EDIT(
+		p, "dataloggerplugin_date_time_format", "DateTime format :",
+		"Select the date time format of the instrument. Default value is: hh:mm:ss", generalSection));
 
 	return true;
 }

--- a/plugins/debugger/src/debuggerplugin.cpp
+++ b/plugins/debugger/src/debuggerplugin.cpp
@@ -80,10 +80,14 @@ bool DebuggerPlugin::loadPreferencesPage()
 	layout->setSpacing(0);
 	layout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	auto use_debugger_v2 = PreferencesHelper::addPreferenceCheckBox(p, "plugins_use_debugger_v2",
-									"Use Debugger V2 plugin", generalSection);
-	auto debugger_include_debugfs = PreferencesHelper::addPreferenceCheckBox(
-		p, "debugger_v2_include_debugfs", "Include debug attributes in IIO Explorer", generalSection);
+	auto use_debugger_v2 = PREFERENCE_CHECK_BOX(p, "plugins_use_debugger_v2", "Use Debugger V2 plugin",
+						    "Switch between the old style debugger instrument, having "
+						    "just basic controls over attributes or the new instrument "
+						    "type, IIO Explorer, having a tree-like structure.",
+						    generalSection);
+	auto debugger_include_debugfs = PREFERENCE_CHECK_BOX(
+		p, "debugger_v2_include_debugfs", "Include debug attributes in IIO Explorer",
+		"Enable/disable the use of advanced debug attributes in the instrument.", generalSection);
 
 	generalSection->contentLayout()->addWidget(use_debugger_v2);
 	generalSection->contentLayout()->addWidget(debugger_include_debugfs);

--- a/plugins/m2k/src/m2kplugin.cpp
+++ b/plugins/m2k/src/m2kplugin.cpp
@@ -297,8 +297,11 @@ bool M2kPlugin::loadPreferencesPage()
 	lay->addWidget(generalWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_instrument_notes_active", "Instrument Notes", generalSection));
+	generalSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_instrument_notes_active", "Instrument Notes",
+		"Enable or disable a text section at the bottom of each ADALM2000 instrument, allowing "
+		"the user to take notes. Disabled by default.",
+		generalSection));
 
 	// Analog tools preferences
 	MenuSectionWidget *analogWidget = new MenuSectionWidget(m_preferencesPage);
@@ -310,22 +313,40 @@ bool M2kPlugin::loadPreferencesPage()
 	lay->addWidget(analogWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_show_adc_filters", "Show ADC digital filter config", analogSection));
 	analogSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "m2k_show_graticule", "Enable graticule", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_mini_histogram", "Enable mini histogram", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_osc_filtering", "Enable sample rate filters", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_osc_label", "Enable labels on the plot", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_spectrum_visible_peak_search", "Only search marker peaks in visible domain", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_na_show_zero", "Always display 0db value on the graph", analogSection));
-	analogSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceEdit(
-		p, "m2k_siggen_periods", "Number of displayed periods", analogSection));
+		PREFERENCE_CHECK_BOX(p, "m2k_show_adc_filters", "Show ADC digital filter config",
+				     "Enable/disable the configuration panel for ADC digital filters. "
+				     "This allows manual control over the parameters of the filters.",
+				     analogSection));
+	analogSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_show_graticule", "Enable graticule",
+		"Select whether the plot backbone (graticule) is displayed in the Oscilloscope.", analogSection));
+	analogSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_mini_histogram", "Enable mini histogram",
+		"Select whether the Oscilloscope plot displays a histogram on the right side.", analogSection));
+	analogSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "m2k_osc_filtering", "Enable sample rate filters",
+				     "Enable or disable the ADALM2000 ADC filters for all samplerates less than "
+				     "100 MHz.",
+				     analogSection));
+	analogSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_osc_label", "Enable labels on the plot",
+		"Enable or disable the plot labels in the Oscilloscope instrument.", analogSection));
+	analogSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_spectrum_visible_peak_search", "Only search marker peaks in visible domain",
+		"Enabled by default, this control allows the Spectrum Analyzer to search for marker "
+		"peaks outside the visible frequency range.",
+		analogSection));
+	analogSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "m2k_na_show_zero", "Always display 0db value on the graph",
+				     "Select whether the 0dB value is displayed as a reference point on the "
+				     "Network Analyzer plot. This control is disabled by default.",
+				     analogSection));
+	analogSection->contentLayout()->addWidget(
+		PREFERENCE_EDIT(p, "m2k_siggen_periods", "Number of displayed periods",
+				"Select the number of displayed signal periods in the Signal Generator. "
+				"Default value is 2.",
+				analogSection));
 
 	// Logic tools preferences
 	MenuSectionWidget *logicWidget = new MenuSectionWidget(m_preferencesPage);
@@ -337,12 +358,21 @@ bool M2kPlugin::loadPreferencesPage()
 	lay->addWidget(logicWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	logicSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_logic_separate_annotations", "Separate decoder annotations when exporting", logicSection));
-	logicSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_logic_display_sampling_points", "Display sampling points when zoomed", logicSection));
-	logicSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "m2k_logic_display_sample_time", "Show sample and time info in decoder table", logicSection));
+	logicSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "m2k_logic_separate_annotations", "Separate decoder annotations when exporting",
+				     "Select whether to export decoder annotations and data separately from the "
+				     "Logic Analyzer instrument. Disabled by default.",
+				     logicSection));
+	logicSection->contentLayout()->addWidget(PREFERENCE_CHECK_BOX(
+		p, "m2k_logic_display_sampling_points", "Display sampling points when zoomed",
+		"Select whether to display each sampling point when zoomed in on the Logic Analyzer. "
+		"Disabled by default.",
+		logicSection));
+	logicSection->contentLayout()->addWidget(
+		PREFERENCE_CHECK_BOX(p, "m2k_logic_display_sample_time", "Show sample and time info in decoder table",
+				     "Select whether the sample and time detailed information is shown in the "
+				     "decoder table of the Logic Analyzer. Enabled by default.",
+				     logicSection));
 
 	return true;
 }

--- a/plugins/regmap/src/regmapplugin.cpp
+++ b/plugins/regmap/src/regmapplugin.cpp
@@ -159,12 +159,20 @@ bool RegmapPlugin::loadPreferencesPage()
 	lay->addWidget(generalWidget);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
-	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "regmap_color_by_value", "Use color to reflect value",
-		{"Default", "Bitfield background", "Bitfield text", "Register background", "Register text",
-		 "Register background and Bitfield background", "Register text and Bitfield text",
-		 "Register background and Bitfield text", "Register text and Bitfield background"},
-		generalSection));
+	QStringList color_value_options = {"Default",
+					   "Bitfield background",
+					   "Bitfield text",
+					   "Register background",
+					   "Register text",
+					   "Register background and Bitfield background",
+					   "Register text and Bitfield text",
+					   "Register background and Bitfield text",
+					   "Register text and Bitfield background"};
+	generalSection->contentLayout()->addWidget(
+		PREFERENCE_COMBO(p, "regmap_color_by_value", "Use color to reflect value",
+				 "Select from various configurations available which elements in the Register Map "
+				 "are color coded for better visual interpretation.",
+				 color_value_options, generalSection));
 
 	return true;
 }

--- a/plugins/test/src/testplugin.cpp
+++ b/plugins/test/src/testplugin.cpp
@@ -84,13 +84,13 @@ bool TestPlugin::loadPreferencesPage()
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "pref1", "First Option", generalSection));
+		PreferencesHelper::addPreferenceCheckBox(p, "pref1", "First Option", "", generalSection));
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceCheckBox(p, "pref2", "Second Option", generalSection));
+		PreferencesHelper::addPreferenceCheckBox(p, "pref2", "Second Option", "", generalSection));
 	generalSection->contentLayout()->addWidget(
-		PreferencesHelper::addPreferenceEdit(p, "prefstr", "PreferenceString", generalSection));
+		PreferencesHelper::addPreferenceEdit(p, "prefstr", "PreferenceString", "", generalSection));
 	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCombo(
-		p, "pref4", "languages", {"english", "french", "italian"}, generalSection));
+		p, "pref4", "languages", "", {"english", "french", "italian"}, generalSection));
 
 	return true;
 }

--- a/tools/plugingenerator/templates/pdk/pdk_src_template.mako
+++ b/tools/plugingenerator/templates/pdk/pdk_src_template.mako
@@ -148,7 +148,7 @@ QWidget *PDKWindow::buildSaveSessionPreference()
 	lay->setMargin(0);
 
 	lay->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(p, "general_save_session",
-								       "Save/Load Scopy session", this));
+								       "Save/Load Scopy session", "", this));
 	lay->addSpacerItem(new QSpacerItem(40, 40, QSizePolicy::Expanding, QSizePolicy::Fixed));
 	lay->addWidget(new QLabel("Settings files location ", this));
 	QPushButton *navigateBtn = new QPushButton("Open", this);
@@ -183,32 +183,32 @@ QWidget *PDKWindow::generalPreferences()
 
 	generalSection->contentLayout()->addWidget(buildSaveSessionPreference());
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_save_attached", "Save/Load tool attached state", generalSection));
+		p, "general_save_attached", "Save/Load tool attached state", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_doubleclick_attach", "Doubleclick to attach/detach tool", generalSection));
+		p, "general_doubleclick_attach", "Doubleclick to attach/detach tool", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_doubleclick_ctrl_opens_menu", "Doubleclick control buttons to open menu", generalSection));
+		p, "general_doubleclick_ctrl_opens_menu", "Doubleclick control buttons to open menu", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_opengl", "Enable OpenGL plotting", generalSection));
+		p, "general_use_opengl", "Enable OpenGL plotting", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_animations", "Enable menu animations", generalSection));
+		p, "general_use_animations", "Enable menu animations", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_check_online_version", "Enable automatic online check for updates.", generalSection));
+		p, "general_check_online_version", "Enable automatic online check for updates.", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
 		p, "general_show_status_bar", "Enable the status bar for displaying important messages.",
-		generalSection));
+		"", generalSection));
 	generalSection->contentLayout()->addWidget(
-		scopy::PreferencesHelper::addPreferenceCheckBox(p, "show_grid", "Show Grid", generalSection));
+		scopy::PreferencesHelper::addPreferenceCheckBox(p, "show_grid", "Show Grid", "", generalSection));
 	generalSection->contentLayout()->addWidget(
-		scopy::PreferencesHelper::addPreferenceCheckBox(p, "show_graticule", "Show Graticule", generalSection));
+		scopy::PreferencesHelper::addPreferenceCheckBox(p, "show_graticule", "Show Graticule", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "iiowidgets_use_lazy_loading", "Use Lazy Loading", generalSection));
+		p, "iiowidgets_use_lazy_loading", "Use Lazy Loading", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "plugins_use_debugger_v2", "Use Debugger V2 plugin", generalSection));
+		p, "plugins_use_debugger_v2", "Use Debugger V2 plugin", "", generalSection));
 	generalSection->contentLayout()->addWidget(PreferencesHelper::addPreferenceCheckBox(
-		p, "general_use_native_dialogs", "Use native dialogs", generalSection));
+		p, "general_use_native_dialogs", "Use native dialogs", "", generalSection));
 	generalSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCombo(
-		p, "general_theme", "Theme", {"default", "light"}, generalSection));
+		p, "general_theme", "Theme", {"default", "light"}, "", generalSection));
 
 	// Debug preferences
 	scopy::MenuSectionWidget *debugWidget = new scopy::MenuSectionWidget(page);
@@ -221,9 +221,9 @@ QWidget *PDKWindow::generalPreferences()
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
 	debugSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCheckBox(
-		p, "general_show_plot_fps", "Show plot FPS", debugSection));
+		p, "general_show_plot_fps", "Show plot FPS", "", debugSection));
 	debugSection->contentLayout()->addWidget(scopy::PreferencesHelper::addPreferenceCombo(
-		p, "general_plot_target_fps", "Plot target FPS", {"15", "20", "30", "60"}, debugSection));
+		p, "general_plot_target_fps", "Plot target FPS", "", {"15", "20", "30", "60"}, debugSection));
 
 	return page;
 }


### PR DESCRIPTION
- Added an info button to display extra details in each preference.
- Create preferences using a macro.
- Scan for the macro when generating documentation and automatically populate it.
- Screenshots on how this looks like: https://github.com/analogdevicesinc/scopy/pull/1884