### PR TITLE
tools: update path for plugin location to match package infrastructure

### DIFF
--- a/tools/packagegenerator/templates/plugin/pluginloader.mako
+++ b/tools/packagegenerator/templates/plugin/pluginloader.mako
@@ -43,7 +43,7 @@ private Q_SLOTS:
 	void metadata();
 };
 
-#define PLUGIN_LOCATION "../../plugins"
+#define PLUGIN_LOCATION "../.."
 #define FILENAME PLUGIN_LOCATION "/libscopy-${plugin_name}.so"
 
 void ${tst_classname}::fileExists()


### PR DESCRIPTION
The current path causes tests to fail 