### PR TITLE
GUI: avoid crash on getChannelColor if theme is not initialized

### DIFF
--- a/gui/src/style.cpp
+++ b/gui/src/style.cpp
@@ -219,7 +219,14 @@ QString Style::getAttribute(const char *key)
 	return replaceAttributes(attr);
 }
 
-QColor Style::getChannelColor(int index) { return getChannelColorList()[index]; }
+QColor Style::getChannelColor(int index)
+{
+	QList<QColor> list = getChannelColorList();
+	if(list.count() <= index)
+		return QColor();
+
+	return getChannelColorList()[index];
+}
 
 QList<QColor> Style::getChannelColorList()
 {

--- a/gui/src/stylehelper.cpp
+++ b/gui/src/stylehelper.cpp
@@ -54,7 +54,7 @@ QString StyleHelper::getChannelColor(int index)
 	QColor color;
 	int colorCount = Style::getChannelColorList().length();
 
-	if(colorCount <= index) {
+	if(colorCount != 0 && colorCount <= index) {
 		color = QColor(getChannelColor(index - colorCount));
 		color.setHsv(color.hue() + 30, color.saturation(), color.value());
 	} else {

--- a/gui/src/widgets/hoverwidget.cpp
+++ b/gui/src/widgets/hoverwidget.cpp
@@ -24,6 +24,9 @@
 #include <QDebug>
 #include <style.h>
 #include <stylehelper.h>
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(CAT_HOVERWIDGET, "HoverWidget")
 
 using namespace scopy;
 
@@ -320,9 +323,9 @@ void HoverWidget::moveToAnchor()
 		break;
 	}
 
-	qDebug() << "moveAnchor"
-		 << "mapped" << mappedPoint << "contentPosition" << contentPosition << "anchorPosition"
-		 << anchorPosition << "offset" << m_anchorOffset;
+	qDebug(CAT_HOVERWIDGET) << "moveAnchor"
+				<< "mapped" << mappedPoint << "contentPosition" << contentPosition << "anchorPosition"
+				<< anchorPosition << "offset" << m_anchorOffset;
 	move(mappedPoint + contentPosition + anchorPosition + m_anchorOffset);
 }
 

--- a/gui/style/qss/generic/global.qss
+++ b/gui/style/qss/generic/global.qss
@@ -17,6 +17,9 @@ QSplitter::handle:disabled { background-color: transparent; }
 QTextBrowser {
     border: none;
 }
+QTextEdit {
+    border: none;
+}
 
 *:focus {
     outline: &interactive_focus&;


### PR DESCRIPTION
This also fixes admt tests crash since no theme is loaded when running tests and StyleHelper is used