### PR TITLE
ci/macos: lock boost version to 1.85

### DIFF
--- a/ci/macOS/install_macos_deps.sh
+++ b/ci/macOS/install_macos_deps.sh
@@ -4,7 +4,7 @@ set -ex
 REPO_SRC=$(git rev-parse --show-toplevel)
 source $REPO_SRC/ci/macOS/macos_config.sh
 
-PACKAGES="${QT_FORMULAE} volk spdlog boost pkg-config cmake fftw bison gettext autoconf automake libzip glib libusb glog doxygen wget gnu-sed libmatio dylibbundler libxml2 ghr libsndfile"
+PACKAGES="${QT_FORMULAE} volk spdlog ${BOOST_FORMULAE} pkg-config cmake fftw bison gettext autoconf automake libzip glib libusb glog doxygen wget gnu-sed libmatio dylibbundler libxml2 ghr libsndfile"
 
 OS_VERSION=${1:-$(sw_vers -productVersion)}
 echo "MacOS version $OS_VERSION"

--- a/ci/macOS/macos_config.sh
+++ b/ci/macOS/macos_config.sh
@@ -6,8 +6,16 @@ REPO_SRC=$(git rev-parse --show-toplevel)
 BUILDDIR=$REPO_SRC/build
 JOBS=-j8
 QT_FORMULAE=qt@5
+
+# In the Boost 1.89.0 release,
+# the Boost.System library, needed by GNU Radio, has been removed
+# Issue explained here: https://github.com/powerdns/pdns/issues/15972
+# Workaround is to use Boost 1.85 for now
+BOOST_FORMULAE=boost@1.85
+
 QT_PATH="$(brew --prefix ${QT_FORMULAE})/bin"
-export PATH="${QT_PATH}:$PATH"
+BOOST_PATH="$(brew --prefix ${BOOST_FORMULAE})/bin"
+export PATH="${QT_PATH}:${BOOST_PATH}:$PATH"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH;$STAGING_AREA_DEPS;$STAGING_AREA_DEPS/lib"
 
 


### PR DESCRIPTION
 - Boost.System lib, needed by GNU Radio, was removed in the 1.89 release