### PR TITLE
plugins/dac: add a switch to repeat the file buffer for all channels 

### DIFF
--- a/docs/plugins/dac/dac.rst
+++ b/docs/plugins/dac/dac.rst
@@ -12,10 +12,16 @@ implements an output IIO buffer or at least one DDS (ALTVOLTAGE) output channel.
 
 Both generation modes feature a few common items in their layout.
 
-1. Tutorial button
+1. Info button
 
- The top left side information button will start a quick tutorial for basic
- usage of the instrument.
+ The top left side information button will open a pop-up window containing
+ two buttons: **Tutorial** and **Documentation**.
+
+ The Documentation button will open this page in a browser and close the 
+ pop-up window.
+
+ The Tutorial button will start a tutorial that will guide the user through
+ the main features of the plugin.
 
 2. Right side menu
 
@@ -61,7 +67,16 @@ Find all the sections of the instrument described below.
  List of detected IIO channels that are buffer capable. These can be 
  enabled or disabled using their left side check.
 
-3. Cyclic
+3. Repeat data
+
+ Choose whether to repeat the data columns loaded from file or not.
+ If enabled, the data columns will be repeated on all enabled channels, 
+ without requiring the user to duplicate the data sets in the file to
+ match the number of enabled channels.
+
+ By default it is set to true.
+
+4. Cyclic
 
  Choose whether to push a cyclic IIO buffer or stream non-cyclic buffers.
  If disabled, a new section containing "Buffer size" and "Kernel buffers"
@@ -69,12 +84,12 @@ Find all the sections of the instrument described below.
 
  By default it is set to true.
 
-4. File Size
+5. File Size
 
  The size of the loaded file. It is populated once loading is successful
  and can be changed to a lower value, truncating the data loaded from file.
 
-5. Run Button
+6. Run Button
 
  Start output generation on the currently enabled channels. If anything 
  is invalid in the setup it will appear in the bottom "Console Log" once 
@@ -86,15 +101,15 @@ Find all the sections of the instrument described below.
   - errors appeared while trying to configure the IIO Buffer
   - the combined enabled channels are not compatible (for I/Q channels)
 
-6. Data Configuration
+7. Data Configuration
 
  This section allows the user to scale the data before output.
 
-7. Console Log
+8. Console Log
 
  All errors or status messages are displayed here.
 
-8. File Configuration
+9. File Configuration
 
  This section is visible only when the buffer is non-cyclic. It contains a 
  control for buffer size and one for kernel buffers. Both are automatically
@@ -138,10 +153,3 @@ for available TX channels with I/Q corresponding channels.
  
  .. note::
    For scale, "-Inf dB" is equivalent with scale=0 or a disabled channel.
-
-
-Tutorial 
---------------------------------------------------------------------------------
-
-A tutorial will automatically start first time the tool is open. It can
-be restarted from tool Preferences.

--- a/docs/tests/plugins/dac/dac_tests.rst
+++ b/docs/tests/plugins/dac/dac_tests.rst
@@ -691,3 +691,74 @@ Test 10 - Channel attributes
   The result of the test goes here (PASS/FAIL).
 
 
+Test 11 - Repeat data option
+--------------------------------------------
+
+.. _TST.DAC.REPEAT_DATA:
+
+**UID:** TST.DAC.REPEAT_DATA
+
+**Description:** This test verifies the DAC plugin repeat data option.
+The data sets loaded from the file should be repeated to fill in all the enabled
+channels.
+
+**Preconditions:**
+    - :ref:`AdalmPluto.Device<adalm_pluto_device_setup>`
+    - Enable 2 TX channels on your Pluto device.
+    - OS: ANY
+
+**Resources:**
+    - `<https://github.com/analogdevicesinc/scopy/blob/main/plugins/dac/res/csv/sinewave_0.9_2ch.csv>`__
+
+**Steps:**
+    1. Open the DAC plugin.
+    2. Switch the "Mode" to "Buffer".
+    3. Browse and select the *sinewave_0.9_2ch.csv* file.
+    4. Press the "Load" button.
+        - **Expected result:** The first 2 channels are enabled.
+        - **Actual result:**
+
+..
+  Actual test result goes here.
+..
+
+    5. Enable the remaining 2 channels from the channel list.
+    6. Set the **Repeat data** option to true and press **Run**.
+        - **Expected result:** The console log displays the following message: *Pushed 8444 samples, 67552 bytes (1/1 buffers).*
+        - **Actual result:**
+
+..
+  Actual test result goes here.
+..
+
+    7. Set the **Repeat data** option to false and press **Run**.
+        - **Expected result:** The console log displays the following message: *Not enough data columns for all enabled channels.*
+        - **Actual result:**
+
+..
+  Actual test result goes here.
+..
+
+    8. Leave the **Repeat data** as is, disable the last 2 channels and press **Run**:
+        - **Expected result:** The console log displays the following message: *Pushed 8444 samples, 33776 bytes (1/1 buffers).*
+        - **Actual result:**
+
+..
+  Actual test result goes here.
+..
+
+**Tested OS:**
+
+..
+  Details about the tested OS goes here.
+
+**Comments:**
+
+..
+  Any comments about the test goes here.
+
+**Result:** PASS/FAIL
+
+..
+  The result of the test goes here (PASS/FAIL).
+

