### PR TITLE
Allow Privilege Override to support All Users installs

### DIFF
--- a/ci/windows/scopy-64.iss.cmakein
+++ b/ci/windows/scopy-64.iss.cmakein
@@ -29,6 +29,7 @@ AlwaysRestart=yes
 DisableDirPage=no
 MinVersion=6.2
 PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
 SetupIconFile="@SCOPY_ICON_ICO@"
 WizardStyle=modern
 


### PR DESCRIPTION
Hello!
I work for an institution where we use Scopy. We need Scopy installed on a fleet of machines, installed for All users. However, this is not supported as PrivilegesRequiredOverridesAllowed is not currently set in [Setup], which is required by the /ALLUSERS command line parameter for the installer

See:
https://jrsoftware.org/ishelp/index.php?topic=setupcmdline
https://jrsoftware.org/ishelp/index.php?topic=setup_privilegesrequiredoverridesallowed

My proposed changes would allow users to use the /ALLUSERS flag successfully, as well as have the dialog option to install in administrative (all user) mode.