### PR TITLE
iioexplorer/watchlistview: Fix remove button not updating

### DIFF
--- a/plugins/debugger/include/debugger/watchlistview.h
+++ b/plugins/debugger/include/debugger/watchlistview.h
@@ -52,6 +52,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void selectedItem(IIOStandardItem *item);
+	void removeItem(IIOStandardItem *item);
 
 protected:
 	void resizeEvent(QResizeEvent *event) override;
@@ -67,11 +68,8 @@ class WatchListView_API : public ApiObject
 	Q_OBJECT
 	Q_PROPERTY(QList<int> offsets READ offsets WRITE setOffsets FINAL)
 public:
-	explicit WatchListView_API(WatchListView *p)
-		: ApiObject(p)
-		, p(p)
-	{}
-	~WatchListView_API(){};
+	explicit WatchListView_API(WatchListView *p);
+	~WatchListView_API() = default;
 
 	QList<int> tableHeader() const;
 	void setTableHeader(const QList<int> &newTableHeader);

--- a/plugins/debugger/src/iioexplorer/iioexplorerinstrument.cpp
+++ b/plugins/debugger/src/iioexplorer/iioexplorerinstrument.cpp
@@ -167,6 +167,12 @@ void IIOExplorerInstrument::connectSignalsAndSlots()
 			 &IIOExplorerInstrument::applySelection);
 
 	QObject::connect(m_watchListView, &WatchListView::selectedItem, this, &IIOExplorerInstrument::selectItem);
+
+	QObject::connect(m_watchListView, &WatchListView::removeItem, this, [this](IIOStandardItem *item) {
+		item->setWatched(false);
+		m_detailsView->setAddToWatchlistState(true);
+	});
+
 	QObject::connect(m_detailsView->readBtn(), &QPushButton::clicked, this, [this]() {
 		qDebug(CAT_DEBUGGERIIOMODEL) << "Read button pressed.";
 		triggerReadOnAllChildItems(m_currentlySelectedItem);

--- a/plugins/debugger/src/iioexplorer/watchlistview.cpp
+++ b/plugins/debugger/src/iioexplorer/watchlistview.cpp
@@ -26,7 +26,6 @@
 #include <QPushButton>
 #include <QHeaderView>
 #include <QScrollBar>
-#include <qnamespace.h>
 #include <style.h>
 
 #define NAME_POS 0
@@ -144,6 +143,8 @@ void WatchListView::addToWatchlist(IIOStandardItem *item)
 
 		item->setWatched(false);
 		entry->deleteLater();
+
+		Q_EMIT removeItem(item);
 	});
 }
 
@@ -210,6 +211,13 @@ void WatchListView::resizeEvent(QResizeEvent *event)
 	setColumnWidth(CLOSE_BTN_POS, sectionWidth + m_offsets[CLOSE_BTN_POS]);
 
 	QTableWidget::resizeEvent(event);
+}
+
+WatchListView_API::WatchListView_API(WatchListView *p)
+	: ApiObject(p)
+	, p(p)
+{
+	setObjectName("WatchListView_API");
 }
 
 QList<int> WatchListView_API::tableHeader() const


### PR DESCRIPTION
The 'x' button from the title path was did not update when the object was deleted from the WatchListView, only when clicking the item again.