### PR TITLE
m2k: disable MATLAB file support in the siggen for this release.

### DIFF
--- a/plugins/m2k/src/old/signal_generator.cpp
+++ b/plugins/m2k/src/old/signal_generator.cpp
@@ -1332,8 +1332,7 @@ void SignalGenerator::loadFile()
 		this, tr("Open File"), "",
 		tr("Comma-separated values files (*.csv);;"
 		   "Tab-delimited values files (*.txt);;"
-		   "Waveform Audio File Format (*.wav);;"
-		   "Matlab files (*.mat)"),
+		   "Waveform Audio File Format (*.wav)"),
 		nullptr, (useNativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog));
 
 	if(fileName.isEmpty()) { // user hit cancel


### PR DESCRIPTION
Due to libmatio not being installed in the currently built dockers.