### PR TITLE
iiowidgets: add IIOWidgetGroup which updates all subscribed automatically

### DIFF
--- a/iio-widgets/include/iio-widgets/iiowidgetgroup.h
+++ b/iio-widgets/include/iio-widgets/iiowidgetgroup.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef SCOPY_IIOWIDGETGROUP_H
+#define SCOPY_IIOWIDGETGROUP_H
+
+#include "scopy-iio-widgets_export.h"
+#include "iiowidget.h"
+#include <QObject>
+
+namespace scopy {
+class SCOPY_IIO_WIDGETS_EXPORT IIOWidgetGroup : public QObject
+{
+	Q_OBJECT
+
+public:
+	IIOWidgetGroup(bool singleTrigger = false, QObject *parent = nullptr);
+	virtual ~IIOWidgetGroup();
+
+	void add(IIOWidget *widget, bool triggerPoint = false);
+
+private Q_SLOTS:
+
+	void handleStatusChanged(QDateTime date, QString old, QString newD, int ret, bool readop);
+
+private:
+	QVector<IIOWidget *> m_widgets;
+	bool m_singleTrigger;
+	IIOWidget *m_trigger;
+};
+} // namespace scopy
+
+#endif // SCOPY_IIOWIDGETGROUP_H

--- a/iio-widgets/src/iiowidgetgroup.cpp
+++ b/iio-widgets/src/iiowidgetgroup.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * This file is part of Scopy
+ * (see https://www.github.com/analogdevicesinc/scopy).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "iiowidgetgroup.h"
+
+using namespace scopy;
+
+IIOWidgetGroup::IIOWidgetGroup(bool singleTrigger, QObject *parent)
+	: QObject(parent)
+	, m_widgets({})
+	, m_singleTrigger(singleTrigger)
+	, m_trigger(nullptr)
+{}
+
+IIOWidgetGroup::~IIOWidgetGroup() { m_widgets.clear(); }
+
+void IIOWidgetGroup::add(IIOWidget *widget, bool triggerPoint)
+{
+	m_widgets.push_back(widget);
+	bool conn = !m_singleTrigger;
+	if(m_singleTrigger && triggerPoint && !m_trigger) {
+		m_trigger = widget;
+		conn = true;
+	}
+
+	if(conn) {
+		connect(dynamic_cast<QObject *>(widget->getDataStrategy()),
+			SIGNAL(emitStatus(QDateTime, QString, QString, int, bool)), this,
+			SLOT(handleStatusChanged(QDateTime, QString, QString, int, bool)), Qt::QueuedConnection);
+	}
+}
+
+void IIOWidgetGroup::handleStatusChanged(QDateTime date, QString old, QString newD, int ret, bool readop)
+{
+	if(old != newD) {
+		for(auto w : qAsConst(m_widgets)) {
+			w->readAsync();
+		}
+	}
+}
+
+#include "moc_iiowidgetgroup.cpp"


### PR DESCRIPTION
Adding IIOWidgets to a group will ensure that all widgets are updated when one of them is modified.

The group also allows a single trigger point, meaning that the selected IIOWidget will be the only one triggering updates for all the others in the group.