### PR TITLE
core: Add device reload functionality.

### DIFF
--- a/core/include/core/deviceimpl.h
+++ b/core/include/core/deviceimpl.h
@@ -80,6 +80,7 @@ Q_SIGNALS:
 	void requestTool(QString) override;
 	void connectionFailed();
 	void forget();
+	void requestReload(QString id, QStringList plugins);
 
 protected:
 	void removeDisabledPlugins();
@@ -92,10 +93,13 @@ protected:
 	void setPingPlugin(Plugin *plugin);
 	void bindPing();
 	void unbindPing();
+	void loadCompatiblePluginsTab(QWidget *pluginsTab);
+	QStringList getPluginsName();
 
 protected:
 	QList<Plugin *> m_plugins;
 	QList<Plugin *> m_connectedPlugins;
+	QSet<QString> m_reloadPluginsSet;
 	DeviceState_t m_state;
 	QString m_id;
 	QString m_category;

--- a/core/include/core/devicemanager.h
+++ b/core/include/core/devicemanager.h
@@ -55,6 +55,7 @@ public Q_SLOTS:
 
 	void removeDeviceById(QString id);
 	QString restartDevice(QString id);
+	QString reloadDevice(QString id, QStringList plugins);
 	void disconnectAll();
 
 	void save(QSettings &s);

--- a/core/ui/devicepage.ui
+++ b/core/ui/devicepage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>591</width>
+    <height>367</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -36,48 +36,24 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="m_buttonLayout">
-     <property name="spacing">
-      <number>5</number>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="tabPosition">
+      <enum>QTabWidget::South</enum>
      </property>
-     <property name="leftMargin">
-      <number>20</number>
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="topMargin">
-      <number>5</number>
-     </property>
-     <property name="rightMargin">
-      <number>20</number>
-     </property>
-     <property name="bottomMargin">
-      <number>5</number>
-     </property>
-    </layout>
-   </item>
-   <item>
-    <widget class="QScrollArea" name="m_scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="m_scrollAreaContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>398</width>
-        <height>288</height>
-       </rect>
-      </property>
+     <widget class="QWidget" name="m_devInfoTab">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <layout class="QVBoxLayout" name="m_scrollAreaLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
+      <attribute name="title">
+       <string>Device info</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -90,6 +66,152 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
+       <item>
+        <layout class="QHBoxLayout" name="m_buttonLayout">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>20</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>20</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="m_scrollArea">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="m_scrollAreaContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>585</width>
+            <height>318</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QVBoxLayout" name="m_scrollAreaLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="m_pluginsTab">
+      <attribute name="title">
+       <string>Available plugins</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="m_pluginsBtnLay">
+         <property name="leftMargin">
+          <number>20</number>
+         </property>
+         <property name="topMargin">
+          <number>8</number>
+         </property>
+         <property name="rightMargin">
+          <number>20</number>
+         </property>
+         <property name="bottomMargin">
+          <number>20</number>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="m_pluginsTabScroll">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="m_pluginsTabContent">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>576</width>
+            <height>300</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QVBoxLayout" name="m_scrollAreaLayout_2">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>14</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
Add a tab widget to device page with device info and plugin selection tabs.
Add reload button to recreate device with selected plugins.
By default the **Device info** tab is shown.  
<img width="1281" height="758" alt="Screenshot from 2025-11-07 10-40-11" src="https://github.com/user-attachments/assets/4a8d247e-9a0f-4cf5-98e5-7ad6d3fcc297" />
<img width="1281" height="758" alt="Screenshot from 2025-11-07 10-40-00" src="https://github.com/user-attachments/assets/1c1a5b96-2403-4508-bad0-be9e8e19ef87" />