### PR TITLE
iioexplorer: Fix splitter sizes

### DIFF
--- a/plugins/debugger/src/iioexplorer/iioexplorerinstrument.cpp
+++ b/plugins/debugger/src/iioexplorer/iioexplorerinstrument.cpp
@@ -500,10 +500,42 @@ void IIOExplorerInstrument::setupCodeGeneratorWindow()
 
 QList<int> IIOExplorerInstrument_API::vSplitter() const { return p->m_VSplitter->sizes(); }
 
-void IIOExplorerInstrument_API::setVSplitter(const QList<int> &newSplitter) { p->m_VSplitter->setSizes(newSplitter); }
+void IIOExplorerInstrument_API::setVSplitter(const QList<int> &newSplitter)
+{
+	if(newSplitter.size() != 2) {
+		qWarning(CAT_DEBUGGERIIOMODEL) << "Invalid splitter size. Expected 2, got" << newSplitter.size();
+		return;
+	}
+
+	// If one of the values is 0, reset to a default value
+	if(newSplitter[0] <= 0 || newSplitter[1] <= 0) {
+		qWarning(CAT_DEBUGGERIIOMODEL) << "Invalid splitter value. Resetting to default.";
+		int sum = newSplitter[0] + newSplitter[1];
+		p->m_VSplitter->setSizes(QList<int>() << (sum * 2) / 3 << sum / 3);
+		return;
+	}
+
+	p->m_VSplitter->setSizes(newSplitter);
+}
 
 QList<int> IIOExplorerInstrument_API::hSplitter() const { return p->m_HSplitter->sizes(); }
 
-void IIOExplorerInstrument_API::setHSplitter(const QList<int> &newSplitter) { p->m_HSplitter->setSizes(newSplitter); }
+void IIOExplorerInstrument_API::setHSplitter(const QList<int> &newSplitter)
+{
+	if(newSplitter.size() != 2) {
+		qWarning(CAT_DEBUGGERIIOMODEL) << "Invalid splitter size. Expected 2, got" << newSplitter.size();
+		return;
+	}
+
+	// If one of the values is 0, reset to a default value
+	if(newSplitter[0] <= 0 || newSplitter[1] <= 0) {
+		qWarning(CAT_DEBUGGERIIOMODEL) << "Invalid splitter value. Resetting to default.";
+		int sum = newSplitter[0] + newSplitter[1];
+		p->m_HSplitter->setSizes(QList<int>() << sum / 4 << (sum * 3) / 4);
+		return;
+	}
+
+	p->m_HSplitter->setSizes(newSplitter);
+}
 
 #include "moc_iioexplorerinstrument.cpp"


### PR DESCRIPTION
In some cases the saved value from the splitter will be 0, causing it to hide some sections. This would be the normal behaviour, but sometimes when the ini file does not exist, the initial value is 0.