--- a/plugins/dac/res/tutorial_chapters.json
+++ b/plugins/dac/res/tutorial_chapters.json
@@ -26,6 +26,14 @@
 		},
 		{
 			"index": 4,
+			"names": ["REPEAT_FILE_BUFFER_BUTTON"],
+			"description": "Repeat the data columns from the loaded file to match the number of enabled channels.",
+			"anchor": "HP_BOTTOM",
+			"content": "HP_BOTTOM",
+			"y_offset": 10
+		},
+		{
+			"index": 5,
 			"names": ["CYCLIC_BUTTON"],
 			"description": "Select whether to use cyclic or non-cyclic buffer",
 			"anchor": "HP_BOTTOM",
@@ -33,7 +41,7 @@
 			"y_offset": 10
 		},
 		{
-			"index": 5,
+			"index": 6,
 			"names": ["FILESIZE"],
 			"description": "Displays the number of samples in file, can be used to truncate the file",
 			"anchor": "HP_BOTTOM",
@@ -41,7 +49,7 @@
 			"y_offset": 10
 		},
 		{
-			"index": 6,
+			"index": 7,
 			"names": ["RUN_BUTTON"],
 			"description": "Start the DAC buffer output.",
 			"anchor": "HP_BOTTOM",
@@ -49,7 +57,7 @@
 			"y_offset": 10
 		},
 		{
-			"index": 7,
+			"index": 8,
 			"names": ["CONSOLE_LOG"],
 			"description": "Displays information on file load status, buffer output status or other errors.",
 			"anchor": "HP_TOP",

--- a/plugins/dac/src/bufferdacaddon.cpp
+++ b/plugins/dac/src/bufferdacaddon.cpp
@@ -133,6 +133,16 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 		m_model, &DacDataModel::invalidRunParams, this, [this]() { m_runBtn->setChecked(false); },
 		Qt::QueuedConnection);
 
+	// Repeat file buffer section
+	MenuSectionWidget *repeatFileBufferContainer = new MenuSectionWidget(this);
+	repeatFileBufferContainer->setProperty("tutorial_name", "REPEAT_FILE_BUFFER_BUTTON");
+	m_repeatFileBufferBtn = new MenuOnOffSwitch("Repeat data", repeatFileBufferContainer);
+	connect(m_repeatFileBufferBtn->onOffswitch(), &QPushButton::toggled, this,
+		[=, this](bool toggled) { m_model->setRepeatFileBuffer(toggled); });
+	repeatFileBufferContainer->contentLayout()->addWidget(m_repeatFileBufferBtn);
+	repeatFileBufferContainer->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+	m_repeatFileBufferBtn->onOffswitch()->setChecked(true);
+
 	// Cyclic buffer section
 	MenuSectionWidget *cyclicContainer = new MenuSectionWidget(this);
 	cyclicContainer->setProperty("tutorial_name", "CYCLIC_BUTTON");
@@ -162,6 +172,7 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 	filesizeContainer->contentLayout()->addWidget(m_fileSizeSpin);
 	filesizeContainer->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 
+	runConfigLay->addWidget(repeatFileBufferContainer);
 	runConfigLay->addWidget(cyclicContainer);
 	runConfigLay->addWidget(filesizeContainer);
 	runConfigLay->addWidget(m_runBtn);

--- a/plugins/dac/src/bufferdacaddon.h
+++ b/plugins/dac/src/bufferdacaddon.h
@@ -71,6 +71,7 @@ private:
 	gui::MenuSpinbox *m_fileSizeSpin;
 	gui::MenuSpinbox *m_kernelCountSpin;
 	MenuOnOffSwitch *m_cyclicBtn;
+	MenuOnOffSwitch *m_repeatFileBufferBtn;
 	QTextBrowser *m_logText;
 	FileBrowser *fm;
 

--- a/plugins/dac/src/dacdatamodel.h
+++ b/plugins/dac/src/dacdatamodel.h
@@ -49,6 +49,7 @@ public:
 	QMap<QString, TxNode *> getBufferTxs() const;
 	QMap<QString, TxNode *> getDdsTxs() const;
 
+	void setRepeatFileBuffer(bool repeat);
 	void setCyclic(bool cyclic);
 	void setKernelBuffersCount(unsigned int kernelCount);
 	void setDecimation(double decimation);
@@ -89,6 +90,7 @@ private:
 	bool m_isBufferCapable;
 	bool m_isDds;
 	bool m_cyclicBuffer;
+	bool m_repeatFileBuffer;
 	int m_decimation;
 
 	bool m_activeDds;


### PR DESCRIPTION
For devices with multiple channels this option will allow the user
to use the same input .csv file for a dynamic number of channels,
without having to duplicate the number of columns in the file.
