### PR TITLE
IIO Widgets: multiple changes on iio widgets controls

### DIFF
--- a/iio-widgets/include/iio-widgets/guistrategy/checkboxguistrategy.h
+++ b/iio-widgets/include/iio-widgets/guistrategy/checkboxguistrategy.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef SCOPY_CHECKBOXGUISTRATEGY_H
+#define SCOPY_CHECKBOXGUISTRATEGY_H
+
+#include <QWidget>
+#include <iio.h>
+#include <gui/widgets/menuonoffswitch.h>
+#include "guistrategy/guistrategyinterface.h"
+#include "iiowidgetdata.h"
+#include "scopy-iio-widgets_export.h"
+
+namespace scopy {
+class SCOPY_IIO_WIDGETS_EXPORT CheckBoxAttrUi : public QObject, public GuiStrategyInterface
+{
+	Q_OBJECT
+	Q_INTERFACES(scopy::GuiStrategyInterface)
+public:
+	/**
+	 * @brief This contain a MenuOnOffSwitch capable of holding boolean values
+	 * */
+	explicit CheckBoxAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact = false, QWidget *parent = nullptr);
+	~CheckBoxAttrUi();
+
+	/**
+	 * @overload GuiStrategyInterface::ui()
+	 * */
+	QWidget *ui() override;
+
+	bool isValid() final;
+
+public Q_SLOTS:
+	void receiveData(QString currentData, QString optionalData) override;
+
+Q_SIGNALS:
+	void displayedNewData(QString data, QString optionalData) override;
+	void emitData(QString data) override;
+	void requestData() override;
+
+private:
+	QWidget *m_ui;
+	MenuOnOffSwitch *m_menuOnOffSwitch;
+	bool m_isCompact;
+};
+} // namespace scopy
+
+#endif // SCOPY_CHECKBOXGUISTRATEGY_H

--- a/iio-widgets/include/iio-widgets/iiowidget.h
+++ b/iio-widgets/include/iio-widgets/iiowidget.h
@@ -129,7 +129,11 @@ public:
 	void setUItoDataConversion(std::function<QString(QString)> func);
 	void setDataToUIConversion(std::function<QString(QString)> func);
 
+	void showProgressBar(bool show);
+
 Q_SIGNALS:
