### PR TITLE
generic: template update CXX_STANDARD 20 does not match current ci fo…

### DIFF
--- a/tools/packagegenerator/templates/pdk/pdk_cmakelists.mako
+++ b/tools/packagegenerator/templates/pdk/pdk_cmakelists.mako
@@ -8,7 +8,7 @@ project(${"${TARGET_NAME}"} VERSION 0.0.1 DESCRIPTION "Project Description")
 # Make sure CMake will take care of moc for us
 set(CMAKE_AUTOMOC ON)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(INSERT CMAKE_MODULE_PATH 0 ${"${PROJECT_SOURCE_DIR}"}/cmake/Modules)
 


### PR DESCRIPTION
…r ubuntu 22 and windows mingw

using CXX_STANDARD 20 causes ci to fail CXX_STANDARD 17 is the one currently used in the ci