### PR TITLE
emu: add a port selector in the EmuWidget.

### DIFF
--- a/core/include/core/emuwidget.h
+++ b/core/include/core/emuwidget.h
@@ -55,6 +55,7 @@ private:
 	QWidget *createDemoOptWidget(QWidget *parent);
 	QWidget *createXmlPathWidget(QWidget *parent);
 	QWidget *createRxTxDevWidget(QWidget *parent);
+	QWidget *createPortWidget(QWidget *parent);
 	QWidget *createUriWidget(QWidget *parent);
 	void initEnBtn(QWidget *parent);
 	void init();
@@ -75,6 +76,7 @@ private:
 	QComboBox *m_demoOptCb;
 	QLineEdit *m_xmlPathEdit;
 	QLineEdit *m_rxTxDevEdit;
+	QLineEdit *m_portEdit;
 	QLineEdit *m_uriEdit;
 	QLabel *m_uriMsgLabel;
 	AnimationPushButton *m_enDemoBtn;


### PR DESCRIPTION
This is useful on systems where the default port is already in use, allowing the iio-emu to run on a different port. This happens on a Kuiper with the local backend enabled.