+	void progressBarVisible(bool);
+
 	/**
 	 * @brief Emits the current state of the IIOWidget system and a string containing a more
 	 * elaborate explanation of the current state

--- a/iio-widgets/include/iio-widgets/iiowidgetbuilder.h
+++ b/iio-widgets/include/iio-widgets/iiowidgetbuilder.h
@@ -51,6 +51,7 @@ public:
 		ComboUi,
 		SwitchUi,
 		RangeUi,
+		CheckBoxUi
 	};
 
 	explicit IIOWidgetBuilder(QWidget *parent = nullptr);

--- a/iio-widgets/src/guistrategy/checkboxguistrategy.cpp
+++ b/iio-widgets/src/guistrategy/checkboxguistrategy.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "guistrategy/checkboxguistrategy.h"
+#include <style.h>
+#include <QLoggingCategory>
+
+using namespace scopy;
+
+Q_LOGGING_CATEGORY(CAT_CHECKBOXGUISTRATEGY, "CheckBoxGuiStrategy")
+
+CheckBoxAttrUi::CheckBoxAttrUi(IIOWidgetFactoryRecipe recipe, bool isCompact, QWidget *parent)
+	: QObject(parent)
+	, m_ui(new QWidget(parent))
+	, m_isCompact(isCompact)
+{
+	m_recipe = recipe;
+	m_ui->setLayout(new QHBoxLayout(m_ui));
+	m_ui->layout()->setMargin(0);
+	m_menuOnOffSwitch = new MenuOnOffSwitch("", m_ui);
+
+	if(!m_isCompact) {
+		QLabel *nameLbl = new QLabel(recipe.data, m_ui);
+		nameLbl->setWordWrap(true);
+		nameLbl->setFixedWidth(m_menuOnOffSwitch->width());
+		Style::setStyle(nameLbl, style::properties::label::subtle);
+		m_ui->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+		m_ui->layout()->addWidget(nameLbl);
+	}
+	m_ui->layout()->addWidget(m_menuOnOffSwitch);
+
+	connect(m_menuOnOffSwitch->onOffswitch(), &QAbstractButton::clicked, this, [this]() {
+		QString currentSelection = QString::number(m_menuOnOffSwitch->onOffswitch()->isChecked());
+		Q_EMIT emitData(currentSelection);
+	});
+	Q_EMIT requestData();
+}
+
+CheckBoxAttrUi::~CheckBoxAttrUi() {}
+
+QWidget *CheckBoxAttrUi::ui() { return m_ui; }
+
+bool CheckBoxAttrUi::isValid()
+{
+	if(m_recipe.channel != nullptr && m_recipe.data != "" && m_recipe.iioDataOptions != "") {
+		return true;
+	}
+	return false;
+}
+
+void CheckBoxAttrUi::receiveData(QString currentData, QString optionalData)
+{
+	QSignalBlocker blocker(m_menuOnOffSwitch);
+	bool ok;
+	int val = currentData.toInt(&ok);
+	if(ok) {
+		m_menuOnOffSwitch->onOffswitch()->setChecked(val);
+		Q_EMIT displayedNewData(currentData, optionalData);
+	} else {
+		qCritical(CAT_CHECKBOXGUISTRATEGY) << "Could not parse the value as a boolean.";
+	}
+}
+
+#include "moc_checkboxguistrategy.cpp"

--- a/iio-widgets/src/iiowidget.cpp
+++ b/iio-widgets/src/iiowidget.cpp
@@ -72,6 +72,8 @@ IIOWidget::IIOWidget(GuiStrategyInterface *uiStrategy, DataStrategyInterface *da
 	// intercept the sendData from dataStrategy to collect information
 	connect(dataStrategyObject, SIGNAL(sendData(QString, QString)), this, SLOT(storeReadInfo(QString, QString)));
 
+	connect(this, SIGNAL(progressBarVisible(bool)), m_progressBar, SLOT(setVisible(bool)));
+
 	// The data will be populated here
 	bool useLazyLoading = Preferences::GetInstance()->get("iiowidgets_use_lazy_loading").toBool();
 	if(!useLazyLoading) { // force skip lazy load
@@ -151,6 +153,8 @@ int IIOWidget::lastReturnCode() { return m_lastReturnCode; }
 void IIOWidget::setUItoDataConversion(std::function<QString(QString)> func) { m_UItoDS = func; }
 
 void IIOWidget::setDataToUIConversion(std::function<QString(QString)> func) { m_DStoUI = func; }
+
+void IIOWidget::showProgressBar(bool show) { Q_EMIT progressBarVisible(show); }
 
 void IIOWidget::startTimer(QString data)
 {

--- a/iio-widgets/src/iiowidgetbuilder.cpp
+++ b/iio-widgets/src/iiowidgetbuilder.cpp
@@ -21,6 +21,7 @@
 #include "iiowidgetbuilder.h"
 #include "guistrategy/editableguistrategy.h"
 #include "guistrategy/switchguistrategy.h"
+#include "guistrategy/checkboxguistrategy.h"
 #include "datastrategy/channelattrdatastrategy.h"
 #include "datastrategy/triggerdatastrategy.h"
 #include "datastrategy/deviceattrdatastrategy.h"
@@ -422,6 +423,9 @@ GuiStrategyInterface *IIOWidgetBuilder::createUIS()
 		break;
 	case UIS::RangeUi:
 		ui = new RangeAttrUi(m_generatedRecipe, m_isCompact, m_widgetParent);
+		break;
+	case UIS::CheckBoxUi:
+		ui = new CheckBoxAttrUi(m_generatedRecipe, m_isCompact, m_widgetParent);
 		break;
 	default:
 		break;

--- a/iio-widgets/src/iiowidgetbuilder.cpp
+++ b/iio-widgets/src/iiowidgetbuilder.cpp
@@ -62,6 +62,7 @@ IIOWidget *IIOWidgetBuilder::buildSingle()
 {
 	DataStrategyInterface *ds = nullptr;
 	GuiStrategyInterface *ui = nullptr;
+	const char *availableAttr = nullptr;
 
 	if(!m_context && !m_device && !m_channel) {
 		qWarning(CAT_ATTRBUILDER) << "No channel/device/context set.";
@@ -71,6 +72,24 @@ IIOWidget *IIOWidgetBuilder::buildSingle()
 	if(m_attribute.isEmpty()) {
 		qWarning(CAT_ATTRBUILDER) << "No attribute name set.";
 		return nullptr;
+	}
+
+	if(m_optionsAttribute.isEmpty()) {
+		if(m_channel) {
+			availableAttr = iio_channel_find_attr(
+				m_channel, (QString(m_attribute) + "_available").toStdString().c_str());
+		} else if(m_device) {
+			availableAttr = iio_device_find_attr(
+				m_device, (QString(m_attribute) + "_available").toStdString().c_str());
+			if(m_includeDebugAttrs) {
+				availableAttr = iio_device_find_debug_attr(
+					m_device, (QString(m_attribute) + "_available").toStdString().c_str());
+			}
+		}
+
+		if(availableAttr) {
+			m_optionsAttribute = availableAttr;
+		}
 	}
 
 	m_generatedRecipe = {


### PR DESCRIPTION
- Expose controls for changing the visibility of the IIO Widget progress bar.
- Check for {requested_attr}_available in the buildSingle function. This is done when buildAll is called for any type of IIO object, but it could make things simpler if it would also scan this when building a single widget.
- Add a new CheckBox GUI Strategy. It is now visually represented by a SmallMenuOnOffSwitch. It should only be used for boolean values. The previously mentioned control over progress bar visibility is implemented for this.