### PR TITLE
m2k: fix the display resample in scenarios with ratio = 0

### DIFF
--- a/plugins/m2k/src/old/signal_generator.hpp
+++ b/plugins/m2k/src/old/signal_generator.hpp
@@ -158,6 +158,8 @@ private:
 
 	Ui::SignalGenerator *ui;
 	CapturePlot *m_plot;
+	QLabel *m_plotStatus;
+	bool m_resampOk;
 	gr::top_block_sptr top_block;
 	struct time_block_data *time_block_data;
 
@@ -238,6 +240,7 @@ private:
 	void loadFileChannelData(int chIdx);
 	bool riffCompare(riff_header_t &ptr, const char *id2);
 	bool chunkCompare(chunk_header_t &ptr, const char *id2);
+	bool handleResampler(gr::basic_block_sptr resamp);
 
 public Q_SLOTS:
 	void run() override;
@@ -289,6 +292,7 @@ private Q_SLOTS:
 	void checkRunEnabled();
 Q_SIGNALS:
 	void showTool();
+	void previewUpdated(bool);
 };
 
 enum SIGNAL_TYPE


### PR DESCRIPTION
In different scenarios, the channel combination can generate a zero ratio when computing the resampling preview parameters. One example is having a buffer source for both channels and configuring 1kHz and 5MHz. This configuration can also be tested using the stairstep waveform.

Add a plot status informing the user that the preview is no longer updated in these scenarios and make sure the gnuradio flow is properly updated.