### PR TITLE
Issues fixes and minor style adjustments

### DIFF
--- a/plugins/swiot/src/ad74413r/ad74413r.cpp
+++ b/plugins/swiot/src/ad74413r/ad74413r.cpp
@@ -242,6 +242,7 @@ void Ad74413r::verifyChnlsChanges()
 	bool changes = m_swiotAdLogic->verifyChannelsEnabledChanges(m_enabledChannels);
 	if(changes) {
 		m_readerThread->requestStop();
+		m_runBtn->setChecked(false);
 		m_swiotAdLogic->applyChannelsEnabledChanges(m_enabledChannels);
 	}
 }

--- a/plugins/swiot/src/max14906/max14906.cpp
+++ b/plugins/swiot/src/max14906/max14906.cpp
@@ -302,6 +302,7 @@ QMainWindow *Max14906::createDockableMainWindow(const QString &title, DioDigital
 						QWidget *parent)
 {
 	auto mainWindow = new QMainWindow(parent);
+	Style::setBackgroundColor(mainWindow, json::theme::background_primary, true);
 	mainWindow->setCentralWidget(nullptr);
 	mainWindow->setWindowFlags(Qt::Widget);
 


### PR DESCRIPTION
https://github.com/analogdevicesinc/scopy/issues/1946
- The plots from the MAX14906 loose the background style when detached
- In the AD74413R tool, if the run button is pressed and a new channel is enabled, the acquisition stops, but the text from the run button still prints "Stop" indicating it is running. The button should just be reset when the acquisition stops.

https://github.com/analogdevicesinc/scopy/issues/1905