### PR TITLE
core/emu: Fix emu path bug.

### DIFF
--- a/core/include/core/emuwidget.h
+++ b/core/include/core/emuwidget.h
@@ -62,6 +62,7 @@ private:
 	QStringList createArgList();
 	void setStatusMessage(QString msg);
 	QString findEmuPath();
+	QString buildEmuPath(QString dirPath);
 	void stopEnableBtn(QString btnText);
 	bool startIioEmuProcess(QString processPath, QStringList arg = {});
 	void killEmuProcess();

--- a/core/include/core/scopypreferencespage.h
+++ b/core/include/core/scopypreferencespage.h
@@ -54,6 +54,8 @@ private:
 	QPushButton *m_devRefresh;
 	QWidget *buildSaveSessionPreference();
 	QWidget *buildResetScopyDefaultButton();
+	QWidget *buildEmuPreference(const QString &id, const QString &title, const QString &description,
+				    QWidget *parent = nullptr);
 	QVBoxLayout *layout;
 	MenuSectionCollapseWidget *m_autoConnectWidget;
 	void removeIniFiles(bool backup = true);

--- a/core/src/scopymainwindow.cpp
+++ b/core/src/scopymainwindow.cpp
@@ -528,6 +528,8 @@ void ScopyMainWindow::handlePreferences(QString str, QVariant val)
 		dm->setExclusive(!general_connect_to_multiple_devices);
 	} else if(str == "general_scan_for_devices") {
 		enableScanner();
+	} else if(str == "iio_emu_dir_path") {
+		Q_EMIT p->restartRequired();
 	}
 }
 

--- a/core/src/scopypreferencespage.cpp
+++ b/core/src/scopypreferencespage.cpp
@@ -32,6 +32,7 @@
 #include <stylehelper.h>
 #include <deviceautoconnect.h>
 #include "gui/preferenceshelper.h"
+#include <QFileDialog>
 #include <style.h>
 #include "application_restarter.h"
 #include "smallOnOffSwitch.h"
@@ -223,6 +224,56 @@ QWidget *ScopyPreferencesPage::buildResetScopyDefaultButton()
 	return w;
 }
 
+QWidget *ScopyPreferencesPage::buildEmuPreference(const QString &id, const QString &title, const QString &description,
+						  QWidget *parent)
+{
+	Preferences *p = Preferences::GetInstance();
+	QWidget *emuPref = new QWidget(parent);
+	QHBoxLayout *layout = new QHBoxLayout(emuPref);
+	layout->setMargin(0);
+	layout->setSpacing(0);
+	layout->setMargin(0);
+
+	QWidget *infoBtn = PreferencesHelper::setupDescriptionButton(id, description, emuPref);
+
+	QLabel *label = new QLabel(title, emuPref);
+	p->initDescription(id, title, description);
+
+	QSpacerItem *space = new QSpacerItem(20, 20, QSizePolicy::Preferred, QSizePolicy::Preferred);
+
+	QWidget *browseW = new QWidget(emuPref);
+	QHBoxLayout *browseLay = new QHBoxLayout(browseW);
+	browseLay->setMargin(0);
+	browseLay->setSpacing(10);
+
+	QString pref1Val = p->get(id).toString();
+	QLineEdit *pref = new QLineEdit(browseW);
+	pref->setText(pref1Val);
+	connect(pref, &QLineEdit::textChanged, this, [p, id](QString b) { p->set(id, b); });
+
+	QPushButton *browseBtn = new QPushButton("...", browseW);
+	StyleHelper::BrowseButton(browseBtn);
+	connect(browseBtn, &QPushButton::pressed, this, [this, pref]() {
+		bool useNativeDialogs = Preferences::get("general_use_native_dialogs").toBool();
+		QString filePath = QFileDialog::getExistingDirectory(
+			this, "Select iio-emu path", "directoryToOpen",
+			(useNativeDialogs ? QFileDialog::Options()
+					  : QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks |
+					 QFileDialog::DontUseNativeDialog));
+		pref->setText(filePath);
+	});
+
+	browseLay->addWidget(pref);
+	browseLay->addWidget(browseBtn);
+
+	layout->addWidget(infoBtn);
+	layout->addWidget(label, 1);
+	layout->addSpacerItem(space);
+	layout->addWidget(browseW, 1);
+
+	return emuPref;
+}
+
 QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 {
 	QWidget *page = new QWidget(this);
@@ -334,6 +385,12 @@ QWidget *ScopyPreferencesPage::buildGeneralPreferencesPage()
 				     "allowing the application to automatically populate the device list with connected"
 				     "devices. Otherwise, all devices need to be added manually from the Add page.",
 				     generalSection));
+	generalSection->contentLayout()->addWidget(buildEmuPreference(
+		"iio_emu_dir_path", "Set the iio-emu location",
+		"Specifies the location of the iio-emu executable. By default, iio-emu is located next "
+		"to the scopy executable. However, if it cannot be found or is not installed on the "
+		"system, this preference offers the possibility to manually set the path to it.",
+		generalSection));
 
 	// Auto-connect
 	m_autoConnectWidget = new MenuSectionCollapseWidget("Session ", MenuCollapseSection::MHCW_NONE,


### PR DESCRIPTION
Some changes have been made in the path finding process.

1. Preference path initialization:
    - The iio_emu_dir_path preference is now initialized with an empty value. This allows users to manually specify a custom path to the iio-emu executable, which may be located outside the default Scopy executable directory. If the preference is left empty or the file does not exist, the next verification will be performed.
2. Scopy executable directory search:
    - If no valid path is provided in the preferences, we will check for the iio-emu executable in the same directory as the Scopy executable.
3. System search:
    - If the iio-emu executable is not found in the Scopy executable directory, a system search is performed.