### PR TITLE
docs: Add structurizr-based architecture documentation.

### DIFF
--- a/.github/workflows/generate_doc.yml
+++ b/.github/workflows/generate_doc.yml
@@ -45,12 +45,23 @@ jobs:
         echo "test_report_folder=$TEST_REPORT_FOLDER" >> "$GITHUB_ENV"
         # python3 test_report_generator.py ../testing_results/ tests/test_report/ "${{ github.sha }}"
 
+    - name: Setup Java for Structurizr
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
     - name: Build doc
       working-directory: docs
       run: |
         python3 extract_macros.py ../ user_guide/preferences_table.rst
         export ADOC_DOC_VERSION=${{ github.ref_name }}
         make html SPHINXOPTS='-W --keep-going'
+
+    - name: Build Structurizr diagrams
+      working-directory: docs/architecture/diagrams
+      run: |
+        ./export-structurizr.sh
 
     - name: Store the generated doc
       uses: actions/upload-artifact@v4

--- a/docs/architecture/.gitignore
+++ b/docs/architecture/.gitignore
@@ -1,0 +1,5 @@
+diagrams/_build
+diagrams/app_diagrams/.structurizr
+diagrams/deployment_diagrams/.structurizr
+diagrams/lib
+diagrams/structurizr*

--- a/docs/architecture/diagrams/app_diagrams/workspace.dsl
+++ b/docs/architecture/diagrams/app_diagrams/workspace.dsl
@@ -1,0 +1,696 @@
+workspace "Scopy ADI" {
+
+    model {
+
+        // Users
+        engineerUser = person "Engineer"
+        student = person "Student"
+
+        // External Systems
+        gnuRadioEcosystem = softwareSystem "GNU Radio Ecosystem" {
+            description "Signal processing backend for advanced operations"
+            tags "System Dependency"
+        }
+        
+        fileSystem = softwareSystem "File System" {
+            description "Local and network storage for data, configurations, and logs"
+            tags "System Dependency"
+        }
+        
+        operatingSystem = softwareSystem "Operating System" {
+            description "Linux, Windows, macOS providing hardware access and system services"
+            tags "System Dependency"
+        }
+        
+        iioFramework = softwareSystem "IIO Framework" {
+            description "Linux Industrial I/O subsystem for hardware abstraction"
+            tags "System Dependency"
+        }
+        
+        adiHardware = softwareSystem "Hardware Devices" {
+            description "Analog Devices evaluation boards and other devices"
+            tags "System Dependency"
+        } 
+
+        iioEmu = softwareSystem "IIO Emulator (iio-emu)" {
+            description "Hardware device emulation system providing virtualized IIO devices for development and testing"
+            tags "System Dependency"
+        }
+
+        // Main System
+         scopySystem = softwareSystem "Scopy" "Multi-functional software toolset with strong capabilities for signal analysis" {
+            tags "Scopy System"
+            // Single Main Container
+            scopyApplication = container "Scopy Application" {
+                description "Monolithic Qt-based desktop application"
+                technology "C++, Qt, Qwt"
+                tags "MainContainer"
+
+                // INFRASTRUCTURE LAYER
+                applicationCoordinator = component "Application Coordinator" {
+                    description "Application startup/shutdown coordination, initialization sequences, and graceful termination handling"
+                    tags "Infrastructure"
+                    group "core"
+                    properties {
+                        "Application initialization" "QApplication setup, Qt attributes, logging, crash handling coordination (main.cpp)"
+                        "Command line processing" "CmdLineHandler for argument parsing, script execution, device auto-connection (core/include/core/cmdlinehandler.h)"
+                        "Application restart coordination" "ApplicationRestarter singleton for graceful restart handling (core/include/core/application_restarter.h)"
+                        "Splash screen management" "ScopySplashscreen startup feedback and progress messaging (gui/include/gui/widgets/scopysplashscreen.h)"
+                    }
+
+                }
+
+                crashReporting = component "Crash Reporting System" {
+                    description "Crash detection, error report generation, and stack trace collection"
+                    tags "Infrastructure"
+                    group "core"
+                }
+
+                commandLineHandler = component "Command Line Handler" {
+                    description "CLI argument parsing and command execution"
+                    tags "Infrastructure"
+                    group "core"
+                }
+
+                scriptingEngine = component "Scripting Engine" {
+                    description "JavaScript runtime, script execution, automation interface, and programmatic API access"
+                    tags "Infrastructure"
+                    group "core"
+                }
+                
+                translationService = component "Translation Service" {
+                    description "Internationalization support and language pack management"
+                    tags "Infrastructure"
+                    group "core"
+                }
+
+                preferencesManagement = component "Preferences Management" {
+                    description "Centralized configuration storage, user preferences, plugin settings, and persistent application state"
+                    tags "Infrastructure"
+                    group "core"
+                }
+
+                loggingSystem = component "Logging System" {
+                    description "Centralized logging, debug output, error tracking, benchmark, and diagnostic information collection"
+                    tags "Infrastructure"
+                    group "core"
+                }
+
+                // CORE BUSINESS LOGIC
+                deviceManagement = component "Device Management" {
+                    description "Device discovery, connection lifecycle, hardware abstraction, and unified device interface"
+                    tags "CoreBusiness"
+                    group "core"
+                    properties {
+                        "Device management" "Device creation, connection, disconnection, restart, reload with state tracking (core/include/core/devicemanager.h)"
+                        "Device abstraction" "DeviceImpl and Device classes providing unified hardware interface (core/include/core/device.h; core/include/core/deviceimpl.h)"
+                    }
+                }
+
+                packageManager = component "Package Manager" {
+                    description "Manages packages installation and distribution"
+                    tags "CoreBusiness"
+                    group "pkg-manager"
+                }
+
+                pluginSystem = component "Plugin System" {
+                    description "Dynamic plugin loading, lifecycle management, dependency resolution, and plugin architecture foundation"
+                    tags "CoreBusiness"
+                    group "core"
+                    properties {
+                        "Plugin repository" "PluginRepository singleton for plugin management, metadata handling, plugin discovery (core/include/core/pluginrepository.h)"
+                        "Plugin manager" "PluginManager for dynamic loading, sorting, filtering, and lifecycle control (core/include/core/pluginmanager.h)"
+                        "Plugin interface" "Plugin base interface defining compatible(), onConnect(), onDisconnect() and other contracts (pluginbase/include/pluginbase/plugin.h)"
+                    }
+                }
+                
+                // Plugin System components
+                pluginRepository = component "Plugin Repository" {
+                    description "Storage and management of available plugins and their metadata"                                                    
+                    tags "PluginSystem"                                          
+                    group "core"
+                }
+                pluginManager = component "Plugin Manager" {                 
+                    description "Dynamic loading and instantiation of plugin libraries"                                                              
+                    tags "PluginSystem"                                         
+                    group "core" 
+                }
+                pluginInterface = component "Plugin Interface" {           
+                    description "Common API contract that all plugins must implement"                                                                    
+                    tags "PluginSystem" 
+                    group "pluginbase"                                         
+                }  
+                pluginManager -> pluginRepository "queries available plugins"
+                pluginManager -> pluginInterface "instantiates plugins"
+
+                // UI AND PRESENTATION LAYER
+                uiFramework = component "UI Framework" {
+                    description "Common UI widgets, plot widgets, style management"
+                    tags "Presentation"
+                    group "gui"
+                    properties {
+                        "Common components" "Menu section widgets, collapse headers, custom controls for patameters, enhanced input widgets, etc. (gui/include/gui; gui/include/gui/widgets)"
+                        "Plot widgets" "Plotting widgets, measurement displays, signal visualization (gui/include/gui)"
+                        "Style management" "QSS-based styling with dynamic theme switching (gui/style)"
+                    }
+                }
+
+                windowManagement = component "Window Management" {
+                    description "Main window coordination, detached tool windows, and workspace management"
+                    tags "Presentation"
+                    group "gui"
+                    properties {
+                        "Main window coordination" "ScopyMainWindow lifecycle, application initialization, event handling (core/include/core/scopymainwindow.h)"
+                        "Detached tool management" "DetachedToolWindowManager for separate tool windows, multi-monitor support (core/include/core/detachedtoolwindowmanager.h)"
+                        "Advanced docking system" "KDDockWidgets backend for professional docking layouts (gui/include/gui/docking)"
+                    }
+                }
+
+                toolManager = component "Tool Manager" {
+                    description "Tool registration, menu organization, tool lifecycle coordination, and unified tool interface"
+                    tags "Presentation"
+                    group "core"
+                }
+
+                statusBar = component "Status Bar" {
+                    description "Real-time status display, device connectivity indicators, operation progress, and system notifications"
+                    tags "Presentation"
+                    group "gui"
+                }
+
+                applicationPages = component "Application Pages" {
+                    description "Page navigation, home page, device browser, preferences pages, packages page, and application flow control"
+                    tags "Presentation"
+                    group "core"
+                    properties {
+                        "Tool stack management" "ToolStack container extending MapStackedWidget for key-based page switching (core/include/core/toolstack.h)"
+                        "Preferences integration" "ScopyPreferencesPage, settings management, configuration dialogs (core/include/core/scopypreferencespage.h)"
+                        "About and info pages" "ScopyAboutPage, version information, system details (core/include/core/scopyaboutpage.h)"
+                        "Home page system" "ScopyHomePage for device scanning, connection management, device browser (core/include/core)"
+                        "Navigation coordination" "Tool selection flow, page switching, menu state management (core/include/core)"
+                    }
+                }
+
+                // SUPPORTING LIBRARIES
+                iioUtilities = component "IIO Utilities" {
+                    description "Industrial I/O communication, command queuing, and connection management"
+                    tags "Library"
+                    group "iio-util"
+                }
+
+                iioWidgets = component "IIO Widgets" {
+                    description "Specialized UI components for IIO devices, parameter controls, and device-specific interfaces"
+                    tags "Library"
+                    group "iio-widgets"
+                }
+
+                gnuRadioWidgets = component "GNU Radio Utilities" {
+                    description "GNU Radio specific components and signal processing controls"
+                    tags "Library"
+                    group "gr-util"
+                }
+                
+                // COMPONENT RELATIONSHIPS
+
+                // Infrastructure Dependencies
+  
+                // Application Coordinator orchestrates system initialization
+                applicationCoordinator -> preferencesManagement "loads application settings"
+                applicationCoordinator -> loggingSystem "initializes logging"
+                applicationCoordinator -> crashReporting "sets up crash handlers"
+                applicationCoordinator -> translationService "initializes localization"
+                applicationCoordinator -> deviceManagement "initializes device system"
+                applicationCoordinator -> pluginSystem "initializes plugin system"
+                applicationCoordinator -> packageManager "initializes package management"
+                applicationCoordinator -> windowManagement "initializes main window"
+
+
+                // Command Line Handler processes startup arguments
+                commandLineHandler -> preferencesManagement "overrides default settings"
+                commandLineHandler -> loggingSystem "configures log verbosity"
+                commandLineHandler -> applicationCoordinator "triggers startup sequence"
+                commandLineHandler -> scriptingEngine "executes script files"
+                
+                scriptingEngine -> applicationCoordinator "accesses application services"
+
+                // Core Business Logic Dependencies
+                deviceManagement -> preferencesManagement "reads device preferences"
+                deviceManagement -> loggingSystem "logs device operations"
+                deviceManagement ->  pluginSystem "loads device specific plugins"
+
+                pluginSystem -> packageManager "manages plugins from packages"
+                pluginSystem -> preferencesManagement "reads plugin configurations"
+                pluginSystem -> loggingSystem "logs plugin operations"
+                pluginSystem -> iioUtilities "uses for device communication"
+                pluginSystem -> gnuRadioWidgets "specific plugins use processing services"
+                pluginSystem -> iioWidgets "specific plugins use"
+
+                // UI and Presentation Dependencies
+                windowManagement -> uiFramework "uses common UI components"
+                windowManagement -> preferencesManagement "persists window state"
+                windowManagement -> applicationPages "manages page containers"
+                windowManagement -> toolManager "manages tool windows"
+
+                toolManager -> pluginSystem "coordinates available plugin tools"
+                toolManager -> uiFramework "uses UI components"
+
+                statusBar -> deviceManagement "subscribes to device status"
+                statusBar -> pluginSystem "receives plugin notifications"
+                statusBar -> uiFramework "uses status widgets"
+
+                applicationPages -> uiFramework "uses page components"
+                applicationPages -> preferencesManagement "reads page preferences"
+                
+                uiFramework -> packageManager "manages styles elements from packages"
+
+                // Library Dependencies
+                iioWidgets -> iioUtilities "uses IIO communication"
+                iioWidgets -> uiFramework "extends UI framework"
+
+            }
+
+            // GENERIC PLUGINS PACKAGE
+            genericPluginsPackage = container "Generic Plugins Package" {
+                description "Standard IIO device plugins for common functionality"
+                technology "C++, Qt"
+
+                adcPlugin = component "ADC Plugin" {
+                    description "The ADC plugin is used to interface with IIO ADCs that implement an IIO buffer mechanism"
+                    tags "Plugin"
+                }
+                dacPlugin = component "DAC Plugin" {
+                    description "The DAC plugin is used to interface with IIO DACs that implement the IIO buffer mechanism or a DDS mechanism"
+                    tags "Plugin"
+                }
+                dataloggerPlugin = component "DataLogger Plugin" {
+                    description "Used to monitor and log data"
+                    tags "Plugin"
+                }
+                debuggerPlugin = component "Debugger Plugin" {
+                    description "The debugger plugin is used to examine IIO contexts and modify individual IIO attributes, as well as examining the structure of an IIO context"
+                    tags "Plugin"
+                } 
+                jesdPlugin = component "JESD Status Plugin" {
+                    description "The JESD Status utility plugin provides a graphical interface to monitor the status of JESD204 in Scopy"
+                    tags "Plugin"
+                }
+                regmapPlugin = component "Register Map Plugin" {
+                    description "The Register Map allow access to reading and writing registers for devices connected to Scopy"
+                    tags "Plugin"
+                }
+                
+                adcPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                adcPlugin -> iioWidgets "use"
+                adcPlugin -> gnuRadioWidgets "use"
+                
+                dacPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                dacPlugin -> iioWidgets "use"
+                
+                dataloggerPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                dataloggerPlugin -> iioWidgets "use"
+                
+                debuggerPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                debuggerPlugin -> iioWidgets "use"
+
+                jesdPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                regmapPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+            }
+
+            // M2K PACKAGE
+            m2kPackage = container "M2K Package" {
+                description "ADALM2000 device support package"
+                technology "C++, Qt"
+
+                m2kPlugin = component "M2K Plugin" {
+                    description "Plugin for ADALM2000 (M2K)"
+                    tags "Plugin"
+                }
+
+                // Relations
+                m2kPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                m2kPlugin -> gnuRadioWidgets "use"
+            }
+
+            // SWIOT PACKAGE
+            swiotPackage = container "SWIOT Package" {
+                description "AD-SWIOT1L-SL platform support package"
+                technology "C++, Qt"
+
+                swiotPlugin = component "SWIOT1L Plugin" {
+                    description "The Scopy AD-SWIOT1L-SL plugin is responsible with the operation and control of the AD-SWIOT1L-SL platform"
+                    tags "Plugin"
+                }
+
+                // Relations
+                swiotPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                swiotPlugin -> iioWidgets "use"
+            }
+
+            // AD936X PACKAGE
+            ad936xPackage = container "AD936X Package" {
+                description "AD936X transceiver support package"
+                technology "C++, Qt"
+
+                ad936xPlugin = component "AD936X Plugin" {
+                    description "The AD936x plugins for Scopy enable integration and control of AD936x-based devices within the Scopy software environment"
+                    tags "Plugin"
+                }
+            
+                // Relations
+                ad936xPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                ad936xPlugin -> iioWidgets "use"  
+
+            }
+
+            // APOLLO AD9084 PACKAGE
+            apolloAd9084Package = container "Apollo AD9084 Package" {
+                description "Apollo MXFE QUAD AD9084 support package"
+                technology "C++, Qt"
+
+                ad9084Plugin = component "AD9084 Plugin" {
+                    description "Apollo MXFE QUAD AD9084 interaction"
+                    tags "Plugin"
+                }
+
+                // Relations
+                ad9084Plugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                ad9084Plugin -> iioWidgets "use"
+            }
+
+            // POWER QUALITY MONITOR PACKAGE
+            pqmonPackage = container "PQMon Package" {
+                description "Power Quality Monitor support package"
+                technology "C++, Qt"
+
+                pqmPlugin = component "PQMON Plugin" {
+                    description "Power Quality Monitor plugin"
+                    tags "Plugin"
+                }
+                pqmPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+            }
+
+            // IMU PACKAGE
+            imuPackage = container "IMU Package" {
+                description "IMU Evaluation Software Package"
+                technology "C++, Qt"
+
+                imuAnalyzerPlugin = component "IMU Analyzer Plugin" {
+                    description "IMU evaluation and analysis functionality"
+                    tags "Plugin"
+                }
+
+                // Relations
+                imuAnalyzerPlugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                imuAnalyzerPlugin -> iioWidgets "use"
+            }
+
+            // ADRV9002 PACKAGE
+            adrv9002Package = container "ADRV9002 Package" {
+                description "ADRV9002 Jupiter transceiver support package"
+                technology "C++, Qt"
+
+                adrv9002Plugin = component "ADRV9002 Plugin" {
+                    description "The ADRV9002 (Jupiter) plugin provides a comprehensive interface for controlling and configuring the ADRV9002 dual-channel RF transceiver"
+                    tags "Plugin"
+                }
+
+                //Relations
+                adrv9002Plugin -> pluginInterface "implements" {
+                    tags "PluginImplementation"
+                }
+                adrv9002Plugin -> iioWidgets "use"
+
+            }
+
+
+            // User Relationships
+            engineerUser -> scopyApplication "uses GUI for device control and analysis"
+            student -> scopyApplication "uses for learning and experiments"
+
+            // External Container Relationships
+            scopyApplication -> iioFramework "sends commands and receives data via"
+            scopyApplication -> gnuRadioEcosystem "uses for signal processing and DSP operations"
+            scopyApplication -> fileSystem "read/write data files and configurations"
+            scopyApplication -> operatingSystem "runs on cross-platform OS"
+            scopyApplication -> iioEmu "launches and communicates with via TCP/IP"
+            scopyApplication -> genericPluginsPackage "loads resources from"
+            scopyApplication -> m2kPackage "loads resources from"
+            scopyApplication -> swiotPackage "loads resources from"
+            scopyApplication -> ad936xPackage "loads resources from"
+            scopyApplication -> apolloAd9084Package "loads resources from"
+            scopyApplication -> pqmonPackage "loads resources from"
+            scopyApplication -> imuPackage "loads resources from"
+            scopyApplication -> adrv9002Package "loads resources from"
+        }        
+        
+        iioFramework -> adiHardware "abstracts hardware communication to"
+        
+    }
+    
+    views {
+
+        // SYSTEM CONTEXT VIEW
+        systemContext scopySystem "SystemContext" {
+            include *
+            include adiHardware
+            title "Scopy"
+            description "High-level view showing Scopy's interactions with users and external systems"
+        }
+
+        // CONTAINER VIEW
+        container scopySystem "ContainerView" {
+            include *
+            exclude "relationship.tag==PluginImplementation"
+            exclude "element.tag==System Dependency"
+            title "Scopy Architecture"
+            description "Container relationships showing how core application loads plugins from packages"
+        }
+        
+        // Infrastructure View
+        component scopyApplication "InfrastructureComponents" {
+            include applicationCoordinator
+            include crashReporting
+            include translationService
+            include scriptingEngine
+            include preferencesManagement
+            include loggingSystem
+            title "Infrastructure Components"
+            description "Core application infrastructure"
+        }
+
+        // Core Business View
+        component scopyApplication "CoreBusinessComponents" {
+            include deviceManagement
+            include pluginSystem
+            include packageManager
+            title "Core Business Components"
+            description "Main business logic components"
+        }
+
+        // UI Layer View
+        component scopyApplication "UIComponents" {
+            include uiFramework
+            include windowManagement
+            include toolManager
+            include statusBar
+            include applicationPages
+            title "UI Components"
+            description "User interface layer components"
+        }
+
+        // Library View
+        component scopyApplication "LibraryComponents" {
+            include iioUtilities
+            include iioWidgets
+            include gnuRadioWidgets
+            title "Supporting Libraries"
+            description "Reusable library components"
+        }
+
+        // Overall View
+        component scopyApplication "CoreComponents" {
+            include applicationCoordinator
+            include deviceManagement
+            include pluginSystem
+            include uiFramework
+            include windowManagement
+            include iioUtilities
+            include packageManager
+            include toolManager
+            include gnuRadioWidgets
+            include iioWidgets
+            title "Components Overview"
+            description "Key components and their relationships"
+        }
+
+        // Plugin View
+        component scopyApplication "PluginComponents" {
+            include pluginRepository
+            include pluginManager
+            include pluginInterface
+
+            title "Plugin Components"
+            description "Plugin system components"
+        }
+
+        // Generic-plugins Package
+        component genericPluginsPackage "Generic-pluginsComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            include gnuRadioWidgets
+            title "Generic-plugins Package"
+            description "The plugins from generic-plugins package"
+        }
+
+        // M2K Package
+        component m2kPackage "M2KComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include gnuRadioWidgets
+            title "M2K Package"
+            description "The plugins from M2K package"
+        }
+
+        // SWIOT Package
+        component swiotPackage "SWIOTComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            title "SWIOT Package"
+            description "The plugins from SWIOT package"
+        }
+
+        // AD936X Package
+        component ad936xPackage "AD936XComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            title "AD936X Package"
+            description "The plugins from AD936X package"
+        }
+
+        // Apollo AD9084 Package
+        component apolloAd9084Package "Apollo-AD9084Components" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            title "Apollo AD9084 Package"
+            description "The plugins from Apollo AD9084 package"
+        }
+
+        // PQMon Package
+        component pqmonPackage "PQMonComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            title "PQMon Package"
+            description "The plugins from PQMon package"
+        }
+
+        // IMU Package
+        component imuPackage "IMUComponents" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            title "IMU Package"
+            description "The plugins from IMU package"
+        }
+
+        // ADRV9002 Package
+        component adrv9002Package "ADRV9002Components" {
+            include *
+            exclude scopyApplication
+            include pluginInterface
+            include iioWidgets
+            title "ADRV9002 Package"
+            description "The plugins from ADRV9002 package"
+        }
+
+
+        styles {            
+            element "Scopy System" {
+                background "#0077b6"
+                color "White"
+            }
+            
+            element "Container" {
+                background "#0077b6"
+                color "White"
+            }
+            
+            element "Person" {
+                shape "Person"
+                background "#023047"
+                color "White"
+            }
+            
+            element "Infrastructure" {
+                background #ff6b6b
+                color "Black"
+            }
+
+            element "CoreBusiness" {
+                background #4ecdc4
+                color "Black"
+            }
+
+            element "Presentation" {
+                background #f9ca24
+                color "Black"
+            }
+
+            element "Library" {
+                background #6c5ce7
+                color "Black"
+            }
+            
+            element "PluginSystem" {
+                background "#00897b"
+                color "Black"
+            }
+
+            element "Plugin" {
+                background "#ffb86b"
+                color "Black"
+            }
+            
+            element "System Dependency" {
+                background "#e0e0e0"
+                color "#666666"
+                opacity 50
+            }
+        }
+    }
+
+}

--- a/docs/architecture/diagrams/app_diagrams/workspace.json
+++ b/docs/architecture/diagrams/app_diagrams/workspace.json
@@ -1,0 +1,2104 @@
+{
+  "configuration" : { },
+  "description" : "Description",
+  "documentation" : { },
+  "id" : 1,
+  "lastModifiedAgent" : "structurizr-ui",
+  "lastModifiedDate" : "2025-12-09T06:54:57Z",
+  "model" : {
+    "people" : [ {
+      "id" : "1",
+      "name" : "Engineer",
+      "properties" : {
+        "structurizr.dsl.identifier" : "engineerUser"
+      },
+      "relationships" : [ {
+        "description" : "uses GUI for device control and analysis",
+        "destinationId" : "10",
+        "id" : "152",
+        "sourceId" : "1",
+        "tags" : "Relationship"
+      }, {
+        "description" : "uses GUI for device control and analysis",
+        "destinationId" : "9",
+        "id" : "153",
+        "linkedRelationshipId" : "152",
+        "sourceId" : "1"
+      } ],
+      "tags" : "Element,Person"
+    }, {
+      "id" : "2",
+      "name" : "Student",
+      "properties" : {
+        "structurizr.dsl.identifier" : "student"
+      },
+      "relationships" : [ {
+        "description" : "uses for learning and experiments",
+        "destinationId" : "10",
+        "id" : "154",
+        "sourceId" : "2",
+        "tags" : "Relationship"
+      }, {
+        "description" : "uses for learning and experiments",
+        "destinationId" : "9",
+        "id" : "155",
+        "linkedRelationshipId" : "154",
+        "sourceId" : "2"
+      } ],
+      "tags" : "Element,Person"
+    } ],
+    "softwareSystems" : [ {
+      "description" : "Signal processing backend for advanced operations",
+      "documentation" : { },
+      "id" : "3",
+      "name" : "GNU Radio Ecosystem",
+      "properties" : {
+        "structurizr.dsl.identifier" : "gnuRadioEcosystem"
+      },
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "description" : "Local and network storage for data, configurations, and logs",
+      "documentation" : { },
+      "id" : "4",
+      "name" : "File System",
+      "properties" : {
+        "structurizr.dsl.identifier" : "fileSystem"
+      },
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "description" : "Linux, Windows, macOS providing hardware access and system services",
+      "documentation" : { },
+      "id" : "5",
+      "name" : "Operating System",
+      "properties" : {
+        "structurizr.dsl.identifier" : "operatingSystem"
+      },
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "description" : "Linux Industrial I/O subsystem for hardware abstraction",
+      "documentation" : { },
+      "id" : "6",
+      "name" : "IIO Framework",
+      "properties" : {
+        "structurizr.dsl.identifier" : "iioFramework"
+      },
+      "relationships" : [ {
+        "description" : "abstracts hardware communication to",
+        "destinationId" : "7",
+        "id" : "174",
+        "sourceId" : "6",
+        "tags" : "Relationship"
+      } ],
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "description" : "Analog Devices evaluation boards and other devices",
+      "documentation" : { },
+      "id" : "7",
+      "name" : "Hardware Devices",
+      "properties" : {
+        "structurizr.dsl.identifier" : "adiHardware"
+      },
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "description" : "Hardware device emulation system providing virtualized IIO devices for development and testing",
+      "documentation" : { },
+      "id" : "8",
+      "name" : "IIO Emulator (iio-emu)",
+      "properties" : {
+        "structurizr.dsl.identifier" : "iioEmu"
+      },
+      "tags" : "Element,Software System,System Dependency"
+    }, {
+      "containers" : [ {
+        "components" : [ {
+          "description" : "Application startup/shutdown coordination, initialization sequences, and graceful termination handling",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "11",
+          "name" : "Application Coordinator",
+          "properties" : {
+            "structurizr.dsl.identifier" : "applicationCoordinator",
+            "Splash screen management" : "ScopySplashscreen startup feedback and progress messaging (gui/include/gui/widgets/scopysplashscreen.h)",
+            "Command line processing" : "CmdLineHandler for argument parsing, script execution, device auto-connection (core/include/core/cmdlinehandler.h)",
+            "Application initialization" : "QApplication setup, Qt attributes, logging, crash handling coordination (main.cpp)",
+            "Application restart coordination" : "ApplicationRestarter singleton for graceful restart handling (core/include/core/application_restarter.h)"
+          },
+          "relationships" : [ {
+            "description" : "loads application settings",
+            "destinationId" : "16",
+            "id" : "34",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes logging",
+            "destinationId" : "17",
+            "id" : "35",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "sets up crash handlers",
+            "destinationId" : "12",
+            "id" : "36",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes localization",
+            "destinationId" : "15",
+            "id" : "37",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes device system",
+            "destinationId" : "18",
+            "id" : "38",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes plugin system",
+            "destinationId" : "20",
+            "id" : "39",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes package management",
+            "destinationId" : "19",
+            "id" : "40",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          }, {
+            "description" : "initializes main window",
+            "destinationId" : "27",
+            "id" : "41",
+            "sourceId" : "11",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "Crash detection, error report generation, and stack trace collection",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "12",
+          "name" : "Crash Reporting System",
+          "properties" : {
+            "structurizr.dsl.identifier" : "crashReporting"
+          },
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "CLI argument parsing and command execution",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "13",
+          "name" : "Command Line Handler",
+          "properties" : {
+            "structurizr.dsl.identifier" : "commandLineHandler"
+          },
+          "relationships" : [ {
+            "description" : "overrides default settings",
+            "destinationId" : "16",
+            "id" : "42",
+            "sourceId" : "13",
+            "tags" : "Relationship"
+          }, {
+            "description" : "configures log verbosity",
+            "destinationId" : "17",
+            "id" : "43",
+            "sourceId" : "13",
+            "tags" : "Relationship"
+          }, {
+            "description" : "triggers startup sequence",
+            "destinationId" : "11",
+            "id" : "44",
+            "sourceId" : "13",
+            "tags" : "Relationship"
+          }, {
+            "description" : "executes script files",
+            "destinationId" : "14",
+            "id" : "45",
+            "sourceId" : "13",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "JavaScript runtime, script execution, automation interface, and programmatic API access",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "14",
+          "name" : "Scripting Engine",
+          "properties" : {
+            "structurizr.dsl.identifier" : "scriptingEngine"
+          },
+          "relationships" : [ {
+            "description" : "accesses application services",
+            "destinationId" : "11",
+            "id" : "46",
+            "sourceId" : "14",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "Internationalization support and language pack management",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "15",
+          "name" : "Translation Service",
+          "properties" : {
+            "structurizr.dsl.identifier" : "translationService"
+          },
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "Centralized configuration storage, user preferences, plugin settings, and persistent application state",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "16",
+          "name" : "Preferences Management",
+          "properties" : {
+            "structurizr.dsl.identifier" : "preferencesManagement"
+          },
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "Centralized logging, debug output, error tracking, benchmark, and diagnostic information collection",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "17",
+          "name" : "Logging System",
+          "properties" : {
+            "structurizr.dsl.identifier" : "loggingSystem"
+          },
+          "tags" : "Element,Component,Infrastructure"
+        }, {
+          "description" : "Device discovery, connection lifecycle, hardware abstraction, and unified device interface",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "18",
+          "name" : "Device Management",
+          "properties" : {
+            "structurizr.dsl.identifier" : "deviceManagement",
+            "Device management" : "Device creation, connection, disconnection, restart, reload with state tracking (core/include/core/devicemanager.h)",
+            "Device abstraction" : "DeviceImpl and Device classes providing unified hardware interface (core/include/core/device.h; core/include/core/deviceimpl.h)"
+          },
+          "relationships" : [ {
+            "description" : "reads device preferences",
+            "destinationId" : "16",
+            "id" : "47",
+            "sourceId" : "18",
+            "tags" : "Relationship"
+          }, {
+            "description" : "logs device operations",
+            "destinationId" : "17",
+            "id" : "48",
+            "sourceId" : "18",
+            "tags" : "Relationship"
+          }, {
+            "description" : "loads device specific plugins",
+            "destinationId" : "20",
+            "id" : "49",
+            "sourceId" : "18",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,CoreBusiness"
+        }, {
+          "description" : "Manages packages installation and distribution",
+          "documentation" : { },
+          "group" : "pkg-manager",
+          "id" : "19",
+          "name" : "Package Manager",
+          "properties" : {
+            "structurizr.dsl.identifier" : "packageManager"
+          },
+          "tags" : "Element,Component,CoreBusiness"
+        }, {
+          "description" : "Dynamic plugin loading, lifecycle management, dependency resolution, and plugin architecture foundation",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "20",
+          "name" : "Plugin System",
+          "properties" : {
+            "structurizr.dsl.identifier" : "pluginSystem",
+            "Plugin manager" : "PluginManager for dynamic loading, sorting, filtering, and lifecycle control (core/include/core/pluginmanager.h)",
+            "Plugin interface" : "Plugin base interface defining compatible(), onConnect(), onDisconnect() and other contracts (pluginbase/include/pluginbase/plugin.h)",
+            "Plugin repository" : "PluginRepository singleton for plugin management, metadata handling, plugin discovery (core/include/core/pluginrepository.h)"
+          },
+          "relationships" : [ {
+            "description" : "manages plugins from packages",
+            "destinationId" : "19",
+            "id" : "50",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          }, {
+            "description" : "reads plugin configurations",
+            "destinationId" : "16",
+            "id" : "51",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          }, {
+            "description" : "logs plugin operations",
+            "destinationId" : "17",
+            "id" : "52",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          }, {
+            "description" : "uses for device communication",
+            "destinationId" : "31",
+            "id" : "53",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          }, {
+            "description" : "specific plugins use processing services",
+            "destinationId" : "33",
+            "id" : "54",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          }, {
+            "description" : "specific plugins use",
+            "destinationId" : "32",
+            "id" : "55",
+            "sourceId" : "20",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,CoreBusiness"
+        }, {
+          "description" : "Storage and management of available plugins and their metadata",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "21",
+          "name" : "Plugin Repository",
+          "properties" : {
+            "structurizr.dsl.identifier" : "pluginRepository"
+          },
+          "tags" : "Element,Component,PluginSystem"
+        }, {
+          "description" : "Dynamic loading and instantiation of plugin libraries",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "22",
+          "name" : "Plugin Manager",
+          "properties" : {
+            "structurizr.dsl.identifier" : "pluginManager"
+          },
+          "relationships" : [ {
+            "description" : "queries available plugins",
+            "destinationId" : "21",
+            "id" : "24",
+            "sourceId" : "22",
+            "tags" : "Relationship"
+          }, {
+            "description" : "instantiates plugins",
+            "destinationId" : "23",
+            "id" : "25",
+            "sourceId" : "22",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,PluginSystem"
+        }, {
+          "description" : "Common API contract that all plugins must implement",
+          "documentation" : { },
+          "group" : "pluginbase",
+          "id" : "23",
+          "name" : "Plugin Interface",
+          "properties" : {
+            "structurizr.dsl.identifier" : "pluginInterface"
+          },
+          "tags" : "Element,Component,PluginSystem"
+        }, {
+          "description" : "Common UI widgets, plot widgets, style management",
+          "documentation" : { },
+          "group" : "gui",
+          "id" : "26",
+          "name" : "UI Framework",
+          "properties" : {
+            "structurizr.dsl.identifier" : "uiFramework",
+            "Plot widgets" : "Plotting widgets, measurement displays, signal visualization (gui/include/gui)",
+            "Common components" : "Menu section widgets, collapse headers, custom controls for patameters, enhanced input widgets, etc. (gui/include/gui; gui/include/gui/widgets)",
+            "Style management" : "QSS-based styling with dynamic theme switching (gui/style)"
+          },
+          "relationships" : [ {
+            "description" : "manages styles elements from packages",
+            "destinationId" : "19",
+            "id" : "67",
+            "sourceId" : "26",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Presentation"
+        }, {
+          "description" : "Main window coordination, detached tool windows, and workspace management",
+          "documentation" : { },
+          "group" : "gui",
+          "id" : "27",
+          "name" : "Window Management",
+          "properties" : {
+            "structurizr.dsl.identifier" : "windowManagement",
+            "Advanced docking system" : "KDDockWidgets backend for professional docking layouts (gui/include/gui/docking)",
+            "Detached tool management" : "DetachedToolWindowManager for separate tool windows, multi-monitor support (core/include/core/detachedtoolwindowmanager.h)",
+            "Main window coordination" : "ScopyMainWindow lifecycle, application initialization, event handling (core/include/core/scopymainwindow.h)"
+          },
+          "relationships" : [ {
+            "description" : "uses common UI components",
+            "destinationId" : "26",
+            "id" : "56",
+            "sourceId" : "27",
+            "tags" : "Relationship"
+          }, {
+            "description" : "persists window state",
+            "destinationId" : "16",
+            "id" : "57",
+            "sourceId" : "27",
+            "tags" : "Relationship"
+          }, {
+            "description" : "manages page containers",
+            "destinationId" : "30",
+            "id" : "58",
+            "sourceId" : "27",
+            "tags" : "Relationship"
+          }, {
+            "description" : "manages tool windows",
+            "destinationId" : "28",
+            "id" : "59",
+            "sourceId" : "27",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Presentation"
+        }, {
+          "description" : "Tool registration, menu organization, tool lifecycle coordination, and unified tool interface",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "28",
+          "name" : "Tool Manager",
+          "properties" : {
+            "structurizr.dsl.identifier" : "toolManager"
+          },
+          "relationships" : [ {
+            "description" : "coordinates available plugin tools",
+            "destinationId" : "20",
+            "id" : "60",
+            "sourceId" : "28",
+            "tags" : "Relationship"
+          }, {
+            "description" : "uses UI components",
+            "destinationId" : "26",
+            "id" : "61",
+            "sourceId" : "28",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Presentation"
+        }, {
+          "description" : "Real-time status display, device connectivity indicators, operation progress, and system notifications",
+          "documentation" : { },
+          "group" : "gui",
+          "id" : "29",
+          "name" : "Status Bar",
+          "properties" : {
+            "structurizr.dsl.identifier" : "statusBar"
+          },
+          "relationships" : [ {
+            "description" : "subscribes to device status",
+            "destinationId" : "18",
+            "id" : "62",
+            "sourceId" : "29",
+            "tags" : "Relationship"
+          }, {
+            "description" : "receives plugin notifications",
+            "destinationId" : "20",
+            "id" : "63",
+            "sourceId" : "29",
+            "tags" : "Relationship"
+          }, {
+            "description" : "uses status widgets",
+            "destinationId" : "26",
+            "id" : "64",
+            "sourceId" : "29",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Presentation"
+        }, {
+          "description" : "Page navigation, home page, device browser, preferences pages, packages page, and application flow control",
+          "documentation" : { },
+          "group" : "core",
+          "id" : "30",
+          "name" : "Application Pages",
+          "properties" : {
+            "structurizr.dsl.identifier" : "applicationPages",
+            "Navigation coordination" : "Tool selection flow, page switching, menu state management (core/include/core)",
+            "Tool stack management" : "ToolStack container extending MapStackedWidget for key-based page switching (core/include/core/toolstack.h)",
+            "Home page system" : "ScopyHomePage for device scanning, connection management, device browser (core/include/core)",
+            "Preferences integration" : "ScopyPreferencesPage, settings management, configuration dialogs (core/include/core/scopypreferencespage.h)",
+            "About and info pages" : "ScopyAboutPage, version information, system details (core/include/core/scopyaboutpage.h)"
+          },
+          "relationships" : [ {
+            "description" : "uses page components",
+            "destinationId" : "26",
+            "id" : "65",
+            "sourceId" : "30",
+            "tags" : "Relationship"
+          }, {
+            "description" : "reads page preferences",
+            "destinationId" : "16",
+            "id" : "66",
+            "sourceId" : "30",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Presentation"
+        }, {
+          "description" : "Industrial I/O communication, command queuing, and connection management",
+          "documentation" : { },
+          "group" : "iio-util",
+          "id" : "31",
+          "name" : "IIO Utilities",
+          "properties" : {
+            "structurizr.dsl.identifier" : "iioUtilities"
+          },
+          "tags" : "Element,Component,Library"
+        }, {
+          "description" : "Specialized UI components for IIO devices, parameter controls, and device-specific interfaces",
+          "documentation" : { },
+          "group" : "iio-widgets",
+          "id" : "32",
+          "name" : "IIO Widgets",
+          "properties" : {
+            "structurizr.dsl.identifier" : "iioWidgets"
+          },
+          "relationships" : [ {
+            "description" : "uses IIO communication",
+            "destinationId" : "31",
+            "id" : "68",
+            "sourceId" : "32",
+            "tags" : "Relationship"
+          }, {
+            "description" : "extends UI framework",
+            "destinationId" : "26",
+            "id" : "69",
+            "sourceId" : "32",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Library"
+        }, {
+          "description" : "GNU Radio specific components and signal processing controls",
+          "documentation" : { },
+          "group" : "gr-util",
+          "id" : "33",
+          "name" : "GNU Radio Utilities",
+          "properties" : {
+            "structurizr.dsl.identifier" : "gnuRadioWidgets"
+          },
+          "tags" : "Element,Component,Library"
+        } ],
+        "description" : "Monolithic Qt-based desktop application",
+        "documentation" : { },
+        "id" : "10",
+        "name" : "Scopy Application",
+        "properties" : {
+          "structurizr.dsl.identifier" : "scopyApplication"
+        },
+        "relationships" : [ {
+          "description" : "sends commands and receives data via",
+          "destinationId" : "6",
+          "id" : "156",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "uses for signal processing and DSP operations",
+          "destinationId" : "3",
+          "id" : "158",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "read/write data files and configurations",
+          "destinationId" : "4",
+          "id" : "160",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "runs on cross-platform OS",
+          "destinationId" : "5",
+          "id" : "162",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "launches and communicates with via TCP/IP",
+          "destinationId" : "8",
+          "id" : "164",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "70",
+          "id" : "166",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "98",
+          "id" : "167",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "106",
+          "id" : "168",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "114",
+          "id" : "169",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "122",
+          "id" : "170",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "130",
+          "id" : "171",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "136",
+          "id" : "172",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        }, {
+          "description" : "loads resources from",
+          "destinationId" : "144",
+          "id" : "173",
+          "sourceId" : "10",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container,MainContainer",
+        "technology" : "C++, Qt, Qwt"
+      }, {
+        "components" : [ {
+          "description" : "The ADC plugin is used to interface with IIO ADCs that implement an IIO buffer mechanism",
+          "documentation" : { },
+          "id" : "71",
+          "name" : "ADC Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "adcPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "77",
+            "sourceId" : "71",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "78",
+            "linkedRelationshipId" : "77",
+            "sourceId" : "71"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "81",
+            "sourceId" : "71",
+            "tags" : "Relationship"
+          }, {
+            "description" : "use",
+            "destinationId" : "33",
+            "id" : "83",
+            "sourceId" : "71",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        }, {
+          "description" : "The DAC plugin is used to interface with IIO DACs that implement the IIO buffer mechanism or a DDS mechanism",
+          "documentation" : { },
+          "id" : "72",
+          "name" : "DAC Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "dacPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "85",
+            "sourceId" : "72",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "86",
+            "linkedRelationshipId" : "85",
+            "sourceId" : "72"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "87",
+            "sourceId" : "72",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        }, {
+          "description" : "Used to monitor and log data",
+          "documentation" : { },
+          "id" : "73",
+          "name" : "DataLogger Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "dataloggerPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "88",
+            "sourceId" : "73",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "89",
+            "linkedRelationshipId" : "88",
+            "sourceId" : "73"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "90",
+            "sourceId" : "73",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        }, {
+          "description" : "The debugger plugin is used to examine IIO contexts and modify individual IIO attributes, as well as examining the structure of an IIO context",
+          "documentation" : { },
+          "id" : "74",
+          "name" : "Debugger Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "debuggerPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "91",
+            "sourceId" : "74",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "92",
+            "linkedRelationshipId" : "91",
+            "sourceId" : "74"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "93",
+            "sourceId" : "74",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        }, {
+          "description" : "The JESD Status utility plugin provides a graphical interface to monitor the status of JESD204 in Scopy",
+          "documentation" : { },
+          "id" : "75",
+          "name" : "JESD Status Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "jesdPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "94",
+            "sourceId" : "75",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "95",
+            "linkedRelationshipId" : "94",
+            "sourceId" : "75"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        }, {
+          "description" : "The Register Map allow access to reading and writing registers for devices connected to Scopy",
+          "documentation" : { },
+          "id" : "76",
+          "name" : "Register Map Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "regmapPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "96",
+            "sourceId" : "76",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "97",
+            "linkedRelationshipId" : "96",
+            "sourceId" : "76"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "Standard IIO device plugins for common functionality",
+        "documentation" : { },
+        "id" : "70",
+        "name" : "Generic Plugins Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "genericPluginsPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "79",
+          "linkedRelationshipId" : "77",
+          "sourceId" : "70"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "80",
+          "linkedRelationshipId" : "77",
+          "sourceId" : "70"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "82",
+          "linkedRelationshipId" : "81",
+          "sourceId" : "70"
+        }, {
+          "description" : "use",
+          "destinationId" : "33",
+          "id" : "84",
+          "linkedRelationshipId" : "83",
+          "sourceId" : "70"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "Plugin for ADALM2000 (M2K)",
+          "documentation" : { },
+          "id" : "99",
+          "name" : "M2K Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "m2kPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "100",
+            "sourceId" : "99",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "101",
+            "linkedRelationshipId" : "100",
+            "sourceId" : "99"
+          }, {
+            "description" : "use",
+            "destinationId" : "33",
+            "id" : "104",
+            "sourceId" : "99",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "ADALM2000 device support package",
+        "documentation" : { },
+        "id" : "98",
+        "name" : "M2K Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "m2kPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "102",
+          "linkedRelationshipId" : "100",
+          "sourceId" : "98"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "103",
+          "linkedRelationshipId" : "100",
+          "sourceId" : "98"
+        }, {
+          "description" : "use",
+          "destinationId" : "33",
+          "id" : "105",
+          "linkedRelationshipId" : "104",
+          "sourceId" : "98"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "The Scopy AD-SWIOT1L-SL plugin is responsible with the operation and control of the AD-SWIOT1L-SL platform",
+          "documentation" : { },
+          "id" : "107",
+          "name" : "SWIOT1L Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "swiotPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "108",
+            "sourceId" : "107",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "109",
+            "linkedRelationshipId" : "108",
+            "sourceId" : "107"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "112",
+            "sourceId" : "107",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "AD-SWIOT1L-SL platform support package",
+        "documentation" : { },
+        "id" : "106",
+        "name" : "SWIOT Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "swiotPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "110",
+          "linkedRelationshipId" : "108",
+          "sourceId" : "106"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "111",
+          "linkedRelationshipId" : "108",
+          "sourceId" : "106"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "113",
+          "linkedRelationshipId" : "112",
+          "sourceId" : "106"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "The AD936x plugins for Scopy enable integration and control of AD936x-based devices within the Scopy software environment",
+          "documentation" : { },
+          "id" : "115",
+          "name" : "AD936X Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "ad936xPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "116",
+            "sourceId" : "115",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "117",
+            "linkedRelationshipId" : "116",
+            "sourceId" : "115"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "120",
+            "sourceId" : "115",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "AD936X transceiver support package",
+        "documentation" : { },
+        "id" : "114",
+        "name" : "AD936X Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "ad936xPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "118",
+          "linkedRelationshipId" : "116",
+          "sourceId" : "114"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "119",
+          "linkedRelationshipId" : "116",
+          "sourceId" : "114"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "121",
+          "linkedRelationshipId" : "120",
+          "sourceId" : "114"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "Apollo MXFE QUAD AD9084 interaction",
+          "documentation" : { },
+          "id" : "123",
+          "name" : "AD9084 Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "ad9084Plugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "124",
+            "sourceId" : "123",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "125",
+            "linkedRelationshipId" : "124",
+            "sourceId" : "123"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "128",
+            "sourceId" : "123",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "Apollo MXFE QUAD AD9084 support package",
+        "documentation" : { },
+        "id" : "122",
+        "name" : "Apollo AD9084 Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "apolloAd9084Package"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "126",
+          "linkedRelationshipId" : "124",
+          "sourceId" : "122"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "127",
+          "linkedRelationshipId" : "124",
+          "sourceId" : "122"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "129",
+          "linkedRelationshipId" : "128",
+          "sourceId" : "122"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "Power Quality Monitor plugin",
+          "documentation" : { },
+          "id" : "131",
+          "name" : "PQMON Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "pqmPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "132",
+            "sourceId" : "131",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "133",
+            "linkedRelationshipId" : "132",
+            "sourceId" : "131"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "Power Quality Monitor support package",
+        "documentation" : { },
+        "id" : "130",
+        "name" : "PQMon Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "pqmonPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "134",
+          "linkedRelationshipId" : "132",
+          "sourceId" : "130"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "135",
+          "linkedRelationshipId" : "132",
+          "sourceId" : "130"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "IMU evaluation and analysis functionality",
+          "documentation" : { },
+          "id" : "137",
+          "name" : "IMU Analyzer Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "imuAnalyzerPlugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "138",
+            "sourceId" : "137",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "139",
+            "linkedRelationshipId" : "138",
+            "sourceId" : "137"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "142",
+            "sourceId" : "137",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "IMU Evaluation Software Package",
+        "documentation" : { },
+        "id" : "136",
+        "name" : "IMU Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "imuPackage"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "140",
+          "linkedRelationshipId" : "138",
+          "sourceId" : "136"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "141",
+          "linkedRelationshipId" : "138",
+          "sourceId" : "136"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "143",
+          "linkedRelationshipId" : "142",
+          "sourceId" : "136"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      }, {
+        "components" : [ {
+          "description" : "The ADRV9002 (Jupiter) plugin provides a comprehensive interface for controlling and configuring the ADRV9002 dual-channel RF transceiver",
+          "documentation" : { },
+          "id" : "145",
+          "name" : "ADRV9002 Plugin",
+          "properties" : {
+            "structurizr.dsl.identifier" : "adrv9002Plugin"
+          },
+          "relationships" : [ {
+            "description" : "implements",
+            "destinationId" : "23",
+            "id" : "146",
+            "sourceId" : "145",
+            "tags" : "Relationship,PluginImplementation"
+          }, {
+            "description" : "implements",
+            "destinationId" : "10",
+            "id" : "147",
+            "linkedRelationshipId" : "146",
+            "sourceId" : "145"
+          }, {
+            "description" : "use",
+            "destinationId" : "32",
+            "id" : "150",
+            "sourceId" : "145",
+            "tags" : "Relationship"
+          } ],
+          "tags" : "Element,Component,Plugin"
+        } ],
+        "description" : "ADRV9002 Jupiter transceiver support package",
+        "documentation" : { },
+        "id" : "144",
+        "name" : "ADRV9002 Package",
+        "properties" : {
+          "structurizr.dsl.identifier" : "adrv9002Package"
+        },
+        "relationships" : [ {
+          "description" : "implements",
+          "destinationId" : "23",
+          "id" : "148",
+          "linkedRelationshipId" : "146",
+          "sourceId" : "144"
+        }, {
+          "description" : "implements",
+          "destinationId" : "10",
+          "id" : "149",
+          "linkedRelationshipId" : "146",
+          "sourceId" : "144"
+        }, {
+          "description" : "use",
+          "destinationId" : "32",
+          "id" : "151",
+          "linkedRelationshipId" : "150",
+          "sourceId" : "144"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++, Qt"
+      } ],
+      "description" : "Multi-functional software toolset with strong capabilities for signal analysis",
+      "documentation" : { },
+      "id" : "9",
+      "name" : "Scopy",
+      "properties" : {
+        "structurizr.dsl.identifier" : "scopySystem"
+      },
+      "relationships" : [ {
+        "description" : "sends commands and receives data via",
+        "destinationId" : "6",
+        "id" : "157",
+        "linkedRelationshipId" : "156",
+        "sourceId" : "9"
+      }, {
+        "description" : "uses for signal processing and DSP operations",
+        "destinationId" : "3",
+        "id" : "159",
+        "linkedRelationshipId" : "158",
+        "sourceId" : "9"
+      }, {
+        "description" : "read/write data files and configurations",
+        "destinationId" : "4",
+        "id" : "161",
+        "linkedRelationshipId" : "160",
+        "sourceId" : "9"
+      }, {
+        "description" : "runs on cross-platform OS",
+        "destinationId" : "5",
+        "id" : "163",
+        "linkedRelationshipId" : "162",
+        "sourceId" : "9"
+      }, {
+        "description" : "launches and communicates with via TCP/IP",
+        "destinationId" : "8",
+        "id" : "165",
+        "linkedRelationshipId" : "164",
+        "sourceId" : "9"
+      } ],
+      "tags" : "Element,Software System,Scopy System"
+    } ]
+  },
+  "name" : "Scopy ADI",
+  "properties" : {
+    "structurizr.inspection.info" : "0",
+    "structurizr.inspection.ignore" : "0",
+    "structurizr.inspection.error" : "128",
+    "structurizr.inspection.warning" : "0",
+    "structurizr.dsl" : "d29ya3NwYWNlICJTY29weSBBREkiIHsKCiAgICBtb2RlbCB7CgogICAgICAgIC8vIFVzZXJzCiAgICAgICAgZW5naW5lZXJVc2VyID0gcGVyc29uICJFbmdpbmVlciIKICAgICAgICBzdHVkZW50ID0gcGVyc29uICJTdHVkZW50IgoKICAgICAgICAvLyBFeHRlcm5hbCBTeXN0ZW1zCiAgICAgICAgZ251UmFkaW9FY29zeXN0ZW0gPSBzb2Z0d2FyZVN5c3RlbSAiR05VIFJhZGlvIEVjb3N5c3RlbSIgewogICAgICAgICAgICBkZXNjcmlwdGlvbiAiU2lnbmFsIHByb2Nlc3NpbmcgYmFja2VuZCBmb3IgYWR2YW5jZWQgb3BlcmF0aW9ucyIKICAgICAgICAgICAgdGFncyAiU3lzdGVtIERlcGVuZGVuY3kiCiAgICAgICAgfQogICAgICAgIAogICAgICAgIGZpbGVTeXN0ZW0gPSBzb2Z0d2FyZVN5c3RlbSAiRmlsZSBTeXN0ZW0iIHsKICAgICAgICAgICAgZGVzY3JpcHRpb24gIkxvY2FsIGFuZCBuZXR3b3JrIHN0b3JhZ2UgZm9yIGRhdGEsIGNvbmZpZ3VyYXRpb25zLCBhbmQgbG9ncyIKICAgICAgICAgICAgdGFncyAiU3lzdGVtIERlcGVuZGVuY3kiCiAgICAgICAgfQogICAgICAgIAogICAgICAgIG9wZXJhdGluZ1N5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJPcGVyYXRpbmcgU3lzdGVtIiB7CiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJMaW51eCwgV2luZG93cywgbWFjT1MgcHJvdmlkaW5nIGhhcmR3YXJlIGFjY2VzcyBhbmQgc3lzdGVtIHNlcnZpY2VzIgogICAgICAgICAgICB0YWdzICJTeXN0ZW0gRGVwZW5kZW5jeSIKICAgICAgICB9CiAgICAgICAgCiAgICAgICAgaWlvRnJhbWV3b3JrID0gc29mdHdhcmVTeXN0ZW0gIklJTyBGcmFtZXdvcmsiIHsKICAgICAgICAgICAgZGVzY3JpcHRpb24gIkxpbnV4IEluZHVzdHJpYWwgSS9PIHN1YnN5c3RlbSBmb3IgaGFyZHdhcmUgYWJzdHJhY3Rpb24iCiAgICAgICAgICAgIHRhZ3MgIlN5c3RlbSBEZXBlbmRlbmN5IgogICAgICAgIH0KICAgICAgICAKICAgICAgICBhZGlIYXJkd2FyZSA9IHNvZnR3YXJlU3lzdGVtICJIYXJkd2FyZSBEZXZpY2VzIiB7CiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJBbmFsb2cgRGV2aWNlcyBldmFsdWF0aW9uIGJvYXJkcyBhbmQgb3RoZXIgZGV2aWNlcyIKICAgICAgICAgICAgdGFncyAiU3lzdGVtIERlcGVuZGVuY3kiCiAgICAgICAgfSAKCiAgICAgICAgaWlvRW11ID0gc29mdHdhcmVTeXN0ZW0gIklJTyBFbXVsYXRvciAoaWlvLWVtdSkiIHsKICAgICAgICAgICAgZGVzY3JpcHRpb24gIkhhcmR3YXJlIGRldmljZSBlbXVsYXRpb24gc3lzdGVtIHByb3ZpZGluZyB2aXJ0dWFsaXplZCBJSU8gZGV2aWNlcyBmb3IgZGV2ZWxvcG1lbnQgYW5kIHRlc3RpbmciCiAgICAgICAgICAgIHRhZ3MgIlN5c3RlbSBEZXBlbmRlbmN5IgogICAgICAgIH0KCiAgICAgICAgLy8gTWFpbiBTeXN0ZW0KICAgICAgICAgc2NvcHlTeXN0ZW0gPSBzb2Z0d2FyZVN5c3RlbSAiU2NvcHkiICJNdWx0aS1mdW5jdGlvbmFsIHNvZnR3YXJlIHRvb2xzZXQgd2l0aCBzdHJvbmcgY2FwYWJpbGl0aWVzIGZvciBzaWduYWwgYW5hbHlzaXMiIHsKICAgICAgICAgICAgdGFncyAiU2NvcHkgU3lzdGVtIgogICAgICAgICAgICAvLyBTaW5nbGUgTWFpbiBDb250YWluZXIKICAgICAgICAgICAgc2NvcHlBcHBsaWNhdGlvbiA9IGNvbnRhaW5lciAiU2NvcHkgQXBwbGljYXRpb24iIHsKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJNb25vbGl0aGljIFF0LWJhc2VkIGRlc2t0b3AgYXBwbGljYXRpb24iCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0LCBRd3QiCiAgICAgICAgICAgICAgICB0YWdzICJNYWluQ29udGFpbmVyIgoKICAgICAgICAgICAgICAgIC8vIElORlJBU1RSVUNUVVJFIExBWUVSCiAgICAgICAgICAgICAgICBhcHBsaWNhdGlvbkNvb3JkaW5hdG9yID0gY29tcG9uZW50ICJBcHBsaWNhdGlvbiBDb29yZGluYXRvciIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJBcHBsaWNhdGlvbiBzdGFydHVwL3NodXRkb3duIGNvb3JkaW5hdGlvbiwgaW5pdGlhbGl6YXRpb24gc2VxdWVuY2VzLCBhbmQgZ3JhY2VmdWwgdGVybWluYXRpb24gaGFuZGxpbmciCiAgICAgICAgICAgICAgICAgICAgdGFncyAiSW5mcmFzdHJ1Y3R1cmUiCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImNvcmUiCiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllcyB7CiAgICAgICAgICAgICAgICAgICAgICAgICJBcHBsaWNhdGlvbiBpbml0aWFsaXphdGlvbiIgIlFBcHBsaWNhdGlvbiBzZXR1cCwgUXQgYXR0cmlidXRlcywgbG9nZ2luZywgY3Jhc2ggaGFuZGxpbmcgY29vcmRpbmF0aW9uIChtYWluLmNwcCkiCiAgICAgICAgICAgICAgICAgICAgICAgICJDb21tYW5kIGxpbmUgcHJvY2Vzc2luZyIgIkNtZExpbmVIYW5kbGVyIGZvciBhcmd1bWVudCBwYXJzaW5nLCBzY3JpcHQgZXhlY3V0aW9uLCBkZXZpY2UgYXV0by1jb25uZWN0aW9uIChjb3JlL2luY2x1ZGUvY29yZS9jbWRsaW5laGFuZGxlci5oKSIKICAgICAgICAgICAgICAgICAgICAgICAgIkFwcGxpY2F0aW9uIHJlc3RhcnQgY29vcmRpbmF0aW9uIiAiQXBwbGljYXRpb25SZXN0YXJ0ZXIgc2luZ2xldG9uIGZvciBncmFjZWZ1bCByZXN0YXJ0IGhhbmRsaW5nIChjb3JlL2luY2x1ZGUvY29yZS9hcHBsaWNhdGlvbl9yZXN0YXJ0ZXIuaCkiCiAgICAgICAgICAgICAgICAgICAgICAgICJTcGxhc2ggc2NyZWVuIG1hbmFnZW1lbnQiICJTY29weVNwbGFzaHNjcmVlbiBzdGFydHVwIGZlZWRiYWNrIGFuZCBwcm9ncmVzcyBtZXNzYWdpbmcgKGd1aS9pbmNsdWRlL2d1aS93aWRnZXRzL3Njb3B5c3BsYXNoc2NyZWVuLmgpIgogICAgICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgY3Jhc2hSZXBvcnRpbmcgPSBjb21wb25lbnQgIkNyYXNoIFJlcG9ydGluZyBTeXN0ZW0iIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiQ3Jhc2ggZGV0ZWN0aW9uLCBlcnJvciByZXBvcnQgZ2VuZXJhdGlvbiwgYW5kIHN0YWNrIHRyYWNlIGNvbGxlY3Rpb24iCiAgICAgICAgICAgICAgICAgICAgdGFncyAiSW5mcmFzdHJ1Y3R1cmUiCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImNvcmUiCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgY29tbWFuZExpbmVIYW5kbGVyID0gY29tcG9uZW50ICJDb21tYW5kIExpbmUgSGFuZGxlciIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJDTEkgYXJndW1lbnQgcGFyc2luZyBhbmQgY29tbWFuZCBleGVjdXRpb24iCiAgICAgICAgICAgICAgICAgICAgdGFncyAiSW5mcmFzdHJ1Y3R1cmUiCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImNvcmUiCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgc2NyaXB0aW5nRW5naW5lID0gY29tcG9uZW50ICJTY3JpcHRpbmcgRW5naW5lIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkphdmFTY3JpcHQgcnVudGltZSwgc2NyaXB0IGV4ZWN1dGlvbiwgYXV0b21hdGlvbiBpbnRlcmZhY2UsIGFuZCBwcm9ncmFtbWF0aWMgQVBJIGFjY2VzcyIKICAgICAgICAgICAgICAgICAgICB0YWdzICJJbmZyYXN0cnVjdHVyZSIKICAgICAgICAgICAgICAgICAgICBncm91cCAiY29yZSIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgdHJhbnNsYXRpb25TZXJ2aWNlID0gY29tcG9uZW50ICJUcmFuc2xhdGlvbiBTZXJ2aWNlIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkludGVybmF0aW9uYWxpemF0aW9uIHN1cHBvcnQgYW5kIGxhbmd1YWdlIHBhY2sgbWFuYWdlbWVudCIKICAgICAgICAgICAgICAgICAgICB0YWdzICJJbmZyYXN0cnVjdHVyZSIKICAgICAgICAgICAgICAgICAgICBncm91cCAiY29yZSIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBwcmVmZXJlbmNlc01hbmFnZW1lbnQgPSBjb21wb25lbnQgIlByZWZlcmVuY2VzIE1hbmFnZW1lbnQiIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiQ2VudHJhbGl6ZWQgY29uZmlndXJhdGlvbiBzdG9yYWdlLCB1c2VyIHByZWZlcmVuY2VzLCBwbHVnaW4gc2V0dGluZ3MsIGFuZCBwZXJzaXN0ZW50IGFwcGxpY2F0aW9uIHN0YXRlIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIkluZnJhc3RydWN0dXJlIgogICAgICAgICAgICAgICAgICAgIGdyb3VwICJjb3JlIgogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGxvZ2dpbmdTeXN0ZW0gPSBjb21wb25lbnQgIkxvZ2dpbmcgU3lzdGVtIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkNlbnRyYWxpemVkIGxvZ2dpbmcsIGRlYnVnIG91dHB1dCwgZXJyb3IgdHJhY2tpbmcsIGJlbmNobWFyaywgYW5kIGRpYWdub3N0aWMgaW5mb3JtYXRpb24gY29sbGVjdGlvbiIKICAgICAgICAgICAgICAgICAgICB0YWdzICJJbmZyYXN0cnVjdHVyZSIKICAgICAgICAgICAgICAgICAgICBncm91cCAiY29yZSIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICAvLyBDT1JFIEJVU0lORVNTIExPR0lDCiAgICAgICAgICAgICAgICBkZXZpY2VNYW5hZ2VtZW50ID0gY29tcG9uZW50ICJEZXZpY2UgTWFuYWdlbWVudCIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJEZXZpY2UgZGlzY292ZXJ5LCBjb25uZWN0aW9uIGxpZmVjeWNsZSwgaGFyZHdhcmUgYWJzdHJhY3Rpb24sIGFuZCB1bmlmaWVkIGRldmljZSBpbnRlcmZhY2UiCiAgICAgICAgICAgICAgICAgICAgdGFncyAiQ29yZUJ1c2luZXNzIgogICAgICAgICAgICAgICAgICAgIGdyb3VwICJjb3JlIgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAgICAgICAgICAgICAiRGV2aWNlIG1hbmFnZW1lbnQiICJEZXZpY2UgY3JlYXRpb24sIGNvbm5lY3Rpb24sIGRpc2Nvbm5lY3Rpb24sIHJlc3RhcnQsIHJlbG9hZCB3aXRoIHN0YXRlIHRyYWNraW5nIChjb3JlL2luY2x1ZGUvY29yZS9kZXZpY2VtYW5hZ2VyLmgpIgogICAgICAgICAgICAgICAgICAgICAgICAiRGV2aWNlIGFic3RyYWN0aW9uIiAiRGV2aWNlSW1wbCBhbmQgRGV2aWNlIGNsYXNzZXMgcHJvdmlkaW5nIHVuaWZpZWQgaGFyZHdhcmUgaW50ZXJmYWNlIChjb3JlL2luY2x1ZGUvY29yZS9kZXZpY2UuaDsgY29yZS9pbmNsdWRlL2NvcmUvZGV2aWNlaW1wbC5oKSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgcGFja2FnZU1hbmFnZXIgPSBjb21wb25lbnQgIlBhY2thZ2UgTWFuYWdlciIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJNYW5hZ2VzIHBhY2thZ2VzIGluc3RhbGxhdGlvbiBhbmQgZGlzdHJpYnV0aW9uIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIkNvcmVCdXNpbmVzcyIKICAgICAgICAgICAgICAgICAgICBncm91cCAicGtnLW1hbmFnZXIiCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgcGx1Z2luU3lzdGVtID0gY29tcG9uZW50ICJQbHVnaW4gU3lzdGVtIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkR5bmFtaWMgcGx1Z2luIGxvYWRpbmcsIGxpZmVjeWNsZSBtYW5hZ2VtZW50LCBkZXBlbmRlbmN5IHJlc29sdXRpb24sIGFuZCBwbHVnaW4gYXJjaGl0ZWN0dXJlIGZvdW5kYXRpb24iCiAgICAgICAgICAgICAgICAgICAgdGFncyAiQ29yZUJ1c2luZXNzIgogICAgICAgICAgICAgICAgICAgIGdyb3VwICJjb3JlIgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAgICAgICAgICAgICAiUGx1Z2luIHJlcG9zaXRvcnkiICJQbHVnaW5SZXBvc2l0b3J5IHNpbmdsZXRvbiBmb3IgcGx1Z2luIG1hbmFnZW1lbnQsIG1ldGFkYXRhIGhhbmRsaW5nLCBwbHVnaW4gZGlzY292ZXJ5IChjb3JlL2luY2x1ZGUvY29yZS9wbHVnaW5yZXBvc2l0b3J5LmgpIgogICAgICAgICAgICAgICAgICAgICAgICAiUGx1Z2luIG1hbmFnZXIiICJQbHVnaW5NYW5hZ2VyIGZvciBkeW5hbWljIGxvYWRpbmcsIHNvcnRpbmcsIGZpbHRlcmluZywgYW5kIGxpZmVjeWNsZSBjb250cm9sIChjb3JlL2luY2x1ZGUvY29yZS9wbHVnaW5tYW5hZ2VyLmgpIgogICAgICAgICAgICAgICAgICAgICAgICAiUGx1Z2luIGludGVyZmFjZSIgIlBsdWdpbiBiYXNlIGludGVyZmFjZSBkZWZpbmluZyBjb21wYXRpYmxlKCksIG9uQ29ubmVjdCgpLCBvbkRpc2Nvbm5lY3QoKSBhbmQgb3RoZXIgY29udHJhY3RzIChwbHVnaW5iYXNlL2luY2x1ZGUvcGx1Z2luYmFzZS9wbHVnaW4uaCkiCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAvLyBQbHVnaW4gU3lzdGVtIGNvbXBvbmVudHMKICAgICAgICAgICAgICAgIHBsdWdpblJlcG9zaXRvcnkgPSBjb21wb25lbnQgIlBsdWdpbiBSZXBvc2l0b3J5IiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIlN0b3JhZ2UgYW5kIG1hbmFnZW1lbnQgb2YgYXZhaWxhYmxlIHBsdWdpbnMgYW5kIHRoZWlyIG1ldGFkYXRhIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW5TeXN0ZW0iICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImNvcmUiCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBwbHVnaW5NYW5hZ2VyID0gY29tcG9uZW50ICJQbHVnaW4gTWFuYWdlciIgeyAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkR5bmFtaWMgbG9hZGluZyBhbmQgaW5zdGFudGlhdGlvbiBvZiBwbHVnaW4gbGlicmFyaWVzIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luU3lzdGVtIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImNvcmUiIAogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgcGx1Z2luSW50ZXJmYWNlID0gY29tcG9uZW50ICJQbHVnaW4gSW50ZXJmYWNlIiB7ICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiQ29tbW9uIEFQSSBjb250cmFjdCB0aGF0IGFsbCBwbHVnaW5zIG11c3QgaW1wbGVtZW50IiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luU3lzdGVtIiAKICAgICAgICAgICAgICAgICAgICBncm91cCAicGx1Z2luYmFzZSIgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgfSAgCiAgICAgICAgICAgICAgICBwbHVnaW5NYW5hZ2VyIC0+IHBsdWdpblJlcG9zaXRvcnkgInF1ZXJpZXMgYXZhaWxhYmxlIHBsdWdpbnMiCiAgICAgICAgICAgICAgICBwbHVnaW5NYW5hZ2VyIC0+IHBsdWdpbkludGVyZmFjZSAiaW5zdGFudGlhdGVzIHBsdWdpbnMiCgogICAgICAgICAgICAgICAgLy8gVUkgQU5EIFBSRVNFTlRBVElPTiBMQVlFUgogICAgICAgICAgICAgICAgdWlGcmFtZXdvcmsgPSBjb21wb25lbnQgIlVJIEZyYW1ld29yayIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJDb21tb24gVUkgd2lkZ2V0cywgcGxvdCB3aWRnZXRzLCBzdHlsZSBtYW5hZ2VtZW50IgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlByZXNlbnRhdGlvbiIKICAgICAgICAgICAgICAgICAgICBncm91cCAiZ3VpIgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAgICAgICAgICAgICAiQ29tbW9uIGNvbXBvbmVudHMiICJNZW51IHNlY3Rpb24gd2lkZ2V0cywgY29sbGFwc2UgaGVhZGVycywgY3VzdG9tIGNvbnRyb2xzIGZvciBwYXRhbWV0ZXJzLCBlbmhhbmNlZCBpbnB1dCB3aWRnZXRzLCBldGMuIChndWkvaW5jbHVkZS9ndWk7IGd1aS9pbmNsdWRlL2d1aS93aWRnZXRzKSIKICAgICAgICAgICAgICAgICAgICAgICAgIlBsb3Qgd2lkZ2V0cyIgIlBsb3R0aW5nIHdpZGdldHMsIG1lYXN1cmVtZW50IGRpc3BsYXlzLCBzaWduYWwgdmlzdWFsaXphdGlvbiAoZ3VpL2luY2x1ZGUvZ3VpKSIKICAgICAgICAgICAgICAgICAgICAgICAgIlN0eWxlIG1hbmFnZW1lbnQiICJRU1MtYmFzZWQgc3R5bGluZyB3aXRoIGR5bmFtaWMgdGhlbWUgc3dpdGNoaW5nIChndWkvc3R5bGUpIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICB3aW5kb3dNYW5hZ2VtZW50ID0gY29tcG9uZW50ICJXaW5kb3cgTWFuYWdlbWVudCIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJNYWluIHdpbmRvdyBjb29yZGluYXRpb24sIGRldGFjaGVkIHRvb2wgd2luZG93cywgYW5kIHdvcmtzcGFjZSBtYW5hZ2VtZW50IgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlByZXNlbnRhdGlvbiIKICAgICAgICAgICAgICAgICAgICBncm91cCAiZ3VpIgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAgICAgICAgICAgICAiTWFpbiB3aW5kb3cgY29vcmRpbmF0aW9uIiAiU2NvcHlNYWluV2luZG93IGxpZmVjeWNsZSwgYXBwbGljYXRpb24gaW5pdGlhbGl6YXRpb24sIGV2ZW50IGhhbmRsaW5nIChjb3JlL2luY2x1ZGUvY29yZS9zY29weW1haW53aW5kb3cuaCkiCiAgICAgICAgICAgICAgICAgICAgICAgICJEZXRhY2hlZCB0b29sIG1hbmFnZW1lbnQiICJEZXRhY2hlZFRvb2xXaW5kb3dNYW5hZ2VyIGZvciBzZXBhcmF0ZSB0b29sIHdpbmRvd3MsIG11bHRpLW1vbml0b3Igc3VwcG9ydCAoY29yZS9pbmNsdWRlL2NvcmUvZGV0YWNoZWR0b29sd2luZG93bWFuYWdlci5oKSIKICAgICAgICAgICAgICAgICAgICAgICAgIkFkdmFuY2VkIGRvY2tpbmcgc3lzdGVtIiAiS0REb2NrV2lkZ2V0cyBiYWNrZW5kIGZvciBwcm9mZXNzaW9uYWwgZG9ja2luZyBsYXlvdXRzIChndWkvaW5jbHVkZS9ndWkvZG9ja2luZykiCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIHRvb2xNYW5hZ2VyID0gY29tcG9uZW50ICJUb29sIE1hbmFnZXIiIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiVG9vbCByZWdpc3RyYXRpb24sIG1lbnUgb3JnYW5pemF0aW9uLCB0b29sIGxpZmVjeWNsZSBjb29yZGluYXRpb24sIGFuZCB1bmlmaWVkIHRvb2wgaW50ZXJmYWNlIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlByZXNlbnRhdGlvbiIKICAgICAgICAgICAgICAgICAgICBncm91cCAiY29yZSIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBzdGF0dXNCYXIgPSBjb21wb25lbnQgIlN0YXR1cyBCYXIiIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiUmVhbC10aW1lIHN0YXR1cyBkaXNwbGF5LCBkZXZpY2UgY29ubmVjdGl2aXR5IGluZGljYXRvcnMsIG9wZXJhdGlvbiBwcm9ncmVzcywgYW5kIHN5c3RlbSBub3RpZmljYXRpb25zIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlByZXNlbnRhdGlvbiIKICAgICAgICAgICAgICAgICAgICBncm91cCAiZ3VpIgogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGFwcGxpY2F0aW9uUGFnZXMgPSBjb21wb25lbnQgIkFwcGxpY2F0aW9uIFBhZ2VzIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIlBhZ2UgbmF2aWdhdGlvbiwgaG9tZSBwYWdlLCBkZXZpY2UgYnJvd3NlciwgcHJlZmVyZW5jZXMgcGFnZXMsIHBhY2thZ2VzIHBhZ2UsIGFuZCBhcHBsaWNhdGlvbiBmbG93IGNvbnRyb2wiCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUHJlc2VudGF0aW9uIgogICAgICAgICAgICAgICAgICAgIGdyb3VwICJjb3JlIgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAgICAgICAgICAgICAiVG9vbCBzdGFjayBtYW5hZ2VtZW50IiAiVG9vbFN0YWNrIGNvbnRhaW5lciBleHRlbmRpbmcgTWFwU3RhY2tlZFdpZGdldCBmb3Iga2V5LWJhc2VkIHBhZ2Ugc3dpdGNoaW5nIChjb3JlL2luY2x1ZGUvY29yZS90b29sc3RhY2suaCkiCiAgICAgICAgICAgICAgICAgICAgICAgICJQcmVmZXJlbmNlcyBpbnRlZ3JhdGlvbiIgIlNjb3B5UHJlZmVyZW5jZXNQYWdlLCBzZXR0aW5ncyBtYW5hZ2VtZW50LCBjb25maWd1cmF0aW9uIGRpYWxvZ3MgKGNvcmUvaW5jbHVkZS9jb3JlL3Njb3B5cHJlZmVyZW5jZXNwYWdlLmgpIgogICAgICAgICAgICAgICAgICAgICAgICAiQWJvdXQgYW5kIGluZm8gcGFnZXMiICJTY29weUFib3V0UGFnZSwgdmVyc2lvbiBpbmZvcm1hdGlvbiwgc3lzdGVtIGRldGFpbHMgKGNvcmUvaW5jbHVkZS9jb3JlL3Njb3B5YWJvdXRwYWdlLmgpIgogICAgICAgICAgICAgICAgICAgICAgICAiSG9tZSBwYWdlIHN5c3RlbSIgIlNjb3B5SG9tZVBhZ2UgZm9yIGRldmljZSBzY2FubmluZywgY29ubmVjdGlvbiBtYW5hZ2VtZW50LCBkZXZpY2UgYnJvd3NlciAoY29yZS9pbmNsdWRlL2NvcmUpIgogICAgICAgICAgICAgICAgICAgICAgICAiTmF2aWdhdGlvbiBjb29yZGluYXRpb24iICJUb29sIHNlbGVjdGlvbiBmbG93LCBwYWdlIHN3aXRjaGluZywgbWVudSBzdGF0ZSBtYW5hZ2VtZW50IChjb3JlL2luY2x1ZGUvY29yZSkiCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIC8vIFNVUFBPUlRJTkcgTElCUkFSSUVTCiAgICAgICAgICAgICAgICBpaW9VdGlsaXRpZXMgPSBjb21wb25lbnQgIklJTyBVdGlsaXRpZXMiIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiSW5kdXN0cmlhbCBJL08gY29tbXVuaWNhdGlvbiwgY29tbWFuZCBxdWV1aW5nLCBhbmQgY29ubmVjdGlvbiBtYW5hZ2VtZW50IgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIkxpYnJhcnkiCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImlpby11dGlsIgogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGlpb1dpZGdldHMgPSBjb21wb25lbnQgIklJTyBXaWRnZXRzIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIlNwZWNpYWxpemVkIFVJIGNvbXBvbmVudHMgZm9yIElJTyBkZXZpY2VzLCBwYXJhbWV0ZXIgY29udHJvbHMsIGFuZCBkZXZpY2Utc3BlY2lmaWMgaW50ZXJmYWNlcyIKICAgICAgICAgICAgICAgICAgICB0YWdzICJMaWJyYXJ5IgogICAgICAgICAgICAgICAgICAgIGdyb3VwICJpaW8td2lkZ2V0cyIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBnbnVSYWRpb1dpZGdldHMgPSBjb21wb25lbnQgIkdOVSBSYWRpbyBVdGlsaXRpZXMiIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiR05VIFJhZGlvIHNwZWNpZmljIGNvbXBvbmVudHMgYW5kIHNpZ25hbCBwcm9jZXNzaW5nIGNvbnRyb2xzIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIkxpYnJhcnkiCiAgICAgICAgICAgICAgICAgICAgZ3JvdXAgImdyLXV0aWwiCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIC8vIENPTVBPTkVOVCBSRUxBVElPTlNISVBTCgogICAgICAgICAgICAgICAgLy8gSW5mcmFzdHJ1Y3R1cmUgRGVwZW5kZW5jaWVzCiAgCiAgICAgICAgICAgICAgICAvLyBBcHBsaWNhdGlvbiBDb29yZGluYXRvciBvcmNoZXN0cmF0ZXMgc3lzdGVtIGluaXRpYWxpemF0aW9uCiAgICAgICAgICAgICAgICBhcHBsaWNhdGlvbkNvb3JkaW5hdG9yIC0+IHByZWZlcmVuY2VzTWFuYWdlbWVudCAibG9hZHMgYXBwbGljYXRpb24gc2V0dGluZ3MiCiAgICAgICAgICAgICAgICBhcHBsaWNhdGlvbkNvb3JkaW5hdG9yIC0+IGxvZ2dpbmdTeXN0ZW0gImluaXRpYWxpemVzIGxvZ2dpbmciCiAgICAgICAgICAgICAgICBhcHBsaWNhdGlvbkNvb3JkaW5hdG9yIC0+IGNyYXNoUmVwb3J0aW5nICJzZXRzIHVwIGNyYXNoIGhhbmRsZXJzIgogICAgICAgICAgICAgICAgYXBwbGljYXRpb25Db29yZGluYXRvciAtPiB0cmFuc2xhdGlvblNlcnZpY2UgImluaXRpYWxpemVzIGxvY2FsaXphdGlvbiIKICAgICAgICAgICAgICAgIGFwcGxpY2F0aW9uQ29vcmRpbmF0b3IgLT4gZGV2aWNlTWFuYWdlbWVudCAiaW5pdGlhbGl6ZXMgZGV2aWNlIHN5c3RlbSIKICAgICAgICAgICAgICAgIGFwcGxpY2F0aW9uQ29vcmRpbmF0b3IgLT4gcGx1Z2luU3lzdGVtICJpbml0aWFsaXplcyBwbHVnaW4gc3lzdGVtIgogICAgICAgICAgICAgICAgYXBwbGljYXRpb25Db29yZGluYXRvciAtPiBwYWNrYWdlTWFuYWdlciAiaW5pdGlhbGl6ZXMgcGFja2FnZSBtYW5hZ2VtZW50IgogICAgICAgICAgICAgICAgYXBwbGljYXRpb25Db29yZGluYXRvciAtPiB3aW5kb3dNYW5hZ2VtZW50ICJpbml0aWFsaXplcyBtYWluIHdpbmRvdyIKCgogICAgICAgICAgICAgICAgLy8gQ29tbWFuZCBMaW5lIEhhbmRsZXIgcHJvY2Vzc2VzIHN0YXJ0dXAgYXJndW1lbnRzCiAgICAgICAgICAgICAgICBjb21tYW5kTGluZUhhbmRsZXIgLT4gcHJlZmVyZW5jZXNNYW5hZ2VtZW50ICJvdmVycmlkZXMgZGVmYXVsdCBzZXR0aW5ncyIKICAgICAgICAgICAgICAgIGNvbW1hbmRMaW5lSGFuZGxlciAtPiBsb2dnaW5nU3lzdGVtICJjb25maWd1cmVzIGxvZyB2ZXJib3NpdHkiCiAgICAgICAgICAgICAgICBjb21tYW5kTGluZUhhbmRsZXIgLT4gYXBwbGljYXRpb25Db29yZGluYXRvciAidHJpZ2dlcnMgc3RhcnR1cCBzZXF1ZW5jZSIKICAgICAgICAgICAgICAgIGNvbW1hbmRMaW5lSGFuZGxlciAtPiBzY3JpcHRpbmdFbmdpbmUgImV4ZWN1dGVzIHNjcmlwdCBmaWxlcyIKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgc2NyaXB0aW5nRW5naW5lIC0+IGFwcGxpY2F0aW9uQ29vcmRpbmF0b3IgImFjY2Vzc2VzIGFwcGxpY2F0aW9uIHNlcnZpY2VzIgoKICAgICAgICAgICAgICAgIC8vIENvcmUgQnVzaW5lc3MgTG9naWMgRGVwZW5kZW5jaWVzCiAgICAgICAgICAgICAgICBkZXZpY2VNYW5hZ2VtZW50IC0+IHByZWZlcmVuY2VzTWFuYWdlbWVudCAicmVhZHMgZGV2aWNlIHByZWZlcmVuY2VzIgogICAgICAgICAgICAgICAgZGV2aWNlTWFuYWdlbWVudCAtPiBsb2dnaW5nU3lzdGVtICJsb2dzIGRldmljZSBvcGVyYXRpb25zIgogICAgICAgICAgICAgICAgZGV2aWNlTWFuYWdlbWVudCAtPiAgcGx1Z2luU3lzdGVtICJsb2FkcyBkZXZpY2Ugc3BlY2lmaWMgcGx1Z2lucyIKCiAgICAgICAgICAgICAgICBwbHVnaW5TeXN0ZW0gLT4gcGFja2FnZU1hbmFnZXIgIm1hbmFnZXMgcGx1Z2lucyBmcm9tIHBhY2thZ2VzIgogICAgICAgICAgICAgICAgcGx1Z2luU3lzdGVtIC0+IHByZWZlcmVuY2VzTWFuYWdlbWVudCAicmVhZHMgcGx1Z2luIGNvbmZpZ3VyYXRpb25zIgogICAgICAgICAgICAgICAgcGx1Z2luU3lzdGVtIC0+IGxvZ2dpbmdTeXN0ZW0gImxvZ3MgcGx1Z2luIG9wZXJhdGlvbnMiCiAgICAgICAgICAgICAgICBwbHVnaW5TeXN0ZW0gLT4gaWlvVXRpbGl0aWVzICJ1c2VzIGZvciBkZXZpY2UgY29tbXVuaWNhdGlvbiIKICAgICAgICAgICAgICAgIHBsdWdpblN5c3RlbSAtPiBnbnVSYWRpb1dpZGdldHMgInNwZWNpZmljIHBsdWdpbnMgdXNlIHByb2Nlc3Npbmcgc2VydmljZXMiCiAgICAgICAgICAgICAgICBwbHVnaW5TeXN0ZW0gLT4gaWlvV2lkZ2V0cyAic3BlY2lmaWMgcGx1Z2lucyB1c2UiCgogICAgICAgICAgICAgICAgLy8gVUkgYW5kIFByZXNlbnRhdGlvbiBEZXBlbmRlbmNpZXMKICAgICAgICAgICAgICAgIHdpbmRvd01hbmFnZW1lbnQgLT4gdWlGcmFtZXdvcmsgInVzZXMgY29tbW9uIFVJIGNvbXBvbmVudHMiCiAgICAgICAgICAgICAgICB3aW5kb3dNYW5hZ2VtZW50IC0+IHByZWZlcmVuY2VzTWFuYWdlbWVudCAicGVyc2lzdHMgd2luZG93IHN0YXRlIgogICAgICAgICAgICAgICAgd2luZG93TWFuYWdlbWVudCAtPiBhcHBsaWNhdGlvblBhZ2VzICJtYW5hZ2VzIHBhZ2UgY29udGFpbmVycyIKICAgICAgICAgICAgICAgIHdpbmRvd01hbmFnZW1lbnQgLT4gdG9vbE1hbmFnZXIgIm1hbmFnZXMgdG9vbCB3aW5kb3dzIgoKICAgICAgICAgICAgICAgIHRvb2xNYW5hZ2VyIC0+IHBsdWdpblN5c3RlbSAiY29vcmRpbmF0ZXMgYXZhaWxhYmxlIHBsdWdpbiB0b29scyIKICAgICAgICAgICAgICAgIHRvb2xNYW5hZ2VyIC0+IHVpRnJhbWV3b3JrICJ1c2VzIFVJIGNvbXBvbmVudHMiCgogICAgICAgICAgICAgICAgc3RhdHVzQmFyIC0+IGRldmljZU1hbmFnZW1lbnQgInN1YnNjcmliZXMgdG8gZGV2aWNlIHN0YXR1cyIKICAgICAgICAgICAgICAgIHN0YXR1c0JhciAtPiBwbHVnaW5TeXN0ZW0gInJlY2VpdmVzIHBsdWdpbiBub3RpZmljYXRpb25zIgogICAgICAgICAgICAgICAgc3RhdHVzQmFyIC0+IHVpRnJhbWV3b3JrICJ1c2VzIHN0YXR1cyB3aWRnZXRzIgoKICAgICAgICAgICAgICAgIGFwcGxpY2F0aW9uUGFnZXMgLT4gdWlGcmFtZXdvcmsgInVzZXMgcGFnZSBjb21wb25lbnRzIgogICAgICAgICAgICAgICAgYXBwbGljYXRpb25QYWdlcyAtPiBwcmVmZXJlbmNlc01hbmFnZW1lbnQgInJlYWRzIHBhZ2UgcHJlZmVyZW5jZXMiCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIHVpRnJhbWV3b3JrIC0+IHBhY2thZ2VNYW5hZ2VyICJtYW5hZ2VzIHN0eWxlcyBlbGVtZW50cyBmcm9tIHBhY2thZ2VzIgoKICAgICAgICAgICAgICAgIC8vIExpYnJhcnkgRGVwZW5kZW5jaWVzCiAgICAgICAgICAgICAgICBpaW9XaWRnZXRzIC0+IGlpb1V0aWxpdGllcyAidXNlcyBJSU8gY29tbXVuaWNhdGlvbiIKICAgICAgICAgICAgICAgIGlpb1dpZGdldHMgLT4gdWlGcmFtZXdvcmsgImV4dGVuZHMgVUkgZnJhbWV3b3JrIgoKICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8gR0VORVJJQyBQTFVHSU5TIFBBQ0tBR0UKICAgICAgICAgICAgZ2VuZXJpY1BsdWdpbnNQYWNrYWdlID0gY29udGFpbmVyICJHZW5lcmljIFBsdWdpbnMgUGFja2FnZSIgewogICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIlN0YW5kYXJkIElJTyBkZXZpY2UgcGx1Z2lucyBmb3IgY29tbW9uIGZ1bmN0aW9uYWxpdHkiCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0IgoKICAgICAgICAgICAgICAgIGFkY1BsdWdpbiA9IGNvbXBvbmVudCAiQURDIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgQURDIHBsdWdpbiBpcyB1c2VkIHRvIGludGVyZmFjZSB3aXRoIElJTyBBRENzIHRoYXQgaW1wbGVtZW50IGFuIElJTyBidWZmZXIgbWVjaGFuaXNtIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIGRhY1BsdWdpbiA9IGNvbXBvbmVudCAiREFDIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgREFDIHBsdWdpbiBpcyB1c2VkIHRvIGludGVyZmFjZSB3aXRoIElJTyBEQUNzIHRoYXQgaW1wbGVtZW50IHRoZSBJSU8gYnVmZmVyIG1lY2hhbmlzbSBvciBhIEREUyBtZWNoYW5pc20iCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgZGF0YWxvZ2dlclBsdWdpbiA9IGNvbXBvbmVudCAiRGF0YUxvZ2dlciBQbHVnaW4iIHsKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiVXNlZCB0byBtb25pdG9yIGFuZCBsb2cgZGF0YSIKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW4iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBkZWJ1Z2dlclBsdWdpbiA9IGNvbXBvbmVudCAiRGVidWdnZXIgUGx1Z2luIiB7CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIlRoZSBkZWJ1Z2dlciBwbHVnaW4gaXMgdXNlZCB0byBleGFtaW5lIElJTyBjb250ZXh0cyBhbmQgbW9kaWZ5IGluZGl2aWR1YWwgSUlPIGF0dHJpYnV0ZXMsIGFzIHdlbGwgYXMgZXhhbWluaW5nIHRoZSBzdHJ1Y3R1cmUgb2YgYW4gSUlPIGNvbnRleHQiCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luIgogICAgICAgICAgICAgICAgfSAKICAgICAgICAgICAgICAgIGplc2RQbHVnaW4gPSBjb21wb25lbnQgIkpFU0QgU3RhdHVzIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgSkVTRCBTdGF0dXMgdXRpbGl0eSBwbHVnaW4gcHJvdmlkZXMgYSBncmFwaGljYWwgaW50ZXJmYWNlIHRvIG1vbml0b3IgdGhlIHN0YXR1cyBvZiBKRVNEMjA0IGluIFNjb3B5IgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHJlZ21hcFBsdWdpbiA9IGNvbXBvbmVudCAiUmVnaXN0ZXIgTWFwIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgUmVnaXN0ZXIgTWFwIGFsbG93IGFjY2VzcyB0byByZWFkaW5nIGFuZCB3cml0aW5nIHJlZ2lzdGVycyBmb3IgZGV2aWNlcyBjb25uZWN0ZWQgdG8gU2NvcHkiCiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICBhZGNQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBhZGNQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgogICAgICAgICAgICAgICAgYWRjUGx1Z2luIC0+IGdudVJhZGlvV2lkZ2V0cyAidXNlIgogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICBkYWNQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBkYWNQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICBkYXRhbG9nZ2VyUGx1Z2luIC0+IHBsdWdpbkludGVyZmFjZSAiaW1wbGVtZW50cyIgewogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbkltcGxlbWVudGF0aW9uIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgZGF0YWxvZ2dlclBsdWdpbiAtPiBpaW9XaWRnZXRzICJ1c2UiCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIGRlYnVnZ2VyUGx1Z2luIC0+IHBsdWdpbkludGVyZmFjZSAiaW1wbGVtZW50cyIgewogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbkltcGxlbWVudGF0aW9uIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgZGVidWdnZXJQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgoKICAgICAgICAgICAgICAgIGplc2RQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICByZWdtYXBQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIC8vIE0ySyBQQUNLQUdFCiAgICAgICAgICAgIG0ya1BhY2thZ2UgPSBjb250YWluZXIgIk0ySyBQYWNrYWdlIiB7CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiQURBTE0yMDAwIGRldmljZSBzdXBwb3J0IHBhY2thZ2UiCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0IgoKICAgICAgICAgICAgICAgIG0ya1BsdWdpbiA9IGNvbXBvbmVudCAiTTJLIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJQbHVnaW4gZm9yIEFEQUxNMjAwMCAoTTJLKSIKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW4iCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLy8gUmVsYXRpb25zCiAgICAgICAgICAgICAgICBtMmtQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBtMmtQbHVnaW4gLT4gZ251UmFkaW9XaWRnZXRzICJ1c2UiCiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIC8vIFNXSU9UIFBBQ0tBR0UKICAgICAgICAgICAgc3dpb3RQYWNrYWdlID0gY29udGFpbmVyICJTV0lPVCBQYWNrYWdlIiB7CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbiAiQUQtU1dJT1QxTC1TTCBwbGF0Zm9ybSBzdXBwb3J0IHBhY2thZ2UiCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0IgoKICAgICAgICAgICAgICAgIHN3aW90UGx1Z2luID0gY29tcG9uZW50ICJTV0lPVDFMIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgU2NvcHkgQUQtU1dJT1QxTC1TTCBwbHVnaW4gaXMgcmVzcG9uc2libGUgd2l0aCB0aGUgb3BlcmF0aW9uIGFuZCBjb250cm9sIG9mIHRoZSBBRC1TV0lPVDFMLVNMIHBsYXRmb3JtIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbiIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICAvLyBSZWxhdGlvbnMKICAgICAgICAgICAgICAgIHN3aW90UGx1Z2luIC0+IHBsdWdpbkludGVyZmFjZSAiaW1wbGVtZW50cyIgewogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbkltcGxlbWVudGF0aW9uIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgc3dpb3RQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgogICAgICAgICAgICB9CgogICAgICAgICAgICAvLyBBRDkzNlggUEFDS0FHRQogICAgICAgICAgICBhZDkzNnhQYWNrYWdlID0gY29udGFpbmVyICJBRDkzNlggUGFja2FnZSIgewogICAgICAgICAgICAgICAgZGVzY3JpcHRpb24gIkFEOTM2WCB0cmFuc2NlaXZlciBzdXBwb3J0IHBhY2thZ2UiCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0IgoKICAgICAgICAgICAgICAgIGFkOTM2eFBsdWdpbiA9IGNvbXBvbmVudCAiQUQ5MzZYIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgQUQ5MzZ4IHBsdWdpbnMgZm9yIFNjb3B5IGVuYWJsZSBpbnRlZ3JhdGlvbiBhbmQgY29udHJvbCBvZiBBRDkzNngtYmFzZWQgZGV2aWNlcyB3aXRoaW4gdGhlIFNjb3B5IHNvZnR3YXJlIGVudmlyb25tZW50IgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAvLyBSZWxhdGlvbnMKICAgICAgICAgICAgICAgIGFkOTM2eFBsdWdpbiAtPiBwbHVnaW5JbnRlcmZhY2UgImltcGxlbWVudHMiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW5JbXBsZW1lbnRhdGlvbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIGFkOTM2eFBsdWdpbiAtPiBpaW9XaWRnZXRzICJ1c2UiICAKCiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIC8vIEFQT0xMTyBBRDkwODQgUEFDS0FHRQogICAgICAgICAgICBhcG9sbG9BZDkwODRQYWNrYWdlID0gY29udGFpbmVyICJBcG9sbG8gQUQ5MDg0IFBhY2thZ2UiIHsKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJBcG9sbG8gTVhGRSBRVUFEIEFEOTA4NCBzdXBwb3J0IHBhY2thZ2UiCiAgICAgICAgICAgICAgICB0ZWNobm9sb2d5ICJDKyssIFF0IgoKICAgICAgICAgICAgICAgIGFkOTA4NFBsdWdpbiA9IGNvbXBvbmVudCAiQUQ5MDg0IFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJBcG9sbG8gTVhGRSBRVUFEIEFEOTA4NCBpbnRlcmFjdGlvbiIKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW4iCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLy8gUmVsYXRpb25zCiAgICAgICAgICAgICAgICBhZDkwODRQbHVnaW4gLT4gcGx1Z2luSW50ZXJmYWNlICJpbXBsZW1lbnRzIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiUGx1Z2luSW1wbGVtZW50YXRpb24iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBhZDkwODRQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgogICAgICAgICAgICB9CgogICAgICAgICAgICAvLyBQT1dFUiBRVUFMSVRZIE1PTklUT1IgUEFDS0FHRQogICAgICAgICAgICBwcW1vblBhY2thZ2UgPSBjb250YWluZXIgIlBRTW9uIFBhY2thZ2UiIHsKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJQb3dlciBRdWFsaXR5IE1vbml0b3Igc3VwcG9ydCBwYWNrYWdlIgogICAgICAgICAgICAgICAgdGVjaG5vbG9neSAiQysrLCBRdCIKCiAgICAgICAgICAgICAgICBwcW1QbHVnaW4gPSBjb21wb25lbnQgIlBRTU9OIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJQb3dlciBRdWFsaXR5IE1vbml0b3IgcGx1Z2luIgogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHBxbVBsdWdpbiAtPiBwbHVnaW5JbnRlcmZhY2UgImltcGxlbWVudHMiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW5JbXBsZW1lbnRhdGlvbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8gSU1VIFBBQ0tBR0UKICAgICAgICAgICAgaW11UGFja2FnZSA9IGNvbnRhaW5lciAiSU1VIFBhY2thZ2UiIHsKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJJTVUgRXZhbHVhdGlvbiBTb2Z0d2FyZSBQYWNrYWdlIgogICAgICAgICAgICAgICAgdGVjaG5vbG9neSAiQysrLCBRdCIKCiAgICAgICAgICAgICAgICBpbXVBbmFseXplclBsdWdpbiA9IGNvbXBvbmVudCAiSU1VIEFuYWx5emVyIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJJTVUgZXZhbHVhdGlvbiBhbmQgYW5hbHlzaXMgZnVuY3Rpb25hbGl0eSIKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW4iCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLy8gUmVsYXRpb25zCiAgICAgICAgICAgICAgICBpbXVBbmFseXplclBsdWdpbiAtPiBwbHVnaW5JbnRlcmZhY2UgImltcGxlbWVudHMiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW5JbXBsZW1lbnRhdGlvbiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIGltdUFuYWx5emVyUGx1Z2luIC0+IGlpb1dpZGdldHMgInVzZSIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8gQURSVjkwMDIgUEFDS0FHRQogICAgICAgICAgICBhZHJ2OTAwMlBhY2thZ2UgPSBjb250YWluZXIgIkFEUlY5MDAyIFBhY2thZ2UiIHsKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJBRFJWOTAwMiBKdXBpdGVyIHRyYW5zY2VpdmVyIHN1cHBvcnQgcGFja2FnZSIKICAgICAgICAgICAgICAgIHRlY2hub2xvZ3kgIkMrKywgUXQiCgogICAgICAgICAgICAgICAgYWRydjkwMDJQbHVnaW4gPSBjb21wb25lbnQgIkFEUlY5MDAyIFBsdWdpbiIgewogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgQURSVjkwMDIgKEp1cGl0ZXIpIHBsdWdpbiBwcm92aWRlcyBhIGNvbXByZWhlbnNpdmUgaW50ZXJmYWNlIGZvciBjb250cm9sbGluZyBhbmQgY29uZmlndXJpbmcgdGhlIEFEUlY5MDAyIGR1YWwtY2hhbm5lbCBSRiB0cmFuc2NlaXZlciIKICAgICAgICAgICAgICAgICAgICB0YWdzICJQbHVnaW4iCiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLy9SZWxhdGlvbnMKICAgICAgICAgICAgICAgIGFkcnY5MDAyUGx1Z2luIC0+IHBsdWdpbkludGVyZmFjZSAiaW1wbGVtZW50cyIgewogICAgICAgICAgICAgICAgICAgIHRhZ3MgIlBsdWdpbkltcGxlbWVudGF0aW9uIgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgYWRydjkwMDJQbHVnaW4gLT4gaWlvV2lkZ2V0cyAidXNlIgoKICAgICAgICAgICAgfQoKCiAgICAgICAgICAgIC8vIFVzZXIgUmVsYXRpb25zaGlwcwogICAgICAgICAgICBlbmdpbmVlclVzZXIgLT4gc2NvcHlBcHBsaWNhdGlvbiAidXNlcyBHVUkgZm9yIGRldmljZSBjb250cm9sIGFuZCBhbmFseXNpcyIKICAgICAgICAgICAgc3R1ZGVudCAtPiBzY29weUFwcGxpY2F0aW9uICJ1c2VzIGZvciBsZWFybmluZyBhbmQgZXhwZXJpbWVudHMiCgogICAgICAgICAgICAvLyBFeHRlcm5hbCBDb250YWluZXIgUmVsYXRpb25zaGlwcwogICAgICAgICAgICBzY29weUFwcGxpY2F0aW9uIC0+IGlpb0ZyYW1ld29yayAic2VuZHMgY29tbWFuZHMgYW5kIHJlY2VpdmVzIGRhdGEgdmlhIgogICAgICAgICAgICBzY29weUFwcGxpY2F0aW9uIC0+IGdudVJhZGlvRWNvc3lzdGVtICJ1c2VzIGZvciBzaWduYWwgcHJvY2Vzc2luZyBhbmQgRFNQIG9wZXJhdGlvbnMiCiAgICAgICAgICAgIHNjb3B5QXBwbGljYXRpb24gLT4gZmlsZVN5c3RlbSAicmVhZC93cml0ZSBkYXRhIGZpbGVzIGFuZCBjb25maWd1cmF0aW9ucyIKICAgICAgICAgICAgc2NvcHlBcHBsaWNhdGlvbiAtPiBvcGVyYXRpbmdTeXN0ZW0gInJ1bnMgb24gY3Jvc3MtcGxhdGZvcm0gT1MiCiAgICAgICAgICAgIHNjb3B5QXBwbGljYXRpb24gLT4gaWlvRW11ICJsYXVuY2hlcyBhbmQgY29tbXVuaWNhdGVzIHdpdGggdmlhIFRDUC9JUCIKICAgICAgICAgICAgc2NvcHlBcHBsaWNhdGlvbiAtPiBnZW5lcmljUGx1Z2luc1BhY2thZ2UgImxvYWRzIHJlc291cmNlcyBmcm9tIgogICAgICAgICAgICBzY29weUFwcGxpY2F0aW9uIC0+IG0ya1BhY2thZ2UgImxvYWRzIHJlc291cmNlcyBmcm9tIgogICAgICAgICAgICBzY29weUFwcGxpY2F0aW9uIC0+IHN3aW90UGFja2FnZSAibG9hZHMgcmVzb3VyY2VzIGZyb20iCiAgICAgICAgICAgIHNjb3B5QXBwbGljYXRpb24gLT4gYWQ5MzZ4UGFja2FnZSAibG9hZHMgcmVzb3VyY2VzIGZyb20iCiAgICAgICAgICAgIHNjb3B5QXBwbGljYXRpb24gLT4gYXBvbGxvQWQ5MDg0UGFja2FnZSAibG9hZHMgcmVzb3VyY2VzIGZyb20iCiAgICAgICAgICAgIHNjb3B5QXBwbGljYXRpb24gLT4gcHFtb25QYWNrYWdlICJsb2FkcyByZXNvdXJjZXMgZnJvbSIKICAgICAgICAgICAgc2NvcHlBcHBsaWNhdGlvbiAtPiBpbXVQYWNrYWdlICJsb2FkcyByZXNvdXJjZXMgZnJvbSIKICAgICAgICAgICAgc2NvcHlBcHBsaWNhdGlvbiAtPiBhZHJ2OTAwMlBhY2thZ2UgImxvYWRzIHJlc291cmNlcyBmcm9tIgogICAgICAgIH0gICAgICAgIAogICAgICAgIAogICAgICAgIGlpb0ZyYW1ld29yayAtPiBhZGlIYXJkd2FyZSAiYWJzdHJhY3RzIGhhcmR3YXJlIGNvbW11bmljYXRpb24gdG8iCiAgICAgICAgCiAgICB9CiAgICAKICAgIHZpZXdzIHsKCiAgICAgICAgLy8gU1lTVEVNIENPTlRFWFQgVklFVwogICAgICAgIHN5c3RlbUNvbnRleHQgc2NvcHlTeXN0ZW0gIlN5c3RlbUNvbnRleHQiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGluY2x1ZGUgYWRpSGFyZHdhcmUKICAgICAgICAgICAgdGl0bGUgIlNjb3B5IgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiSGlnaC1sZXZlbCB2aWV3IHNob3dpbmcgU2NvcHkncyBpbnRlcmFjdGlvbnMgd2l0aCB1c2VycyBhbmQgZXh0ZXJuYWwgc3lzdGVtcyIKICAgICAgICB9CgogICAgICAgIC8vIENPTlRBSU5FUiBWSUVXCiAgICAgICAgY29udGFpbmVyIHNjb3B5U3lzdGVtICJDb250YWluZXJWaWV3IiB7CiAgICAgICAgICAgIGluY2x1ZGUgKgogICAgICAgICAgICBleGNsdWRlICJyZWxhdGlvbnNoaXAudGFnPT1QbHVnaW5JbXBsZW1lbnRhdGlvbiIKICAgICAgICAgICAgZXhjbHVkZSAiZWxlbWVudC50YWc9PVN5c3RlbSBEZXBlbmRlbmN5IgogICAgICAgICAgICB0aXRsZSAiU2NvcHkgQXJjaGl0ZWN0dXJlIgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiQ29udGFpbmVyIHJlbGF0aW9uc2hpcHMgc2hvd2luZyBob3cgY29yZSBhcHBsaWNhdGlvbiBsb2FkcyBwbHVnaW5zIGZyb20gcGFja2FnZXMiCiAgICAgICAgfQogICAgICAgIAogICAgICAgIC8vIEluZnJhc3RydWN0dXJlIFZpZXcKICAgICAgICBjb21wb25lbnQgc2NvcHlBcHBsaWNhdGlvbiAiSW5mcmFzdHJ1Y3R1cmVDb21wb25lbnRzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgYXBwbGljYXRpb25Db29yZGluYXRvcgogICAgICAgICAgICBpbmNsdWRlIGNyYXNoUmVwb3J0aW5nCiAgICAgICAgICAgIGluY2x1ZGUgdHJhbnNsYXRpb25TZXJ2aWNlCiAgICAgICAgICAgIGluY2x1ZGUgc2NyaXB0aW5nRW5naW5lCiAgICAgICAgICAgIGluY2x1ZGUgcHJlZmVyZW5jZXNNYW5hZ2VtZW50CiAgICAgICAgICAgIGluY2x1ZGUgbG9nZ2luZ1N5c3RlbQogICAgICAgICAgICB0aXRsZSAiSW5mcmFzdHJ1Y3R1cmUgQ29tcG9uZW50cyIKICAgICAgICAgICAgZGVzY3JpcHRpb24gIkNvcmUgYXBwbGljYXRpb24gaW5mcmFzdHJ1Y3R1cmUiCiAgICAgICAgfQoKICAgICAgICAvLyBDb3JlIEJ1c2luZXNzIFZpZXcKICAgICAgICBjb21wb25lbnQgc2NvcHlBcHBsaWNhdGlvbiAiQ29yZUJ1c2luZXNzQ29tcG9uZW50cyIgewogICAgICAgICAgICBpbmNsdWRlIGRldmljZU1hbmFnZW1lbnQKICAgICAgICAgICAgaW5jbHVkZSBwbHVnaW5TeXN0ZW0KICAgICAgICAgICAgaW5jbHVkZSBwYWNrYWdlTWFuYWdlcgogICAgICAgICAgICB0aXRsZSAiQ29yZSBCdXNpbmVzcyBDb21wb25lbnRzIgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiTWFpbiBidXNpbmVzcyBsb2dpYyBjb21wb25lbnRzIgogICAgICAgIH0KCiAgICAgICAgLy8gVUkgTGF5ZXIgVmlldwogICAgICAgIGNvbXBvbmVudCBzY29weUFwcGxpY2F0aW9uICJVSUNvbXBvbmVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSB1aUZyYW1ld29yawogICAgICAgICAgICBpbmNsdWRlIHdpbmRvd01hbmFnZW1lbnQKICAgICAgICAgICAgaW5jbHVkZSB0b29sTWFuYWdlcgogICAgICAgICAgICBpbmNsdWRlIHN0YXR1c0JhcgogICAgICAgICAgICBpbmNsdWRlIGFwcGxpY2F0aW9uUGFnZXMKICAgICAgICAgICAgdGl0bGUgIlVJIENvbXBvbmVudHMiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJVc2VyIGludGVyZmFjZSBsYXllciBjb21wb25lbnRzIgogICAgICAgIH0KCiAgICAgICAgLy8gTGlicmFyeSBWaWV3CiAgICAgICAgY29tcG9uZW50IHNjb3B5QXBwbGljYXRpb24gIkxpYnJhcnlDb21wb25lbnRzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgaWlvVXRpbGl0aWVzCiAgICAgICAgICAgIGluY2x1ZGUgaWlvV2lkZ2V0cwogICAgICAgICAgICBpbmNsdWRlIGdudVJhZGlvV2lkZ2V0cwogICAgICAgICAgICB0aXRsZSAiU3VwcG9ydGluZyBMaWJyYXJpZXMiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJSZXVzYWJsZSBsaWJyYXJ5IGNvbXBvbmVudHMiCiAgICAgICAgfQoKICAgICAgICAvLyBPdmVyYWxsIFZpZXcKICAgICAgICBjb21wb25lbnQgc2NvcHlBcHBsaWNhdGlvbiAiQ29yZUNvbXBvbmVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSBhcHBsaWNhdGlvbkNvb3JkaW5hdG9yCiAgICAgICAgICAgIGluY2x1ZGUgZGV2aWNlTWFuYWdlbWVudAogICAgICAgICAgICBpbmNsdWRlIHBsdWdpblN5c3RlbQogICAgICAgICAgICBpbmNsdWRlIHVpRnJhbWV3b3JrCiAgICAgICAgICAgIGluY2x1ZGUgd2luZG93TWFuYWdlbWVudAogICAgICAgICAgICBpbmNsdWRlIGlpb1V0aWxpdGllcwogICAgICAgICAgICBpbmNsdWRlIHBhY2thZ2VNYW5hZ2VyCiAgICAgICAgICAgIGluY2x1ZGUgdG9vbE1hbmFnZXIKICAgICAgICAgICAgaW5jbHVkZSBnbnVSYWRpb1dpZGdldHMKICAgICAgICAgICAgaW5jbHVkZSBpaW9XaWRnZXRzCiAgICAgICAgICAgIHRpdGxlICJDb21wb25lbnRzIE92ZXJ2aWV3IgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiS2V5IGNvbXBvbmVudHMgYW5kIHRoZWlyIHJlbGF0aW9uc2hpcHMiCiAgICAgICAgfQoKICAgICAgICAvLyBQbHVnaW4gVmlldwogICAgICAgIGNvbXBvbmVudCBzY29weUFwcGxpY2F0aW9uICJQbHVnaW5Db21wb25lbnRzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgcGx1Z2luUmVwb3NpdG9yeQogICAgICAgICAgICBpbmNsdWRlIHBsdWdpbk1hbmFnZXIKICAgICAgICAgICAgaW5jbHVkZSBwbHVnaW5JbnRlcmZhY2UKCiAgICAgICAgICAgIHRpdGxlICJQbHVnaW4gQ29tcG9uZW50cyIKICAgICAgICAgICAgZGVzY3JpcHRpb24gIlBsdWdpbiBzeXN0ZW0gY29tcG9uZW50cyIKICAgICAgICB9CgogICAgICAgIC8vIEdlbmVyaWMtcGx1Z2lucyBQYWNrYWdlCiAgICAgICAgY29tcG9uZW50IGdlbmVyaWNQbHVnaW5zUGFja2FnZSAiR2VuZXJpYy1wbHVnaW5zQ29tcG9uZW50cyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICAgICAgZXhjbHVkZSBzY29weUFwcGxpY2F0aW9uCiAgICAgICAgICAgIGluY2x1ZGUgcGx1Z2luSW50ZXJmYWNlCiAgICAgICAgICAgIGluY2x1ZGUgaWlvV2lkZ2V0cwogICAgICAgICAgICBpbmNsdWRlIGdudVJhZGlvV2lkZ2V0cwogICAgICAgICAgICB0aXRsZSAiR2VuZXJpYy1wbHVnaW5zIFBhY2thZ2UiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgcGx1Z2lucyBmcm9tIGdlbmVyaWMtcGx1Z2lucyBwYWNrYWdlIgogICAgICAgIH0KCiAgICAgICAgLy8gTTJLIFBhY2thZ2UKICAgICAgICBjb21wb25lbnQgbTJrUGFja2FnZSAiTTJLQ29tcG9uZW50cyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICAgICAgZXhjbHVkZSBzY29weUFwcGxpY2F0aW9uCiAgICAgICAgICAgIGluY2x1ZGUgcGx1Z2luSW50ZXJmYWNlCiAgICAgICAgICAgIGluY2x1ZGUgZ251UmFkaW9XaWRnZXRzCiAgICAgICAgICAgIHRpdGxlICJNMksgUGFja2FnZSIKICAgICAgICAgICAgZGVzY3JpcHRpb24gIlRoZSBwbHVnaW5zIGZyb20gTTJLIHBhY2thZ2UiCiAgICAgICAgfQoKICAgICAgICAvLyBTV0lPVCBQYWNrYWdlCiAgICAgICAgY29tcG9uZW50IHN3aW90UGFja2FnZSAiU1dJT1RDb21wb25lbnRzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgKgogICAgICAgICAgICBleGNsdWRlIHNjb3B5QXBwbGljYXRpb24KICAgICAgICAgICAgaW5jbHVkZSBwbHVnaW5JbnRlcmZhY2UKICAgICAgICAgICAgaW5jbHVkZSBpaW9XaWRnZXRzCiAgICAgICAgICAgIHRpdGxlICJTV0lPVCBQYWNrYWdlIgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiVGhlIHBsdWdpbnMgZnJvbSBTV0lPVCBwYWNrYWdlIgogICAgICAgIH0KCiAgICAgICAgLy8gQUQ5MzZYIFBhY2thZ2UKICAgICAgICBjb21wb25lbnQgYWQ5MzZ4UGFja2FnZSAiQUQ5MzZYQ29tcG9uZW50cyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICAgICAgZXhjbHVkZSBzY29weUFwcGxpY2F0aW9uCiAgICAgICAgICAgIGluY2x1ZGUgcGx1Z2luSW50ZXJmYWNlCiAgICAgICAgICAgIGluY2x1ZGUgaWlvV2lkZ2V0cwogICAgICAgICAgICB0aXRsZSAiQUQ5MzZYIFBhY2thZ2UiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgcGx1Z2lucyBmcm9tIEFEOTM2WCBwYWNrYWdlIgogICAgICAgIH0KCiAgICAgICAgLy8gQXBvbGxvIEFEOTA4NCBQYWNrYWdlCiAgICAgICAgY29tcG9uZW50IGFwb2xsb0FkOTA4NFBhY2thZ2UgIkFwb2xsby1BRDkwODRDb21wb25lbnRzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgKgogICAgICAgICAgICBleGNsdWRlIHNjb3B5QXBwbGljYXRpb24KICAgICAgICAgICAgaW5jbHVkZSBwbHVnaW5JbnRlcmZhY2UKICAgICAgICAgICAgaW5jbHVkZSBpaW9XaWRnZXRzCiAgICAgICAgICAgIHRpdGxlICJBcG9sbG8gQUQ5MDg0IFBhY2thZ2UiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgcGx1Z2lucyBmcm9tIEFwb2xsbyBBRDkwODQgcGFja2FnZSIKICAgICAgICB9CgogICAgICAgIC8vIFBRTW9uIFBhY2thZ2UKICAgICAgICBjb21wb25lbnQgcHFtb25QYWNrYWdlICJQUU1vbkNvbXBvbmVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGV4Y2x1ZGUgc2NvcHlBcHBsaWNhdGlvbgogICAgICAgICAgICBpbmNsdWRlIHBsdWdpbkludGVyZmFjZQogICAgICAgICAgICB0aXRsZSAiUFFNb24gUGFja2FnZSIKICAgICAgICAgICAgZGVzY3JpcHRpb24gIlRoZSBwbHVnaW5zIGZyb20gUFFNb24gcGFja2FnZSIKICAgICAgICB9CgogICAgICAgIC8vIElNVSBQYWNrYWdlCiAgICAgICAgY29tcG9uZW50IGltdVBhY2thZ2UgIklNVUNvbXBvbmVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGV4Y2x1ZGUgc2NvcHlBcHBsaWNhdGlvbgogICAgICAgICAgICBpbmNsdWRlIHBsdWdpbkludGVyZmFjZQogICAgICAgICAgICBpbmNsdWRlIGlpb1dpZGdldHMKICAgICAgICAgICAgdGl0bGUgIklNVSBQYWNrYWdlIgogICAgICAgICAgICBkZXNjcmlwdGlvbiAiVGhlIHBsdWdpbnMgZnJvbSBJTVUgcGFja2FnZSIKICAgICAgICB9CgogICAgICAgIC8vIEFEUlY5MDAyIFBhY2thZ2UKICAgICAgICBjb21wb25lbnQgYWRydjkwMDJQYWNrYWdlICJBRFJWOTAwMkNvbXBvbmVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGV4Y2x1ZGUgc2NvcHlBcHBsaWNhdGlvbgogICAgICAgICAgICBpbmNsdWRlIHBsdWdpbkludGVyZmFjZQogICAgICAgICAgICBpbmNsdWRlIGlpb1dpZGdldHMKICAgICAgICAgICAgdGl0bGUgIkFEUlY5MDAyIFBhY2thZ2UiCiAgICAgICAgICAgIGRlc2NyaXB0aW9uICJUaGUgcGx1Z2lucyBmcm9tIEFEUlY5MDAyIHBhY2thZ2UiCiAgICAgICAgfQoKCiAgICAgICAgc3R5bGVzIHsgICAgICAgICAgICAKICAgICAgICAgICAgZWxlbWVudCAiU2NvcHkgU3lzdGVtIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICIjMDA3N2I2IgogICAgICAgICAgICAgICAgY29sb3IgIldoaXRlIgogICAgICAgICAgICB9CiAgICAgICAgICAgIAogICAgICAgICAgICBlbGVtZW50ICJDb250YWluZXIiIHsKICAgICAgICAgICAgICAgIGJhY2tncm91bmQgIiMwMDc3YjYiCiAgICAgICAgICAgICAgICBjb2xvciAiV2hpdGUiCiAgICAgICAgICAgIH0KICAgICAgICAgICAgCiAgICAgICAgICAgIGVsZW1lbnQgIlBlcnNvbiIgewogICAgICAgICAgICAgICAgc2hhcGUgIlBlcnNvbiIKICAgICAgICAgICAgICAgIGJhY2tncm91bmQgIiMwMjMwNDciCiAgICAgICAgICAgICAgICBjb2xvciAiV2hpdGUiCiAgICAgICAgICAgIH0KICAgICAgICAgICAgCiAgICAgICAgICAgIGVsZW1lbnQgIkluZnJhc3RydWN0dXJlIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICNmZjZiNmIKICAgICAgICAgICAgICAgIGNvbG9yICJCbGFjayIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgZWxlbWVudCAiQ29yZUJ1c2luZXNzIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICM0ZWNkYzQKICAgICAgICAgICAgICAgIGNvbG9yICJCbGFjayIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgZWxlbWVudCAiUHJlc2VudGF0aW9uIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICNmOWNhMjQKICAgICAgICAgICAgICAgIGNvbG9yICJCbGFjayIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgZWxlbWVudCAiTGlicmFyeSIgewogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjNmM1Y2U3CiAgICAgICAgICAgICAgICBjb2xvciAiQmxhY2siCiAgICAgICAgICAgIH0KICAgICAgICAgICAgCiAgICAgICAgICAgIGVsZW1lbnQgIlBsdWdpblN5c3RlbSIgewogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAiIzAwODk3YiIKICAgICAgICAgICAgICAgIGNvbG9yICJCbGFjayIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgZWxlbWVudCAiUGx1Z2luIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICIjZmZiODZiIgogICAgICAgICAgICAgICAgY29sb3IgIkJsYWNrIgogICAgICAgICAgICB9CiAgICAgICAgICAgIAogICAgICAgICAgICBlbGVtZW50ICJTeXN0ZW0gRGVwZW5kZW5jeSIgewogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAiI2UwZTBlMCIKICAgICAgICAgICAgICAgIGNvbG9yICIjNjY2NjY2IgogICAgICAgICAgICAgICAgb3BhY2l0eSA1MAogICAgICAgICAgICB9CiAgICAgICAgfQogICAgfQoKfQ=="
+  },
+  "views" : {
+    "componentViews" : [ {
+      "containerId" : "10",
+      "description" : "Core application infrastructure",
+      "dimensions" : {
+        "height" : 1631,
+        "width" : 2640
+      },
+      "elements" : [ {
+        "id" : "11",
+        "x" : 1095,
+        "y" : 203
+      }, {
+        "id" : "12",
+        "x" : 830,
+        "y" : 788
+      }, {
+        "id" : "14",
+        "x" : 1925,
+        "y" : 208
+      }, {
+        "id" : "15",
+        "x" : 1930,
+        "y" : 788
+      }, {
+        "id" : "16",
+        "x" : 260,
+        "y" : 793
+      }, {
+        "id" : "17",
+        "x" : 1380,
+        "y" : 788
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "InfrastructureComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 3,
+      "relationships" : [ {
+        "id" : "34"
+      }, {
+        "id" : "35"
+      }, {
+        "id" : "36"
+      }, {
+        "id" : "37"
+      }, {
+        "id" : "46"
+      } ],
+      "title" : "Infrastructure Components"
+    }, {
+      "containerId" : "10",
+      "description" : "Main business logic components",
+      "dimensions" : {
+        "height" : 1566,
+        "width" : 1750
+      },
+      "elements" : [ {
+        "id" : "18",
+        "x" : 259,
+        "y" : 203
+      }, {
+        "id" : "19",
+        "x" : 1039,
+        "y" : 718
+      }, {
+        "id" : "20",
+        "x" : 259,
+        "y" : 728
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "CoreBusinessComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 4,
+      "relationships" : [ {
+        "id" : "49"
+      }, {
+        "id" : "50"
+      } ],
+      "title" : "Core Business Components"
+    }, {
+      "containerId" : "10",
+      "description" : "User interface layer components",
+      "dimensions" : {
+        "height" : 2134,
+        "width" : 1720
+      },
+      "elements" : [ {
+        "id" : "26",
+        "x" : 1010,
+        "y" : 816
+      }, {
+        "id" : "27",
+        "x" : 260,
+        "y" : 816
+      }, {
+        "id" : "28",
+        "x" : 263,
+        "y" : 206
+      }, {
+        "id" : "29",
+        "x" : 1008,
+        "y" : 1296
+      }, {
+        "id" : "30",
+        "x" : 1010,
+        "y" : 203
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "UIComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 5,
+      "relationships" : [ {
+        "id" : "56"
+      }, {
+        "id" : "58",
+        "vertices" : [ {
+          "x" : 1103,
+          "y" : 651
+        } ]
+      }, {
+        "id" : "59"
+      }, {
+        "id" : "61",
+        "vertices" : [ {
+          "x" : 583,
+          "y" : 656
+        } ]
+      }, {
+        "id" : "64"
+      }, {
+        "id" : "65",
+        "vertices" : [ {
+          "x" : 1235,
+          "y" : 557
+        }, {
+          "x" : 1235,
+          "y" : 761
+        } ]
+      } ],
+      "title" : "UI Components"
+    }, {
+      "containerId" : "10",
+      "description" : "Reusable library components",
+      "dimensions" : {
+        "height" : 1654,
+        "width" : 1720
+      },
+      "elements" : [ {
+        "id" : "31",
+        "x" : 260,
+        "y" : 815
+      }, {
+        "id" : "32",
+        "x" : 1010,
+        "y" : 815
+      }, {
+        "id" : "33",
+        "x" : 1010,
+        "y" : 202
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "LibraryComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 6,
+      "relationships" : [ {
+        "id" : "68"
+      } ],
+      "title" : "Supporting Libraries"
+    }, {
+      "containerId" : "10",
+      "description" : "Key components and their relationships",
+      "dimensions" : {
+        "height" : 2908,
+        "width" : 2662
+      },
+      "elements" : [ {
+        "id" : "11",
+        "x" : 1140,
+        "y" : 1255
+      }, {
+        "id" : "18",
+        "x" : 292,
+        "y" : 1248
+      }, {
+        "id" : "19",
+        "x" : 1876,
+        "y" : 1235
+      }, {
+        "id" : "20",
+        "x" : 1137,
+        "y" : 663
+      }, {
+        "id" : "26",
+        "x" : 1875,
+        "y" : 2060
+      }, {
+        "id" : "27",
+        "x" : 1150,
+        "y" : 2080
+      }, {
+        "id" : "28",
+        "x" : 290,
+        "y" : 1610
+      }, {
+        "id" : "31",
+        "x" : 1947,
+        "y" : 213
+      }, {
+        "id" : "32",
+        "x" : 1952,
+        "y" : 693
+      }, {
+        "id" : "33",
+        "x" : 1147,
+        "y" : 203
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "CoreComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 7,
+      "relationships" : [ {
+        "id" : "38"
+      }, {
+        "id" : "39"
+      }, {
+        "id" : "40"
+      }, {
+        "id" : "41"
+      }, {
+        "id" : "49"
+      }, {
+        "id" : "50"
+      }, {
+        "id" : "53"
+      }, {
+        "id" : "54"
+      }, {
+        "id" : "55"
+      }, {
+        "id" : "56"
+      }, {
+        "id" : "59",
+        "vertices" : [ {
+          "x" : 1270,
+          "y" : 2050
+        }, {
+          "x" : 1265,
+          "y" : 1940
+        }, {
+          "x" : 885,
+          "y" : 1770
+        } ]
+      }, {
+        "id" : "60",
+        "vertices" : [ {
+          "x" : 282,
+          "y" : 1808
+        }, {
+          "x" : 287,
+          "y" : 818
+        } ]
+      }, {
+        "id" : "61",
+        "vertices" : [ {
+          "x" : 525,
+          "y" : 2505
+        }, {
+          "x" : 2100,
+          "y" : 2505
+        } ]
+      }, {
+        "id" : "67"
+      }, {
+        "id" : "68"
+      }, {
+        "id" : "69",
+        "vertices" : [ {
+          "x" : 2372,
+          "y" : 1163
+        }, {
+          "x" : 2375,
+          "y" : 1690
+        } ]
+      } ],
+      "title" : "Components Overview"
+    }, {
+      "containerId" : "10",
+      "description" : "Plugin system components",
+      "dimensions" : {
+        "height" : 1594,
+        "width" : 1659
+      },
+      "elements" : [ {
+        "id" : "21",
+        "x" : 949,
+        "y" : 755
+      }, {
+        "id" : "22",
+        "x" : 265,
+        "y" : 747
+      }, {
+        "id" : "23",
+        "x" : 260,
+        "y" : 202
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "PluginComponents",
+      "name" : "Component View: Scopy - Scopy Application",
+      "order" : 8,
+      "relationships" : [ {
+        "id" : "24"
+      }, {
+        "id" : "25"
+      } ],
+      "title" : "Plugin Components"
+    }, {
+      "containerId" : "70",
+      "description" : "The plugins from generic-plugins package",
+      "dimensions" : {
+        "height" : 1921,
+        "width" : 5600
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 1514,
+        "y" : 1082
+      }, {
+        "id" : "32",
+        "x" : 3989,
+        "y" : 1082
+      }, {
+        "id" : "33",
+        "x" : 4889,
+        "y" : 1082
+      }, {
+        "id" : "71",
+        "x" : 4364,
+        "y" : 182
+      }, {
+        "id" : "72",
+        "x" : 3239,
+        "y" : 182
+      }, {
+        "id" : "73",
+        "x" : 2489,
+        "y" : 182
+      }, {
+        "id" : "74",
+        "x" : 1739,
+        "y" : 182
+      }, {
+        "id" : "75",
+        "x" : 989,
+        "y" : 182
+      }, {
+        "id" : "76",
+        "x" : 239,
+        "y" : 182
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "Generic-pluginsComponents",
+      "name" : "Component View: Scopy - Generic Plugins Package",
+      "order" : 9,
+      "relationships" : [ {
+        "id" : "77"
+      }, {
+        "id" : "81"
+      }, {
+        "id" : "83"
+      }, {
+        "id" : "85"
+      }, {
+        "id" : "87"
+      }, {
+        "id" : "88"
+      }, {
+        "id" : "90"
+      }, {
+        "id" : "91"
+      }, {
+        "id" : "93"
+      }, {
+        "id" : "94"
+      }, {
+        "id" : "96"
+      } ],
+      "title" : "Generic-plugins Package"
+    }, {
+      "containerId" : "98",
+      "description" : "The plugins from M2K package",
+      "dimensions" : {
+        "height" : 1641,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 989,
+        "y" : 202
+      }, {
+        "id" : "33",
+        "x" : 989,
+        "y" : 802
+      }, {
+        "id" : "99",
+        "x" : 239,
+        "y" : 502
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "M2KComponents",
+      "name" : "Component View: Scopy - M2K Package",
+      "order" : 10,
+      "relationships" : [ {
+        "id" : "100"
+      }, {
+        "id" : "104"
+      } ],
+      "title" : "M2K Package"
+    }, {
+      "containerId" : "106",
+      "description" : "The plugins from SWIOT package",
+      "dimensions" : {
+        "height" : 1641,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 989,
+        "y" : 202
+      }, {
+        "id" : "32",
+        "x" : 989,
+        "y" : 802
+      }, {
+        "id" : "107",
+        "x" : 239,
+        "y" : 502
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "SWIOTComponents",
+      "name" : "Component View: Scopy - SWIOT Package",
+      "order" : 11,
+      "relationships" : [ {
+        "id" : "108"
+      }, {
+        "id" : "112"
+      } ],
+      "title" : "SWIOT Package"
+    }, {
+      "containerId" : "114",
+      "description" : "The plugins from AD936X package",
+      "dimensions" : {
+        "height" : 1641,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 989,
+        "y" : 202
+      }, {
+        "id" : "32",
+        "x" : 989,
+        "y" : 802
+      }, {
+        "id" : "115",
+        "x" : 239,
+        "y" : 502
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "AD936XComponents",
+      "name" : "Component View: Scopy - AD936X Package",
+      "order" : 12,
+      "relationships" : [ {
+        "id" : "116"
+      }, {
+        "id" : "120"
+      } ],
+      "title" : "AD936X Package"
+    }, {
+      "containerId" : "122",
+      "description" : "The plugins from Apollo AD9084 package",
+      "dimensions" : {
+        "height" : 1641,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 989,
+        "y" : 202
+      }, {
+        "id" : "32",
+        "x" : 989,
+        "y" : 802
+      }, {
+        "id" : "123",
+        "x" : 239,
+        "y" : 502
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "Apollo-AD9084Components",
+      "name" : "Component View: Scopy - Apollo AD9084 Package",
+      "order" : 13,
+      "relationships" : [ {
+        "id" : "124"
+      }, {
+        "id" : "128"
+      } ],
+      "title" : "Apollo AD9084 Package"
+    }, {
+      "containerId" : "130",
+      "description" : "The plugins from PQMon package",
+      "dimensions" : {
+        "height" : 1041,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 990,
+        "y" : 203
+      }, {
+        "id" : "131",
+        "x" : 240,
+        "y" : 203
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "PQMonComponents",
+      "name" : "Component View: Scopy - PQMon Package",
+      "order" : 14,
+      "relationships" : [ {
+        "id" : "132"
+      } ],
+      "title" : "PQMon Package"
+    }, {
+      "containerId" : "136",
+      "description" : "The plugins from IMU package",
+      "dimensions" : {
+        "height" : 1641,
+        "width" : 1700
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 989,
+        "y" : 202
+      }, {
+        "id" : "32",
+        "x" : 989,
+        "y" : 802
+      }, {
+        "id" : "137",
+        "x" : 239,
+        "y" : 502
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "IMUComponents",
+      "name" : "Component View: Scopy - IMU Package",
+      "order" : 15,
+      "relationships" : [ {
+        "id" : "138"
+      }, {
+        "id" : "142"
+      } ],
+      "title" : "IMU Package"
+    }, {
+      "containerId" : "144",
+      "description" : "The plugins from ADRV9002 package",
+      "dimensions" : {
+        "height" : 1654,
+        "width" : 1746
+      },
+      "elements" : [ {
+        "id" : "23",
+        "x" : 1035,
+        "y" : 816
+      }, {
+        "id" : "32",
+        "x" : 1035,
+        "y" : 203
+      }, {
+        "id" : "145",
+        "x" : 239,
+        "y" : 511
+      } ],
+      "externalContainerBoundariesVisible" : false,
+      "key" : "ADRV9002Components",
+      "name" : "Component View: Scopy - ADRV9002 Package",
+      "order" : 16,
+      "relationships" : [ {
+        "id" : "146"
+      }, {
+        "id" : "150"
+      } ],
+      "title" : "ADRV9002 Package"
+    } ],
+    "configuration" : {
+      "branding" : { },
+      "lastSavedView" : "CoreComponents",
+      "metadataSymbols" : "SquareBrackets",
+      "styles" : {
+        "elements" : [ {
+          "background" : "#0077b6",
+          "color" : "#ffffff",
+          "tag" : "Container"
+        }, {
+          "background" : "#4ecdc4",
+          "color" : "#000000",
+          "tag" : "CoreBusiness"
+        }, {
+          "background" : "#ff6b6b",
+          "color" : "#000000",
+          "tag" : "Infrastructure"
+        }, {
+          "background" : "#6c5ce7",
+          "color" : "#000000",
+          "tag" : "Library"
+        }, {
+          "background" : "#023047",
+          "color" : "#ffffff",
+          "shape" : "Person",
+          "tag" : "Person"
+        }, {
+          "background" : "#ffb86b",
+          "color" : "#000000",
+          "tag" : "Plugin"
+        }, {
+          "background" : "#00897b",
+          "color" : "#000000",
+          "tag" : "PluginSystem"
+        }, {
+          "background" : "#f9ca24",
+          "color" : "#000000",
+          "tag" : "Presentation"
+        }, {
+          "background" : "#0077b6",
+          "color" : "#ffffff",
+          "tag" : "Scopy System"
+        }, {
+          "background" : "#e0e0e0",
+          "color" : "#666666",
+          "opacity" : 50,
+          "tag" : "System Dependency"
+        } ]
+      },
+      "terminology" : { }
+    },
+    "containerViews" : [ {
+      "description" : "Container relationships showing how core application loads plugins from packages",
+      "dimensions" : {
+        "height" : 2219,
+        "width" : 2480
+      },
+      "elements" : [ {
+        "id" : "1",
+        "x" : 684,
+        "y" : 142
+      }, {
+        "id" : "2",
+        "x" : 1324,
+        "y" : 142
+      }, {
+        "id" : "10",
+        "x" : 1069,
+        "y" : 930
+      }, {
+        "id" : "70",
+        "x" : 219,
+        "y" : 847
+      }, {
+        "id" : "98",
+        "x" : 219,
+        "y" : 1197
+      }, {
+        "id" : "106",
+        "x" : 229,
+        "y" : 1562
+      }, {
+        "id" : "114",
+        "x" : 769,
+        "y" : 1562
+      }, {
+        "id" : "122",
+        "x" : 1799,
+        "y" : 1560
+      }, {
+        "id" : "130",
+        "x" : 1804,
+        "y" : 1202
+      }, {
+        "id" : "136",
+        "x" : 1809,
+        "y" : 852
+      }, {
+        "id" : "144",
+        "x" : 1289,
+        "y" : 1562
+      } ],
+      "externalSoftwareSystemBoundariesVisible" : false,
+      "key" : "ContainerView",
+      "name" : "Container View: Scopy",
+      "order" : 2,
+      "relationships" : [ {
+        "id" : "152"
+      }, {
+        "id" : "154"
+      }, {
+        "id" : "166"
+      }, {
+        "id" : "167"
+      }, {
+        "id" : "168"
+      }, {
+        "id" : "169"
+      }, {
+        "id" : "170"
+      }, {
+        "id" : "171"
+      }, {
+        "id" : "172"
+      }, {
+        "id" : "173"
+      } ],
+      "softwareSystemId" : "9",
+      "title" : "Scopy Architecture"
+    } ],
+    "systemContextViews" : [ {
+      "description" : "High-level view showing Scopy's interactions with users and external systems",
+      "dimensions" : {
+        "height" : 1882,
+        "width" : 2575
+      },
+      "elements" : [ {
+        "id" : "1",
+        "x" : 614,
+        "y" : 142
+      }, {
+        "id" : "2",
+        "x" : 1299,
+        "y" : 177
+      }, {
+        "id" : "3",
+        "x" : 1344,
+        "y" : 1319
+      }, {
+        "id" : "4",
+        "x" : 1919,
+        "y" : 1324
+      }, {
+        "id" : "5",
+        "x" : 1924,
+        "y" : 844
+      }, {
+        "id" : "6",
+        "x" : 199,
+        "y" : 849
+      }, {
+        "id" : "7",
+        "x" : 199,
+        "y" : 1324
+      }, {
+        "id" : "8",
+        "x" : 744,
+        "y" : 1324
+      }, {
+        "id" : "9",
+        "x" : 1009,
+        "y" : 817
+      } ],
+      "enterpriseBoundaryVisible" : true,
+      "key" : "SystemContext",
+      "name" : "System Context View: Scopy",
+      "order" : 1,
+      "relationships" : [ {
+        "id" : "153"
+      }, {
+        "id" : "155"
+      }, {
+        "id" : "157"
+      }, {
+        "id" : "159"
+      }, {
+        "id" : "161"
+      }, {
+        "id" : "163"
+      }, {
+        "id" : "165"
+      }, {
+        "id" : "174"
+      } ],
+      "softwareSystemId" : "9",
+      "title" : "Scopy"
+    } ]
+  }
+}

--- a/docs/architecture/diagrams/deployment_diagrams/workspace.dsl
+++ b/docs/architecture/diagrams/deployment_diagrams/workspace.dsl
@@ -1,0 +1,311 @@
+workspace "Scopy Deployment Architecture" "CI/CD and deployment architecture for Scopy multi-platform builds" {
+
+    model {
+        # External systems
+        github = softwareSystem "GitHub" "Source code repository" "External"
+        dockerhub = softwareSystem "Docker Hub" "Container image registry" "External"
+        artifactStore = softwareSystem "GitHub Releases" "Artifact storage and distribution" "External"
+
+        # Main software system
+        scopy = softwareSystem "Scopy" "Signal analysis and device control software for ADI hardware" {
+            # Core application
+            scopyApp = container "Scopy Application" "Main Qt-based GUI application" "C++/Qt"
+
+            # Dependencies
+            libiio = container "libiio" "Industrial I/O library for ADI hardware" "C"
+            gnuradio = container "GNU Radio" "Signal processing framework" "C++/Python"
+            libm2k = container "libm2k" "ADALM2000 support library" "C++"
+            qwt = container "Qwt" "Technical plotting widgets" "C++/Qt"
+            libsigrok = container "libsigrokdecode" "Protocol decoder library" "C"
+        }
+
+        # CI/CD Platform 
+        cicdPlatform = softwareSystem "CI/CD Platform" "CI/CD platform orchestration layer" {
+            # GitHub Actions Platform
+            githubActions = container "GitHub Actions" "GitHub-hosted CI/CD runners and workflow execution" "GitHub Platform" 
+            azureDevOps = container "Azure DevOps" "Microsoft cloud CI/CD platform" "Azure Platform"
+        }
+
+        # CI/CD Infrastructure
+        cicd = softwareSystem "CI/CD Infrastructure" "Continuous integration and deployment system" {
+
+            # GitHub Actions workflows
+            windowsWorkflow = container "Windows MinGW Workflow" "Builds Windows installer" "GitHub Actions"
+            linuxFlatpakWorkflow = container "Linux Flatpak Workflow" "Builds Flatpak package" "GitHub Actions"
+            linuxAppImageWorkflow = container "Linux AppImage Workflow" "Builds AppImage packages" "GitHub Actions"
+            arm64Workflow = container "ARM64 Build Workflow" "Cross-compiles for ARM64 platforms" "GitHub Actions"
+            armhfWorkflow = container "ARMHF Build Workflow" "Cross-compiles for ARMHF platforms" "GitHub Actions"
+            ubuntuWorkflow = container "Ubuntu Workflow" "Build on ubuntu" "GitHub Actions"
+            macosWorkflow = container "macOS Build Workflow" "Builds macOS DMG package" "Azure DevOps"
+        }
+
+        # Docker Build Environments
+        dockerInfra = softwareSystem "Docker Build Infrastructure" "Pre-configured build environments" {
+            mingwContainer = container "mingw64 container" "Windows build environment with MSYS2" "cristianbindea/scopy2-mingw64"
+            flatpakContainer = container "flatpak container" "Linux Flatpak build environment" "cristianbindea/scopy2-flatpak"
+            x86Container = container "x86_64-appimage container" "x86_64 AppImage build environment" "cristianbindea/scopy2-x86_64-appimage"
+            arm64Container = container "arm64-appimage container" "ARM64 cross-compilation environment" "cristianbindea/scopy2-arm64-appimage"
+            armhfContainer = container "armhf-appimage container" "ARMHF cross-compilation environment" "cristianbindea/scopy2-armhf-appimage"
+            ubuntuContainer = container "ubuntu-22 container" "Development build environment" "cristianbindea/scopy2-ubuntu22"
+        }
+
+        # Build Scripts and Configuration
+        buildScripts = softwareSystem "Build Scripts" "Platform-specific build automation" {
+            windowsScript = container "Windows Build Script" "MSYS2/MinGW build process" "ci/windows/windows_build_process.sh"
+            flatpakScript = container "Flatpak Build Script" "Sandboxed Flatpak build" "ci/flatpak/flatpak_build_process.sh"
+            appimageScript = container "AppImage Build Script" "AppImage packaging process" "ci/x86_64/x86-64_appimage_process.sh"
+            arm64Script = container "ARM64 Build Script" "Cross-compilation for ARM64" "ci/arm64/arm64_build_process.sh"
+            armhfScript = container "ARMHF Build Script" "Cross-compilation for ARMHF" "ci/armhf/armhf_build_process.sh"
+            ubuntuScript = container "Ubuntu Build Script" "Ubuntu development builds" "ci/ubuntu/ubuntu_build_process.sh"
+            macosScript = container "macOS Build Script" "Homebrew-based macOS build" "ci/macOS/build_azure_macos.sh"
+        }
+
+        # Deployment targets
+        deploymentTargets = softwareSystem "Deployment Targets" "Final deployment destinations" {
+            windowsInstaller = container "Windows Installer" "Scopy Windows setup executable" ".exe"
+            linuxFlatpak = container "Linux Flatpak" "Sandboxed Linux package" ".flatpak"
+            linuxAppImage = container "Linux AppImage" "Portable Linux application" ".AppImage"
+            arm64AppImage = container "ARM64 AppImage" "ARM64 portable application" ".AppImage"
+            armhfAppImage = container "ARMHF AppImage" "ARMHF portable application" ".AppImage"
+            ubuntuPackage = container "Ubuntu build" "Development build" "test build"
+            macosDMG = container "macOS DMG" "macOS disk image package" ".dmg"
+        }
+
+        # GitHub triggers individual workflows
+        github -> githubActions "Triggers on push/PR"
+        github -> azureDevOps "Triggers on push/PR"
+        githubActions -> windowsWorkflow "Runs"
+        githubActions -> linuxFlatpakWorkflow "Runs"
+        githubActions -> linuxAppImageWorkflow "Runs"
+        githubActions -> arm64Workflow "Runs"
+        githubActions -> armhfWorkflow "Runs"
+        githubActions -> ubuntuWorkflow "Runs"
+        azureDevOps -> macosWorkflow "Runs"
+
+
+        # Workflow relationships
+        cicd -> dockerhub "Pulls container images"
+        windowsWorkflow -> dockerhub "Pulls MinGW container"
+        linuxFlatpakWorkflow -> dockerhub "Pulls Flatpak container"
+        linuxAppImageWorkflow -> dockerhub "Pulls AppImage container"
+        arm64Workflow -> dockerhub "Pulls ARM64 container"
+        armhfWorkflow -> dockerhub "Pulls ARMHF container"
+        ubuntuWorkflow -> dockerhub "Pulls Ubuntu container"
+        dockerInfra -> buildScripts "Executes"
+
+        windowsWorkflow -> mingwContainer "Uses"
+        linuxFlatpakWorkflow -> flatpakContainer "Uses"
+        linuxAppImageWorkflow -> x86Container "Uses"
+        arm64Workflow -> arm64Container "Uses"
+        armhfWorkflow -> armhfContainer "Uses"
+        ubuntuWorkflow -> ubuntuContainer "Uses"
+
+
+        mingwContainer -> windowsScript "Executes"
+        flatpakContainer -> flatpakScript "Executes"
+        x86Container -> appimageScript "Executes"
+        arm64Container -> arm64Script "Executes"
+        armhfContainer -> armhfScript "Executes"
+        ubuntuContainer -> ubuntuScript "Executes"
+       
+        # Build script execution
+        macosWorkflow -> macosScript "Executes" {
+            tag "workflow"
+        }
+
+
+        # Build outputs
+        ubuntuScript -> ubuntuPackage "Generates"
+        windowsScript -> windowsInstaller "Generates"
+        flatpakScript -> linuxFlatpak "Generates"
+        appimageScript -> linuxAppImage "Generates"
+        arm64Script -> arm64AppImage "Generates"
+        armhfScript -> armhfAppImage "Generates"
+        macosScript -> macosDMG "Generates"
+
+        # Artifact storage
+        windowsInstaller -> artifactStore "Uploads to (continuous release)"
+        linuxFlatpak -> artifactStore "Uploads to (continuous release)"
+        linuxAppImage -> artifactStore "Uploads to (artifacts)"
+        arm64AppImage -> artifactStore "Uploads to (artifacts)"
+        armhfAppImage -> artifactStore "Uploads to (artifacts)"
+        macosDMG -> artifactStore "Uploads to (artifacts)"
+
+        # Dependencies within Scopy
+        scopyApp -> libiio "Uses for hardware communication"
+        scopyApp -> gnuradio "Uses for signal processing"
+        scopyApp -> libm2k "Uses for ADALM2000 support"
+        scopyApp -> qwt "Uses for plotting"
+        scopyApp -> libsigrok "Uses for protocol decoding"
+
+
+        # Users
+        developer = person "Developer" "Scopy developer"
+        endUser = person "End User" "Engineer using Scopy for signal analysis"
+
+        developer -> github "Commits code"
+        developer -> scopy "Develops"
+        endUser -> artifactStore "Downloads"
+
+        # Deployment environments
+        buildEnvironment = deploymentEnvironment "Multi-Platform Build Environment" {
+            deploymentNode "GitHub Actions Infrastructure" "GitHub-hosted CI/CD platform" "GitHub Actions" {
+                deploymentNode "Windows Runner" "Windows 2022" "Microsoft Windows" {
+                    deploymentNode "MinGW Docker Container" "cristianbindea/scopy2-mingw64" "MSYS2/MinGW64" {
+                        containerInstance windowsScript
+                        containerInstance scopyApp "Windows Build"
+                    }
+                }
+                deploymentNode "Linux Runner" "Ubuntu 22.04" "Ubuntu Linux" {
+                    deploymentNode "Flatpak Container" "cristianbindea/scopy2-flatpak" "Flatpak Runtime" {
+                        containerInstance flatpakScript
+                        containerInstance scopyApp "Flatpak Build"
+                    }
+                    deploymentNode "AppImage Container" "cristianbindea/scopy2-x86_64-appimage" "Ubuntu Container" {
+                        containerInstance appimageScript
+                        containerInstance scopyApp "AppImage Build"
+                    }
+                    deploymentNode "Ubuntu Container" "cristianbindea/scopy2-ubuntu" "Development Environment" {
+                        containerInstance ubuntuScript
+                        containerInstance scopyApp "Ubuntu Build"
+                    }
+                    deploymentNode "ARM64 Container" "cristianbindea/scopy2-arm64-appimage" "Cross-compilation" {
+                        deploymentNode "ARM64 Sysroot" "aarch64-linux-gnu" "Chroot Environment" {
+                            containerInstance arm64Script "ARM64 Build"
+                            containerInstance scopyApp "ARM64 Binary"
+                        }
+                    }
+                    deploymentNode "ARMHF Container" "cristianbindea/scopy2-armhf-appimage" "Cross-compilation" {
+                        deploymentNode "ARMHF Sysroot" "arm-linux-gnueabihf" "Chroot Environment" {
+                            containerInstance armhfScript "ARMHF Build"
+                            containerInstance scopyApp "ARMHF Binary"
+                        }
+                    }
+                }
+            }
+            deploymentNode "Azure DevOps Infrastructure" "Microsoft cloud CI/CD platform" "Azure DevOps" {
+                deploymentNode "macOS Agent" "macOS" "macOS x86_64" {
+                    deploymentNode "Homebrew Environment" "Package Manager" "macOS Native" {
+                        containerInstance macosScript
+                        containerInstance scopyApp "macOS Build"
+                    }
+                }
+            }
+        }
+
+        distributionEnvironment = deploymentEnvironment "Artifact Distribution Environment" {
+            deploymentNode "GitHub Releases" "Artifact Storage and Distribution" "GitHub" {
+                containerInstance windowsInstaller
+                containerInstance linuxFlatpak
+                containerInstance linuxAppImage
+                containerInstance arm64AppImage
+                containerInstance armhfAppImage
+                containerInstance ubuntuPackage
+                containerInstance macosDMG
+            }
+        }
+    }
+
+    views {
+        systemLandscape "SystemLandscape" "Overall Scopy deployment ecosystem" {
+            include *
+            exclude "relationship.tag==workflow"
+        }
+
+        container cicdPlatform "CICDPlatform" "CI/CD running platforms" {
+            include *
+        }
+
+        container cicd "CICDContainers" "CI/CD workflow containers" {
+            include *
+            exclude cicdPlatform
+            include githubActions azureDevOps
+        }
+
+        container deploymentTargets "DeploymentTargets" "Final deployment artifacts" {
+            include *
+        }
+
+        deployment scopy buildEnvironment "BuildDeployment" "Multi-platform build infrastructure showing all compilation environments" {
+            include *
+        }
+
+        deployment * distributionEnvironment "ArtifactDistribution" "Final artifact distribution showing all generated packages" {
+            include *
+        }
+
+        dynamic cicd "BuildProcess" "Build process flow" {
+            developer -> github "Push code"
+
+            github -> githubActions "triggers GitHub Actions workflows"
+            github -> azureDevOps "triggers Azure workflows"
+
+            githubActions -> windowsWorkflow "Trigger Windows build"
+            githubActions -> linuxFlatpakWorkflow "Trigger Linux builds"
+            githubActions -> linuxAppImageWorkflow "Trigger Linux AppImage builds"
+            githubActions -> ubuntuWorkflow "Trigger Ubuntu builds"
+            githubActions -> arm64Workflow "Trigger ARM64 builds"
+            githubActions -> armhfWorkflow "Trigger ARMHF builds"
+            azureDevOps -> macosWorkflow "Trigger MacOS builds"
+
+            windowsWorkflow -> mingwContainer "Uses"
+            mingwContainer -> windowsScript "Execute Windows build"
+            linuxFlatpakWorkflow -> flatpakContainer "Uses"
+            flatpakContainer -> flatpakScript "Execute Flatpak build"
+            linuxAppImageWorkflow -> x86Container "Uses"
+            x86Container -> appimageScript "Execute AppImage build"
+            ubuntuWorkflow -> ubuntuContainer "Uses"
+            ubuntuContainer -> ubuntuScript "Execute Ubuntu build"
+            arm64Workflow -> arm64Container "Uses"
+            arm64Container -> arm64Script "Execute ARM64 builds"
+            armhfWorkflow -> armhfContainer "Uses"
+            armhfContainer -> armhfScript "Execute ARMHF builds"
+            macosWorkflow -> macosScript "Execute macOS build"
+            
+            windowsScript -> windowsInstaller "Generate installer"
+            appimageScript -> linuxAppImage "Generate AppImage"
+            ubuntuScript -> ubuntuPackage "Generate Ubuntu build"
+            flatpakScript -> linuxFlatpak "Generate Flatpak"
+            arm64Script -> arm64AppImage "Generate ARM64 AppImage"
+            armhfScript -> armhfAppImage "Generate ARMHF AppImage"
+            macosScript -> macosDMG "Generate DMG"
+            
+            windowsInstaller -> artifactStore "Upload artifacts"
+            linuxAppImage -> artifactStore "Upload artifacts"
+            arm64AppImage -> artifactStore "Upload artifacts"
+            armhfAppImage -> artifactStore "Upload artifacts"
+            linuxFlatpak -> artifactStore "Upload artifacts"
+            macosDMG -> artifactStore "Upload macOS artifacts"
+            
+        }
+
+        styles {
+            element "Software System" {
+                background #1168bd
+                color #ffffff
+                shape RoundedBox
+            }
+            element "Container" {
+                background #438dd5
+                color #ffffff
+                shape RoundedBox
+            }
+            element "Person" {
+                background #08427b
+                color #ffffff
+                shape Person
+            }
+            element "External" {
+                background #999999
+                color #ffffff
+            }
+
+            relationship "Relationship" {
+                dashed false
+            }
+            relationship "Async" {
+                dashed true
+            }
+        }
+    }
+}

--- a/docs/architecture/diagrams/deployment_diagrams/workspace.json
+++ b/docs/architecture/diagrams/deployment_diagrams/workspace.json
@@ -1,0 +1,2416 @@
+{
+  "configuration" : { },
+  "description" : "CI/CD and deployment architecture for Scopy multi-platform builds",
+  "documentation" : { },
+  "id" : 1,
+  "lastModifiedAgent" : "structurizr-ui",
+  "lastModifiedDate" : "2025-12-09T06:59:13Z",
+  "model" : {
+    "deploymentNodes" : [ {
+      "children" : [ {
+        "children" : [ {
+          "containerInstances" : [ {
+            "containerId" : "30",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "156",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "63591e3c-df1d-4ca0-99ec-b07824cbaa46"
+            },
+            "tags" : "Container Instance"
+          }, {
+            "containerId" : "5",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "157",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "a53e61db-49c0-4618-aae9-3573746fa388"
+            },
+            "tags" : "Container Instance"
+          } ],
+          "description" : "cristianbindea/scopy2-mingw64",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "155",
+          "instances" : "1",
+          "name" : "MinGW Docker Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "426de54f-0181-4e94-81ae-3ee2ef74daf6"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "MSYS2/MinGW64"
+        } ],
+        "description" : "Windows 2022",
+        "environment" : "Multi-Platform Build Environment",
+        "id" : "154",
+        "instances" : "1",
+        "name" : "Windows Runner",
+        "properties" : {
+          "structurizr.dsl.identifier" : "0b431717-442e-4f2b-845c-15c92ebc12f5"
+        },
+        "tags" : "Element,Deployment Node",
+        "technology" : "Microsoft Windows"
+      }, {
+        "children" : [ {
+          "containerInstances" : [ {
+            "containerId" : "31",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "160",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "d9e12b68-0403-461f-ae3e-1aa6b3c24b99"
+            },
+            "tags" : "Container Instance"
+          }, {
+            "containerId" : "5",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "161",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "4ac49842-f6e6-4617-b38b-df020f04210b"
+            },
+            "tags" : "Container Instance"
+          } ],
+          "description" : "cristianbindea/scopy2-flatpak",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "159",
+          "instances" : "1",
+          "name" : "Flatpak Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "e9611555-346b-487f-be58-adcf3090a865"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "Flatpak Runtime"
+        }, {
+          "containerInstances" : [ {
+            "containerId" : "32",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "163",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "57dda38f-a319-494f-9a10-004555dd43c8"
+            },
+            "tags" : "Container Instance"
+          }, {
+            "containerId" : "5",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "164",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "5c053015-8ff0-4941-9cbd-9763ec69afdd"
+            },
+            "tags" : "Container Instance"
+          } ],
+          "description" : "cristianbindea/scopy2-x86_64-appimage",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "162",
+          "instances" : "1",
+          "name" : "AppImage Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "5decad99-7f0a-4895-a8ae-7b7fc5332aee"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "Ubuntu Container"
+        }, {
+          "containerInstances" : [ {
+            "containerId" : "35",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "166",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "b8ad4622-da6b-499f-bfa9-c13b51826285"
+            },
+            "tags" : "Container Instance"
+          }, {
+            "containerId" : "5",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "167",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "6f53e87c-80f6-4989-89b4-899de7c33d4d"
+            },
+            "tags" : "Container Instance"
+          } ],
+          "description" : "cristianbindea/scopy2-ubuntu",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "165",
+          "instances" : "1",
+          "name" : "Ubuntu Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "1570087b-749f-4f68-b7e1-af7183cc5433"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "Development Environment"
+        }, {
+          "children" : [ {
+            "containerInstances" : [ {
+              "containerId" : "33",
+              "deploymentGroups" : [ "Default" ],
+              "environment" : "Multi-Platform Build Environment",
+              "id" : "170",
+              "instanceId" : 1,
+              "properties" : {
+                "structurizr.dsl.identifier" : "f29972c6-f427-4096-be1c-c2521d077ca6"
+              },
+              "tags" : "Container Instance"
+            }, {
+              "containerId" : "5",
+              "deploymentGroups" : [ "Default" ],
+              "environment" : "Multi-Platform Build Environment",
+              "id" : "171",
+              "instanceId" : 1,
+              "properties" : {
+                "structurizr.dsl.identifier" : "abb4a6fb-5ae3-4820-872e-4a332e2ae5dd"
+              },
+              "tags" : "Container Instance"
+            } ],
+            "description" : "aarch64-linux-gnu",
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "169",
+            "instances" : "1",
+            "name" : "ARM64 Sysroot",
+            "properties" : {
+              "structurizr.dsl.identifier" : "8aa03a6e-f72b-4cea-b8a4-98e1e39f1a13"
+            },
+            "tags" : "Element,Deployment Node",
+            "technology" : "Chroot Environment"
+          } ],
+          "description" : "cristianbindea/scopy2-arm64-appimage",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "168",
+          "instances" : "1",
+          "name" : "ARM64 Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "d9485912-42e1-42da-b774-02188787f36b"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "Cross-compilation"
+        }, {
+          "children" : [ {
+            "containerInstances" : [ {
+              "containerId" : "34",
+              "deploymentGroups" : [ "Default" ],
+              "environment" : "Multi-Platform Build Environment",
+              "id" : "174",
+              "instanceId" : 1,
+              "properties" : {
+                "structurizr.dsl.identifier" : "d924f458-4ddb-4e99-8676-843a2015c315"
+              },
+              "tags" : "Container Instance"
+            }, {
+              "containerId" : "5",
+              "deploymentGroups" : [ "Default" ],
+              "environment" : "Multi-Platform Build Environment",
+              "id" : "175",
+              "instanceId" : 1,
+              "properties" : {
+                "structurizr.dsl.identifier" : "7c5301d6-827e-4630-a6d5-46be01d818c0"
+              },
+              "tags" : "Container Instance"
+            } ],
+            "description" : "arm-linux-gnueabihf",
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "173",
+            "instances" : "1",
+            "name" : "ARMHF Sysroot",
+            "properties" : {
+              "structurizr.dsl.identifier" : "0cb279c5-4c74-4dc2-b7db-bec6c193bc5a"
+            },
+            "tags" : "Element,Deployment Node",
+            "technology" : "Chroot Environment"
+          } ],
+          "description" : "cristianbindea/scopy2-armhf-appimage",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "172",
+          "instances" : "1",
+          "name" : "ARMHF Container",
+          "properties" : {
+            "structurizr.dsl.identifier" : "6d30796e-47d5-432c-8577-6e17a4c9571d"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "Cross-compilation"
+        } ],
+        "description" : "Ubuntu 22.04",
+        "environment" : "Multi-Platform Build Environment",
+        "id" : "158",
+        "instances" : "1",
+        "name" : "Linux Runner",
+        "properties" : {
+          "structurizr.dsl.identifier" : "8a2fe21f-1578-4a96-a7e5-19d0914783a5"
+        },
+        "tags" : "Element,Deployment Node",
+        "technology" : "Ubuntu Linux"
+      } ],
+      "description" : "GitHub-hosted CI/CD platform",
+      "environment" : "Multi-Platform Build Environment",
+      "id" : "153",
+      "instances" : "1",
+      "name" : "GitHub Actions Infrastructure",
+      "properties" : {
+        "structurizr.dsl.identifier" : "50e10e88-b0d2-4e73-9d4d-b606659333a2"
+      },
+      "tags" : "Element,Deployment Node",
+      "technology" : "GitHub Actions"
+    }, {
+      "children" : [ {
+        "children" : [ {
+          "containerInstances" : [ {
+            "containerId" : "36",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "179",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "7c98bbbc-1efc-473c-a246-95cf8c257f1a"
+            },
+            "tags" : "Container Instance"
+          }, {
+            "containerId" : "5",
+            "deploymentGroups" : [ "Default" ],
+            "environment" : "Multi-Platform Build Environment",
+            "id" : "180",
+            "instanceId" : 1,
+            "properties" : {
+              "structurizr.dsl.identifier" : "72285b53-b9e4-4abe-a1ca-aef22fbc45e0"
+            },
+            "tags" : "Container Instance"
+          } ],
+          "description" : "Package Manager",
+          "environment" : "Multi-Platform Build Environment",
+          "id" : "178",
+          "instances" : "1",
+          "name" : "Homebrew Environment",
+          "properties" : {
+            "structurizr.dsl.identifier" : "b2cde0b4-1ba6-4af5-9d7c-52f78e2e3629"
+          },
+          "tags" : "Element,Deployment Node",
+          "technology" : "macOS Native"
+        } ],
+        "description" : "macOS",
+        "environment" : "Multi-Platform Build Environment",
+        "id" : "177",
+        "instances" : "1",
+        "name" : "macOS Agent",
+        "properties" : {
+          "structurizr.dsl.identifier" : "b55b4fd1-691f-4325-aaa9-bd540ba7d1ac"
+        },
+        "tags" : "Element,Deployment Node",
+        "technology" : "macOS x86_64"
+      } ],
+      "description" : "Microsoft cloud CI/CD platform",
+      "environment" : "Multi-Platform Build Environment",
+      "id" : "176",
+      "instances" : "1",
+      "name" : "Azure DevOps Infrastructure",
+      "properties" : {
+        "structurizr.dsl.identifier" : "3d34b2bd-61ec-4068-9ab3-05107a3b3531"
+      },
+      "tags" : "Element,Deployment Node",
+      "technology" : "Azure DevOps"
+    }, {
+      "containerInstances" : [ {
+        "containerId" : "38",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "182",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "8d77921e-61fa-4d30-b1cf-4c8ea4e0b00c"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "39",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "183",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "7a67a16b-3b43-4f5d-92ec-52f02145bd14"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "40",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "184",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "d52fc8e2-02ce-4284-9264-e0dfef307bc4"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "41",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "185",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "b8c64c02-1aea-4233-8b8c-c0e2a4118839"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "42",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "186",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "83a828ab-c030-4175-9cc4-e74f026f66db"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "43",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "187",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "2c3f781d-e6a4-4e41-95a0-63b36c023969"
+        },
+        "tags" : "Container Instance"
+      }, {
+        "containerId" : "44",
+        "deploymentGroups" : [ "Default" ],
+        "environment" : "Artifact Distribution Environment",
+        "id" : "188",
+        "instanceId" : 1,
+        "properties" : {
+          "structurizr.dsl.identifier" : "1c3e1cf4-87d6-4bf7-8f0f-43e43fa3d96f"
+        },
+        "tags" : "Container Instance"
+      } ],
+      "description" : "Artifact Storage and Distribution",
+      "environment" : "Artifact Distribution Environment",
+      "id" : "181",
+      "instances" : "1",
+      "name" : "GitHub Releases",
+      "properties" : {
+        "structurizr.dsl.identifier" : "75b709e3-3116-4323-946f-6fc86c4adf70"
+      },
+      "tags" : "Element,Deployment Node",
+      "technology" : "GitHub"
+    } ],
+    "people" : [ {
+      "description" : "Scopy developer",
+      "id" : "148",
+      "name" : "Developer",
+      "properties" : {
+        "structurizr.dsl.identifier" : "developer"
+      },
+      "relationships" : [ {
+        "description" : "Commits code",
+        "destinationId" : "1",
+        "id" : "150",
+        "sourceId" : "148",
+        "tags" : "Relationship"
+      }, {
+        "description" : "Develops",
+        "destinationId" : "4",
+        "id" : "151",
+        "sourceId" : "148",
+        "tags" : "Relationship"
+      } ],
+      "tags" : "Element,Person"
+    }, {
+      "description" : "Engineer using Scopy for signal analysis",
+      "id" : "149",
+      "name" : "End User",
+      "properties" : {
+        "structurizr.dsl.identifier" : "endUser"
+      },
+      "relationships" : [ {
+        "description" : "Downloads",
+        "destinationId" : "3",
+        "id" : "152",
+        "sourceId" : "149",
+        "tags" : "Relationship"
+      } ],
+      "tags" : "Element,Person"
+    } ],
+    "softwareSystems" : [ {
+      "description" : "Source code repository",
+      "documentation" : { },
+      "id" : "1",
+      "name" : "GitHub",
+      "properties" : {
+        "structurizr.dsl.identifier" : "github"
+      },
+      "relationships" : [ {
+        "description" : "Triggers on push/PR",
+        "destinationId" : "12",
+        "id" : "45",
+        "sourceId" : "1",
+        "tags" : "Relationship"
+      }, {
+        "description" : "Triggers on push/PR",
+        "destinationId" : "11",
+        "id" : "46",
+        "linkedRelationshipId" : "45",
+        "sourceId" : "1"
+      }, {
+        "description" : "Triggers on push/PR",
+        "destinationId" : "13",
+        "id" : "47",
+        "sourceId" : "1",
+        "tags" : "Relationship"
+      } ],
+      "tags" : "Element,Software System,External"
+    }, {
+      "description" : "Container image registry",
+      "documentation" : { },
+      "id" : "2",
+      "name" : "Docker Hub",
+      "properties" : {
+        "structurizr.dsl.identifier" : "dockerhub"
+      },
+      "tags" : "Element,Software System,External"
+    }, {
+      "description" : "Artifact storage and distribution",
+      "documentation" : { },
+      "id" : "3",
+      "name" : "GitHub Releases",
+      "properties" : {
+        "structurizr.dsl.identifier" : "artifactStore"
+      },
+      "tags" : "Element,Software System,External"
+    }, {
+      "containers" : [ {
+        "description" : "Main Qt-based GUI application",
+        "documentation" : { },
+        "id" : "5",
+        "name" : "Scopy Application",
+        "properties" : {
+          "structurizr.dsl.identifier" : "scopyApp"
+        },
+        "relationships" : [ {
+          "description" : "Uses for hardware communication",
+          "destinationId" : "6",
+          "id" : "143",
+          "sourceId" : "5",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses for signal processing",
+          "destinationId" : "7",
+          "id" : "144",
+          "sourceId" : "5",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses for ADALM2000 support",
+          "destinationId" : "8",
+          "id" : "145",
+          "sourceId" : "5",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses for plotting",
+          "destinationId" : "9",
+          "id" : "146",
+          "sourceId" : "5",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses for protocol decoding",
+          "destinationId" : "10",
+          "id" : "147",
+          "sourceId" : "5",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "C++/Qt"
+      }, {
+        "description" : "Industrial I/O library for ADI hardware",
+        "documentation" : { },
+        "id" : "6",
+        "name" : "libiio",
+        "properties" : {
+          "structurizr.dsl.identifier" : "libiio"
+        },
+        "tags" : "Element,Container",
+        "technology" : "C"
+      }, {
+        "description" : "Signal processing framework",
+        "documentation" : { },
+        "id" : "7",
+        "name" : "GNU Radio",
+        "properties" : {
+          "structurizr.dsl.identifier" : "gnuradio"
+        },
+        "tags" : "Element,Container",
+        "technology" : "C++/Python"
+      }, {
+        "description" : "ADALM2000 support library",
+        "documentation" : { },
+        "id" : "8",
+        "name" : "libm2k",
+        "properties" : {
+          "structurizr.dsl.identifier" : "libm2k"
+        },
+        "tags" : "Element,Container",
+        "technology" : "C++"
+      }, {
+        "description" : "Technical plotting widgets",
+        "documentation" : { },
+        "id" : "9",
+        "name" : "Qwt",
+        "properties" : {
+          "structurizr.dsl.identifier" : "qwt"
+        },
+        "tags" : "Element,Container",
+        "technology" : "C++/Qt"
+      }, {
+        "description" : "Protocol decoder library",
+        "documentation" : { },
+        "id" : "10",
+        "name" : "libsigrokdecode",
+        "properties" : {
+          "structurizr.dsl.identifier" : "libsigrok"
+        },
+        "tags" : "Element,Container",
+        "technology" : "C"
+      } ],
+      "description" : "Signal analysis and device control software for ADI hardware",
+      "documentation" : { },
+      "id" : "4",
+      "name" : "Scopy",
+      "properties" : {
+        "structurizr.dsl.identifier" : "scopy"
+      },
+      "tags" : "Element,Software System"
+    }, {
+      "containers" : [ {
+        "description" : "GitHub-hosted CI/CD runners and workflow execution",
+        "documentation" : { },
+        "id" : "12",
+        "name" : "GitHub Actions",
+        "properties" : {
+          "structurizr.dsl.identifier" : "githubActions"
+        },
+        "relationships" : [ {
+          "description" : "Runs",
+          "destinationId" : "15",
+          "id" : "48",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "14",
+          "id" : "49",
+          "linkedRelationshipId" : "48",
+          "sourceId" : "12"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "16",
+          "id" : "52",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "17",
+          "id" : "54",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "18",
+          "id" : "56",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "19",
+          "id" : "58",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "20",
+          "id" : "60",
+          "sourceId" : "12",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Platform"
+      }, {
+        "description" : "Microsoft cloud CI/CD platform",
+        "documentation" : { },
+        "id" : "13",
+        "name" : "Azure DevOps",
+        "properties" : {
+          "structurizr.dsl.identifier" : "azureDevOps"
+        },
+        "relationships" : [ {
+          "description" : "Runs",
+          "destinationId" : "21",
+          "id" : "62",
+          "sourceId" : "13",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Runs",
+          "destinationId" : "14",
+          "id" : "63",
+          "linkedRelationshipId" : "62",
+          "sourceId" : "13"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "Azure Platform"
+      } ],
+      "description" : "CI/CD platform orchestration layer",
+      "documentation" : { },
+      "id" : "11",
+      "name" : "CI/CD Platform",
+      "properties" : {
+        "structurizr.dsl.identifier" : "cicdPlatform"
+      },
+      "relationships" : [ {
+        "description" : "Runs",
+        "destinationId" : "15",
+        "id" : "50",
+        "linkedRelationshipId" : "48",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "14",
+        "id" : "51",
+        "linkedRelationshipId" : "48",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "16",
+        "id" : "53",
+        "linkedRelationshipId" : "52",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "17",
+        "id" : "55",
+        "linkedRelationshipId" : "54",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "18",
+        "id" : "57",
+        "linkedRelationshipId" : "56",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "19",
+        "id" : "59",
+        "linkedRelationshipId" : "58",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "20",
+        "id" : "61",
+        "linkedRelationshipId" : "60",
+        "sourceId" : "11"
+      }, {
+        "description" : "Runs",
+        "destinationId" : "21",
+        "id" : "64",
+        "linkedRelationshipId" : "62",
+        "sourceId" : "11"
+      } ],
+      "tags" : "Element,Software System"
+    }, {
+      "containers" : [ {
+        "description" : "Builds Windows installer",
+        "documentation" : { },
+        "id" : "15",
+        "name" : "Windows MinGW Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "windowsWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls MinGW container",
+          "destinationId" : "2",
+          "id" : "66",
+          "sourceId" : "15",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "23",
+          "id" : "73",
+          "sourceId" : "15",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "74",
+          "linkedRelationshipId" : "73",
+          "sourceId" : "15"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Builds Flatpak package",
+        "documentation" : { },
+        "id" : "16",
+        "name" : "Linux Flatpak Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "linuxFlatpakWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls Flatpak container",
+          "destinationId" : "2",
+          "id" : "67",
+          "sourceId" : "16",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "24",
+          "id" : "77",
+          "sourceId" : "16",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "78",
+          "linkedRelationshipId" : "77",
+          "sourceId" : "16"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Builds AppImage packages",
+        "documentation" : { },
+        "id" : "17",
+        "name" : "Linux AppImage Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "linuxAppImageWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls AppImage container",
+          "destinationId" : "2",
+          "id" : "68",
+          "sourceId" : "17",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "25",
+          "id" : "80",
+          "sourceId" : "17",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "81",
+          "linkedRelationshipId" : "80",
+          "sourceId" : "17"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Cross-compiles for ARM64 platforms",
+        "documentation" : { },
+        "id" : "18",
+        "name" : "ARM64 Build Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "arm64Workflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls ARM64 container",
+          "destinationId" : "2",
+          "id" : "69",
+          "sourceId" : "18",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "26",
+          "id" : "83",
+          "sourceId" : "18",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "84",
+          "linkedRelationshipId" : "83",
+          "sourceId" : "18"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Cross-compiles for ARMHF platforms",
+        "documentation" : { },
+        "id" : "19",
+        "name" : "ARMHF Build Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "armhfWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls ARMHF container",
+          "destinationId" : "2",
+          "id" : "70",
+          "sourceId" : "19",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "27",
+          "id" : "86",
+          "sourceId" : "19",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "87",
+          "linkedRelationshipId" : "86",
+          "sourceId" : "19"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Build on ubuntu",
+        "documentation" : { },
+        "id" : "20",
+        "name" : "Ubuntu Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "ubuntuWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Pulls Ubuntu container",
+          "destinationId" : "2",
+          "id" : "71",
+          "sourceId" : "20",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "28",
+          "id" : "89",
+          "sourceId" : "20",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Uses",
+          "destinationId" : "22",
+          "id" : "90",
+          "linkedRelationshipId" : "89",
+          "sourceId" : "20"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "GitHub Actions"
+      }, {
+        "description" : "Builds macOS DMG package",
+        "documentation" : { },
+        "id" : "21",
+        "name" : "macOS Build Workflow",
+        "properties" : {
+          "structurizr.dsl.identifier" : "macosWorkflow"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "36",
+          "id" : "110",
+          "sourceId" : "21",
+          "tags" : "Relationship,workflow"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "111",
+          "linkedRelationshipId" : "110",
+          "sourceId" : "21"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "Azure DevOps"
+      } ],
+      "description" : "Continuous integration and deployment system",
+      "documentation" : { },
+      "id" : "14",
+      "name" : "CI/CD Infrastructure",
+      "properties" : {
+        "structurizr.dsl.identifier" : "cicd"
+      },
+      "relationships" : [ {
+        "description" : "Pulls container images",
+        "destinationId" : "2",
+        "id" : "65",
+        "sourceId" : "14",
+        "tags" : "Relationship"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "23",
+        "id" : "75",
+        "linkedRelationshipId" : "73",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "22",
+        "id" : "76",
+        "linkedRelationshipId" : "73",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "24",
+        "id" : "79",
+        "linkedRelationshipId" : "77",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "25",
+        "id" : "82",
+        "linkedRelationshipId" : "80",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "26",
+        "id" : "85",
+        "linkedRelationshipId" : "83",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "27",
+        "id" : "88",
+        "linkedRelationshipId" : "86",
+        "sourceId" : "14"
+      }, {
+        "description" : "Uses",
+        "destinationId" : "28",
+        "id" : "91",
+        "linkedRelationshipId" : "89",
+        "sourceId" : "14"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "36",
+        "id" : "112",
+        "linkedRelationshipId" : "110",
+        "sourceId" : "14"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "29",
+        "id" : "113",
+        "linkedRelationshipId" : "110",
+        "sourceId" : "14"
+      } ],
+      "tags" : "Element,Software System"
+    }, {
+      "containers" : [ {
+        "description" : "Windows build environment with MSYS2",
+        "documentation" : { },
+        "id" : "23",
+        "name" : "mingw64 container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "mingwContainer"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "30",
+          "id" : "92",
+          "sourceId" : "23",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "93",
+          "linkedRelationshipId" : "92",
+          "sourceId" : "23"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-mingw64"
+      }, {
+        "description" : "Linux Flatpak build environment",
+        "documentation" : { },
+        "id" : "24",
+        "name" : "flatpak container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "flatpakContainer"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "31",
+          "id" : "95",
+          "sourceId" : "24",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "96",
+          "linkedRelationshipId" : "95",
+          "sourceId" : "24"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-flatpak"
+      }, {
+        "description" : "x86_64 AppImage build environment",
+        "documentation" : { },
+        "id" : "25",
+        "name" : "x86_64-appimage container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "x86Container"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "32",
+          "id" : "98",
+          "sourceId" : "25",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "99",
+          "linkedRelationshipId" : "98",
+          "sourceId" : "25"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-x86_64-appimage"
+      }, {
+        "description" : "ARM64 cross-compilation environment",
+        "documentation" : { },
+        "id" : "26",
+        "name" : "arm64-appimage container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "arm64Container"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "33",
+          "id" : "101",
+          "sourceId" : "26",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "102",
+          "linkedRelationshipId" : "101",
+          "sourceId" : "26"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-arm64-appimage"
+      }, {
+        "description" : "ARMHF cross-compilation environment",
+        "documentation" : { },
+        "id" : "27",
+        "name" : "armhf-appimage container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "armhfContainer"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "34",
+          "id" : "104",
+          "sourceId" : "27",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "105",
+          "linkedRelationshipId" : "104",
+          "sourceId" : "27"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-armhf-appimage"
+      }, {
+        "description" : "Development build environment",
+        "documentation" : { },
+        "id" : "28",
+        "name" : "ubuntu-22 container",
+        "properties" : {
+          "structurizr.dsl.identifier" : "ubuntuContainer"
+        },
+        "relationships" : [ {
+          "description" : "Executes",
+          "destinationId" : "35",
+          "id" : "107",
+          "sourceId" : "28",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Executes",
+          "destinationId" : "29",
+          "id" : "108",
+          "linkedRelationshipId" : "107",
+          "sourceId" : "28"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "cristianbindea/scopy2-ubuntu22"
+      } ],
+      "description" : "Pre-configured build environments",
+      "documentation" : { },
+      "id" : "22",
+      "name" : "Docker Build Infrastructure",
+      "properties" : {
+        "structurizr.dsl.identifier" : "dockerInfra"
+      },
+      "relationships" : [ {
+        "description" : "Executes",
+        "destinationId" : "29",
+        "id" : "72",
+        "sourceId" : "22",
+        "tags" : "Relationship"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "30",
+        "id" : "94",
+        "linkedRelationshipId" : "92",
+        "sourceId" : "22"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "31",
+        "id" : "97",
+        "linkedRelationshipId" : "95",
+        "sourceId" : "22"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "32",
+        "id" : "100",
+        "linkedRelationshipId" : "98",
+        "sourceId" : "22"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "33",
+        "id" : "103",
+        "linkedRelationshipId" : "101",
+        "sourceId" : "22"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "34",
+        "id" : "106",
+        "linkedRelationshipId" : "104",
+        "sourceId" : "22"
+      }, {
+        "description" : "Executes",
+        "destinationId" : "35",
+        "id" : "109",
+        "linkedRelationshipId" : "107",
+        "sourceId" : "22"
+      } ],
+      "tags" : "Element,Software System"
+    }, {
+      "containers" : [ {
+        "description" : "MSYS2/MinGW build process",
+        "documentation" : { },
+        "id" : "30",
+        "name" : "Windows Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "windowsScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "38",
+          "id" : "118",
+          "sourceId" : "30",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "119",
+          "linkedRelationshipId" : "118",
+          "sourceId" : "30"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/windows/windows_build_process.sh"
+      }, {
+        "description" : "Sandboxed Flatpak build",
+        "documentation" : { },
+        "id" : "31",
+        "name" : "Flatpak Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "flatpakScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "39",
+          "id" : "121",
+          "sourceId" : "31",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "122",
+          "linkedRelationshipId" : "121",
+          "sourceId" : "31"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/flatpak/flatpak_build_process.sh"
+      }, {
+        "description" : "AppImage packaging process",
+        "documentation" : { },
+        "id" : "32",
+        "name" : "AppImage Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "appimageScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "40",
+          "id" : "124",
+          "sourceId" : "32",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "125",
+          "linkedRelationshipId" : "124",
+          "sourceId" : "32"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/x86_64/x86-64_appimage_process.sh"
+      }, {
+        "description" : "Cross-compilation for ARM64",
+        "documentation" : { },
+        "id" : "33",
+        "name" : "ARM64 Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "arm64Script"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "41",
+          "id" : "127",
+          "sourceId" : "33",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "128",
+          "linkedRelationshipId" : "127",
+          "sourceId" : "33"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/arm64/arm64_build_process.sh"
+      }, {
+        "description" : "Cross-compilation for ARMHF",
+        "documentation" : { },
+        "id" : "34",
+        "name" : "ARMHF Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "armhfScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "42",
+          "id" : "130",
+          "sourceId" : "34",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "131",
+          "linkedRelationshipId" : "130",
+          "sourceId" : "34"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/armhf/armhf_build_process.sh"
+      }, {
+        "description" : "Ubuntu development builds",
+        "documentation" : { },
+        "id" : "35",
+        "name" : "Ubuntu Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "ubuntuScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "43",
+          "id" : "114",
+          "sourceId" : "35",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "115",
+          "linkedRelationshipId" : "114",
+          "sourceId" : "35"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/ubuntu/ubuntu_build_process.sh"
+      }, {
+        "description" : "Homebrew-based macOS build",
+        "documentation" : { },
+        "id" : "36",
+        "name" : "macOS Build Script",
+        "properties" : {
+          "structurizr.dsl.identifier" : "macosScript"
+        },
+        "relationships" : [ {
+          "description" : "Generates",
+          "destinationId" : "44",
+          "id" : "133",
+          "sourceId" : "36",
+          "tags" : "Relationship"
+        }, {
+          "description" : "Generates",
+          "destinationId" : "37",
+          "id" : "134",
+          "linkedRelationshipId" : "133",
+          "sourceId" : "36"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : "ci/macOS/build_azure_macos.sh"
+      } ],
+      "description" : "Platform-specific build automation",
+      "documentation" : { },
+      "id" : "29",
+      "name" : "Build Scripts",
+      "properties" : {
+        "structurizr.dsl.identifier" : "buildScripts"
+      },
+      "relationships" : [ {
+        "description" : "Generates",
+        "destinationId" : "43",
+        "id" : "116",
+        "linkedRelationshipId" : "114",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "37",
+        "id" : "117",
+        "linkedRelationshipId" : "114",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "38",
+        "id" : "120",
+        "linkedRelationshipId" : "118",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "39",
+        "id" : "123",
+        "linkedRelationshipId" : "121",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "40",
+        "id" : "126",
+        "linkedRelationshipId" : "124",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "41",
+        "id" : "129",
+        "linkedRelationshipId" : "127",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "42",
+        "id" : "132",
+        "linkedRelationshipId" : "130",
+        "sourceId" : "29"
+      }, {
+        "description" : "Generates",
+        "destinationId" : "44",
+        "id" : "135",
+        "linkedRelationshipId" : "133",
+        "sourceId" : "29"
+      } ],
+      "tags" : "Element,Software System"
+    }, {
+      "containers" : [ {
+        "description" : "Scopy Windows setup executable",
+        "documentation" : { },
+        "id" : "38",
+        "name" : "Windows Installer",
+        "properties" : {
+          "structurizr.dsl.identifier" : "windowsInstaller"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (continuous release)",
+          "destinationId" : "3",
+          "id" : "136",
+          "sourceId" : "38",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".exe"
+      }, {
+        "description" : "Sandboxed Linux package",
+        "documentation" : { },
+        "id" : "39",
+        "name" : "Linux Flatpak",
+        "properties" : {
+          "structurizr.dsl.identifier" : "linuxFlatpak"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (continuous release)",
+          "destinationId" : "3",
+          "id" : "138",
+          "sourceId" : "39",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".flatpak"
+      }, {
+        "description" : "Portable Linux application",
+        "documentation" : { },
+        "id" : "40",
+        "name" : "Linux AppImage",
+        "properties" : {
+          "structurizr.dsl.identifier" : "linuxAppImage"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (artifacts)",
+          "destinationId" : "3",
+          "id" : "139",
+          "sourceId" : "40",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".AppImage"
+      }, {
+        "description" : "ARM64 portable application",
+        "documentation" : { },
+        "id" : "41",
+        "name" : "ARM64 AppImage",
+        "properties" : {
+          "structurizr.dsl.identifier" : "arm64AppImage"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (artifacts)",
+          "destinationId" : "3",
+          "id" : "140",
+          "sourceId" : "41",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".AppImage"
+      }, {
+        "description" : "ARMHF portable application",
+        "documentation" : { },
+        "id" : "42",
+        "name" : "ARMHF AppImage",
+        "properties" : {
+          "structurizr.dsl.identifier" : "armhfAppImage"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (artifacts)",
+          "destinationId" : "3",
+          "id" : "141",
+          "sourceId" : "42",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".AppImage"
+      }, {
+        "description" : "Development build",
+        "documentation" : { },
+        "id" : "43",
+        "name" : "Ubuntu build",
+        "properties" : {
+          "structurizr.dsl.identifier" : "ubuntuPackage"
+        },
+        "tags" : "Element,Container",
+        "technology" : "test build"
+      }, {
+        "description" : "macOS disk image package",
+        "documentation" : { },
+        "id" : "44",
+        "name" : "macOS DMG",
+        "properties" : {
+          "structurizr.dsl.identifier" : "macosDMG"
+        },
+        "relationships" : [ {
+          "description" : "Uploads to (artifacts)",
+          "destinationId" : "3",
+          "id" : "142",
+          "sourceId" : "44",
+          "tags" : "Relationship"
+        } ],
+        "tags" : "Element,Container",
+        "technology" : ".dmg"
+      } ],
+      "description" : "Final deployment destinations",
+      "documentation" : { },
+      "id" : "37",
+      "name" : "Deployment Targets",
+      "properties" : {
+        "structurizr.dsl.identifier" : "deploymentTargets"
+      },
+      "relationships" : [ {
+        "description" : "Uploads to (continuous release)",
+        "destinationId" : "3",
+        "id" : "137",
+        "linkedRelationshipId" : "136",
+        "sourceId" : "37"
+      } ],
+      "tags" : "Element,Software System"
+    } ]
+  },
+  "name" : "Scopy Deployment Architecture",
+  "properties" : {
+    "structurizr.inspection.info" : "0",
+    "structurizr.inspection.ignore" : "0",
+    "structurizr.inspection.error" : "155",
+    "structurizr.inspection.warning" : "0",
+    "structurizr.dsl" : "d29ya3NwYWNlICJTY29weSBEZXBsb3ltZW50IEFyY2hpdGVjdHVyZSIgIkNJL0NEIGFuZCBkZXBsb3ltZW50IGFyY2hpdGVjdHVyZSBmb3IgU2NvcHkgbXVsdGktcGxhdGZvcm0gYnVpbGRzIiB7CgogICAgbW9kZWwgewogICAgICAgICMgRXh0ZXJuYWwgc3lzdGVtcwogICAgICAgIGdpdGh1YiA9IHNvZnR3YXJlU3lzdGVtICJHaXRIdWIiICJTb3VyY2UgY29kZSByZXBvc2l0b3J5IiAiRXh0ZXJuYWwiCiAgICAgICAgZG9ja2VyaHViID0gc29mdHdhcmVTeXN0ZW0gIkRvY2tlciBIdWIiICJDb250YWluZXIgaW1hZ2UgcmVnaXN0cnkiICJFeHRlcm5hbCIKICAgICAgICBhcnRpZmFjdFN0b3JlID0gc29mdHdhcmVTeXN0ZW0gIkdpdEh1YiBSZWxlYXNlcyIgIkFydGlmYWN0IHN0b3JhZ2UgYW5kIGRpc3RyaWJ1dGlvbiIgIkV4dGVybmFsIgoKICAgICAgICAjIE1haW4gc29mdHdhcmUgc3lzdGVtCiAgICAgICAgc2NvcHkgPSBzb2Z0d2FyZVN5c3RlbSAiU2NvcHkiICJTaWduYWwgYW5hbHlzaXMgYW5kIGRldmljZSBjb250cm9sIHNvZnR3YXJlIGZvciBBREkgaGFyZHdhcmUiIHsKICAgICAgICAgICAgIyBDb3JlIGFwcGxpY2F0aW9uCiAgICAgICAgICAgIHNjb3B5QXBwID0gY29udGFpbmVyICJTY29weSBBcHBsaWNhdGlvbiIgIk1haW4gUXQtYmFzZWQgR1VJIGFwcGxpY2F0aW9uIiAiQysrL1F0IgoKICAgICAgICAgICAgIyBEZXBlbmRlbmNpZXMKICAgICAgICAgICAgbGliaWlvID0gY29udGFpbmVyICJsaWJpaW8iICJJbmR1c3RyaWFsIEkvTyBsaWJyYXJ5IGZvciBBREkgaGFyZHdhcmUiICJDIgogICAgICAgICAgICBnbnVyYWRpbyA9IGNvbnRhaW5lciAiR05VIFJhZGlvIiAiU2lnbmFsIHByb2Nlc3NpbmcgZnJhbWV3b3JrIiAiQysrL1B5dGhvbiIKICAgICAgICAgICAgbGlibTJrID0gY29udGFpbmVyICJsaWJtMmsiICJBREFMTTIwMDAgc3VwcG9ydCBsaWJyYXJ5IiAiQysrIgogICAgICAgICAgICBxd3QgPSBjb250YWluZXIgIlF3dCIgIlRlY2huaWNhbCBwbG90dGluZyB3aWRnZXRzIiAiQysrL1F0IgogICAgICAgICAgICBsaWJzaWdyb2sgPSBjb250YWluZXIgImxpYnNpZ3Jva2RlY29kZSIgIlByb3RvY29sIGRlY29kZXIgbGlicmFyeSIgIkMiCiAgICAgICAgfQoKICAgICAgICAjIENJL0NEIFBsYXRmb3JtIAogICAgICAgIGNpY2RQbGF0Zm9ybSA9IHNvZnR3YXJlU3lzdGVtICJDSS9DRCBQbGF0Zm9ybSIgIkNJL0NEIHBsYXRmb3JtIG9yY2hlc3RyYXRpb24gbGF5ZXIiIHsKICAgICAgICAgICAgIyBHaXRIdWIgQWN0aW9ucyBQbGF0Zm9ybQogICAgICAgICAgICBnaXRodWJBY3Rpb25zID0gY29udGFpbmVyICJHaXRIdWIgQWN0aW9ucyIgIkdpdEh1Yi1ob3N0ZWQgQ0kvQ0QgcnVubmVycyBhbmQgd29ya2Zsb3cgZXhlY3V0aW9uIiAiR2l0SHViIFBsYXRmb3JtIiAKICAgICAgICAgICAgYXp1cmVEZXZPcHMgPSBjb250YWluZXIgIkF6dXJlIERldk9wcyIgIk1pY3Jvc29mdCBjbG91ZCBDSS9DRCBwbGF0Zm9ybSIgIkF6dXJlIFBsYXRmb3JtIgogICAgICAgIH0KCiAgICAgICAgIyBDSS9DRCBJbmZyYXN0cnVjdHVyZQogICAgICAgIGNpY2QgPSBzb2Z0d2FyZVN5c3RlbSAiQ0kvQ0QgSW5mcmFzdHJ1Y3R1cmUiICJDb250aW51b3VzIGludGVncmF0aW9uIGFuZCBkZXBsb3ltZW50IHN5c3RlbSIgewoKICAgICAgICAgICAgIyBHaXRIdWIgQWN0aW9ucyB3b3JrZmxvd3MKICAgICAgICAgICAgd2luZG93c1dvcmtmbG93ID0gY29udGFpbmVyICJXaW5kb3dzIE1pbkdXIFdvcmtmbG93IiAiQnVpbGRzIFdpbmRvd3MgaW5zdGFsbGVyIiAiR2l0SHViIEFjdGlvbnMiCiAgICAgICAgICAgIGxpbnV4RmxhdHBha1dvcmtmbG93ID0gY29udGFpbmVyICJMaW51eCBGbGF0cGFrIFdvcmtmbG93IiAiQnVpbGRzIEZsYXRwYWsgcGFja2FnZSIgIkdpdEh1YiBBY3Rpb25zIgogICAgICAgICAgICBsaW51eEFwcEltYWdlV29ya2Zsb3cgPSBjb250YWluZXIgIkxpbnV4IEFwcEltYWdlIFdvcmtmbG93IiAiQnVpbGRzIEFwcEltYWdlIHBhY2thZ2VzIiAiR2l0SHViIEFjdGlvbnMiCiAgICAgICAgICAgIGFybTY0V29ya2Zsb3cgPSBjb250YWluZXIgIkFSTTY0IEJ1aWxkIFdvcmtmbG93IiAiQ3Jvc3MtY29tcGlsZXMgZm9yIEFSTTY0IHBsYXRmb3JtcyIgIkdpdEh1YiBBY3Rpb25zIgogICAgICAgICAgICBhcm1oZldvcmtmbG93ID0gY29udGFpbmVyICJBUk1IRiBCdWlsZCBXb3JrZmxvdyIgIkNyb3NzLWNvbXBpbGVzIGZvciBBUk1IRiBwbGF0Zm9ybXMiICJHaXRIdWIgQWN0aW9ucyIKICAgICAgICAgICAgdWJ1bnR1V29ya2Zsb3cgPSBjb250YWluZXIgIlVidW50dSBXb3JrZmxvdyIgIkJ1aWxkIG9uIHVidW50dSIgIkdpdEh1YiBBY3Rpb25zIgogICAgICAgICAgICBtYWNvc1dvcmtmbG93ID0gY29udGFpbmVyICJtYWNPUyBCdWlsZCBXb3JrZmxvdyIgIkJ1aWxkcyBtYWNPUyBETUcgcGFja2FnZSIgIkF6dXJlIERldk9wcyIKICAgICAgICB9CgogICAgICAgICMgRG9ja2VyIEJ1aWxkIEVudmlyb25tZW50cwogICAgICAgIGRvY2tlckluZnJhID0gc29mdHdhcmVTeXN0ZW0gIkRvY2tlciBCdWlsZCBJbmZyYXN0cnVjdHVyZSIgIlByZS1jb25maWd1cmVkIGJ1aWxkIGVudmlyb25tZW50cyIgewogICAgICAgICAgICBtaW5nd0NvbnRhaW5lciA9IGNvbnRhaW5lciAibWluZ3c2NCBjb250YWluZXIiICJXaW5kb3dzIGJ1aWxkIGVudmlyb25tZW50IHdpdGggTVNZUzIiICJjcmlzdGlhbmJpbmRlYS9zY29weTItbWluZ3c2NCIKICAgICAgICAgICAgZmxhdHBha0NvbnRhaW5lciA9IGNvbnRhaW5lciAiZmxhdHBhayBjb250YWluZXIiICJMaW51eCBGbGF0cGFrIGJ1aWxkIGVudmlyb25tZW50IiAiY3Jpc3RpYW5iaW5kZWEvc2NvcHkyLWZsYXRwYWsiCiAgICAgICAgICAgIHg4NkNvbnRhaW5lciA9IGNvbnRhaW5lciAieDg2XzY0LWFwcGltYWdlIGNvbnRhaW5lciIgIng4Nl82NCBBcHBJbWFnZSBidWlsZCBlbnZpcm9ubWVudCIgImNyaXN0aWFuYmluZGVhL3Njb3B5Mi14ODZfNjQtYXBwaW1hZ2UiCiAgICAgICAgICAgIGFybTY0Q29udGFpbmVyID0gY29udGFpbmVyICJhcm02NC1hcHBpbWFnZSBjb250YWluZXIiICJBUk02NCBjcm9zcy1jb21waWxhdGlvbiBlbnZpcm9ubWVudCIgImNyaXN0aWFuYmluZGVhL3Njb3B5Mi1hcm02NC1hcHBpbWFnZSIKICAgICAgICAgICAgYXJtaGZDb250YWluZXIgPSBjb250YWluZXIgImFybWhmLWFwcGltYWdlIGNvbnRhaW5lciIgIkFSTUhGIGNyb3NzLWNvbXBpbGF0aW9uIGVudmlyb25tZW50IiAiY3Jpc3RpYW5iaW5kZWEvc2NvcHkyLWFybWhmLWFwcGltYWdlIgogICAgICAgICAgICB1YnVudHVDb250YWluZXIgPSBjb250YWluZXIgInVidW50dS0yMiBjb250YWluZXIiICJEZXZlbG9wbWVudCBidWlsZCBlbnZpcm9ubWVudCIgImNyaXN0aWFuYmluZGVhL3Njb3B5Mi11YnVudHUyMiIKICAgICAgICB9CgogICAgICAgICMgQnVpbGQgU2NyaXB0cyBhbmQgQ29uZmlndXJhdGlvbgogICAgICAgIGJ1aWxkU2NyaXB0cyA9IHNvZnR3YXJlU3lzdGVtICJCdWlsZCBTY3JpcHRzIiAiUGxhdGZvcm0tc3BlY2lmaWMgYnVpbGQgYXV0b21hdGlvbiIgewogICAgICAgICAgICB3aW5kb3dzU2NyaXB0ID0gY29udGFpbmVyICJXaW5kb3dzIEJ1aWxkIFNjcmlwdCIgIk1TWVMyL01pbkdXIGJ1aWxkIHByb2Nlc3MiICJjaS93aW5kb3dzL3dpbmRvd3NfYnVpbGRfcHJvY2Vzcy5zaCIKICAgICAgICAgICAgZmxhdHBha1NjcmlwdCA9IGNvbnRhaW5lciAiRmxhdHBhayBCdWlsZCBTY3JpcHQiICJTYW5kYm94ZWQgRmxhdHBhayBidWlsZCIgImNpL2ZsYXRwYWsvZmxhdHBha19idWlsZF9wcm9jZXNzLnNoIgogICAgICAgICAgICBhcHBpbWFnZVNjcmlwdCA9IGNvbnRhaW5lciAiQXBwSW1hZ2UgQnVpbGQgU2NyaXB0IiAiQXBwSW1hZ2UgcGFja2FnaW5nIHByb2Nlc3MiICJjaS94ODZfNjQveDg2LTY0X2FwcGltYWdlX3Byb2Nlc3Muc2giCiAgICAgICAgICAgIGFybTY0U2NyaXB0ID0gY29udGFpbmVyICJBUk02NCBCdWlsZCBTY3JpcHQiICJDcm9zcy1jb21waWxhdGlvbiBmb3IgQVJNNjQiICJjaS9hcm02NC9hcm02NF9idWlsZF9wcm9jZXNzLnNoIgogICAgICAgICAgICBhcm1oZlNjcmlwdCA9IGNvbnRhaW5lciAiQVJNSEYgQnVpbGQgU2NyaXB0IiAiQ3Jvc3MtY29tcGlsYXRpb24gZm9yIEFSTUhGIiAiY2kvYXJtaGYvYXJtaGZfYnVpbGRfcHJvY2Vzcy5zaCIKICAgICAgICAgICAgdWJ1bnR1U2NyaXB0ID0gY29udGFpbmVyICJVYnVudHUgQnVpbGQgU2NyaXB0IiAiVWJ1bnR1IGRldmVsb3BtZW50IGJ1aWxkcyIgImNpL3VidW50dS91YnVudHVfYnVpbGRfcHJvY2Vzcy5zaCIKICAgICAgICAgICAgbWFjb3NTY3JpcHQgPSBjb250YWluZXIgIm1hY09TIEJ1aWxkIFNjcmlwdCIgIkhvbWVicmV3LWJhc2VkIG1hY09TIGJ1aWxkIiAiY2kvbWFjT1MvYnVpbGRfYXp1cmVfbWFjb3Muc2giCiAgICAgICAgfQoKICAgICAgICAjIERlcGxveW1lbnQgdGFyZ2V0cwogICAgICAgIGRlcGxveW1lbnRUYXJnZXRzID0gc29mdHdhcmVTeXN0ZW0gIkRlcGxveW1lbnQgVGFyZ2V0cyIgIkZpbmFsIGRlcGxveW1lbnQgZGVzdGluYXRpb25zIiB7CiAgICAgICAgICAgIHdpbmRvd3NJbnN0YWxsZXIgPSBjb250YWluZXIgIldpbmRvd3MgSW5zdGFsbGVyIiAiU2NvcHkgV2luZG93cyBzZXR1cCBleGVjdXRhYmxlIiAiLmV4ZSIKICAgICAgICAgICAgbGludXhGbGF0cGFrID0gY29udGFpbmVyICJMaW51eCBGbGF0cGFrIiAiU2FuZGJveGVkIExpbnV4IHBhY2thZ2UiICIuZmxhdHBhayIKICAgICAgICAgICAgbGludXhBcHBJbWFnZSA9IGNvbnRhaW5lciAiTGludXggQXBwSW1hZ2UiICJQb3J0YWJsZSBMaW51eCBhcHBsaWNhdGlvbiIgIi5BcHBJbWFnZSIKICAgICAgICAgICAgYXJtNjRBcHBJbWFnZSA9IGNvbnRhaW5lciAiQVJNNjQgQXBwSW1hZ2UiICJBUk02NCBwb3J0YWJsZSBhcHBsaWNhdGlvbiIgIi5BcHBJbWFnZSIKICAgICAgICAgICAgYXJtaGZBcHBJbWFnZSA9IGNvbnRhaW5lciAiQVJNSEYgQXBwSW1hZ2UiICJBUk1IRiBwb3J0YWJsZSBhcHBsaWNhdGlvbiIgIi5BcHBJbWFnZSIKICAgICAgICAgICAgdWJ1bnR1UGFja2FnZSA9IGNvbnRhaW5lciAiVWJ1bnR1IGJ1aWxkIiAiRGV2ZWxvcG1lbnQgYnVpbGQiICJ0ZXN0IGJ1aWxkIgogICAgICAgICAgICBtYWNvc0RNRyA9IGNvbnRhaW5lciAibWFjT1MgRE1HIiAibWFjT1MgZGlzayBpbWFnZSBwYWNrYWdlIiAiLmRtZyIKICAgICAgICB9CgogICAgICAgICMgR2l0SHViIHRyaWdnZXJzIGluZGl2aWR1YWwgd29ya2Zsb3dzCiAgICAgICAgZ2l0aHViIC0+IGdpdGh1YkFjdGlvbnMgIlRyaWdnZXJzIG9uIHB1c2gvUFIiCiAgICAgICAgZ2l0aHViIC0+IGF6dXJlRGV2T3BzICJUcmlnZ2VycyBvbiBwdXNoL1BSIgogICAgICAgIGdpdGh1YkFjdGlvbnMgLT4gd2luZG93c1dvcmtmbG93ICJSdW5zIgogICAgICAgIGdpdGh1YkFjdGlvbnMgLT4gbGludXhGbGF0cGFrV29ya2Zsb3cgIlJ1bnMiCiAgICAgICAgZ2l0aHViQWN0aW9ucyAtPiBsaW51eEFwcEltYWdlV29ya2Zsb3cgIlJ1bnMiCiAgICAgICAgZ2l0aHViQWN0aW9ucyAtPiBhcm02NFdvcmtmbG93ICJSdW5zIgogICAgICAgIGdpdGh1YkFjdGlvbnMgLT4gYXJtaGZXb3JrZmxvdyAiUnVucyIKICAgICAgICBnaXRodWJBY3Rpb25zIC0+IHVidW50dVdvcmtmbG93ICJSdW5zIgogICAgICAgIGF6dXJlRGV2T3BzIC0+IG1hY29zV29ya2Zsb3cgIlJ1bnMiCgoKICAgICAgICAjIFdvcmtmbG93IHJlbGF0aW9uc2hpcHMKICAgICAgICBjaWNkIC0+IGRvY2tlcmh1YiAiUHVsbHMgY29udGFpbmVyIGltYWdlcyIKICAgICAgICB3aW5kb3dzV29ya2Zsb3cgLT4gZG9ja2VyaHViICJQdWxscyBNaW5HVyBjb250YWluZXIiCiAgICAgICAgbGludXhGbGF0cGFrV29ya2Zsb3cgLT4gZG9ja2VyaHViICJQdWxscyBGbGF0cGFrIGNvbnRhaW5lciIKICAgICAgICBsaW51eEFwcEltYWdlV29ya2Zsb3cgLT4gZG9ja2VyaHViICJQdWxscyBBcHBJbWFnZSBjb250YWluZXIiCiAgICAgICAgYXJtNjRXb3JrZmxvdyAtPiBkb2NrZXJodWIgIlB1bGxzIEFSTTY0IGNvbnRhaW5lciIKICAgICAgICBhcm1oZldvcmtmbG93IC0+IGRvY2tlcmh1YiAiUHVsbHMgQVJNSEYgY29udGFpbmVyIgogICAgICAgIHVidW50dVdvcmtmbG93IC0+IGRvY2tlcmh1YiAiUHVsbHMgVWJ1bnR1IGNvbnRhaW5lciIKICAgICAgICBkb2NrZXJJbmZyYSAtPiBidWlsZFNjcmlwdHMgIkV4ZWN1dGVzIgoKICAgICAgICB3aW5kb3dzV29ya2Zsb3cgLT4gbWluZ3dDb250YWluZXIgIlVzZXMiCiAgICAgICAgbGludXhGbGF0cGFrV29ya2Zsb3cgLT4gZmxhdHBha0NvbnRhaW5lciAiVXNlcyIKICAgICAgICBsaW51eEFwcEltYWdlV29ya2Zsb3cgLT4geDg2Q29udGFpbmVyICJVc2VzIgogICAgICAgIGFybTY0V29ya2Zsb3cgLT4gYXJtNjRDb250YWluZXIgIlVzZXMiCiAgICAgICAgYXJtaGZXb3JrZmxvdyAtPiBhcm1oZkNvbnRhaW5lciAiVXNlcyIKICAgICAgICB1YnVudHVXb3JrZmxvdyAtPiB1YnVudHVDb250YWluZXIgIlVzZXMiCgoKICAgICAgICBtaW5nd0NvbnRhaW5lciAtPiB3aW5kb3dzU2NyaXB0ICJFeGVjdXRlcyIKICAgICAgICBmbGF0cGFrQ29udGFpbmVyIC0+IGZsYXRwYWtTY3JpcHQgIkV4ZWN1dGVzIgogICAgICAgIHg4NkNvbnRhaW5lciAtPiBhcHBpbWFnZVNjcmlwdCAiRXhlY3V0ZXMiCiAgICAgICAgYXJtNjRDb250YWluZXIgLT4gYXJtNjRTY3JpcHQgIkV4ZWN1dGVzIgogICAgICAgIGFybWhmQ29udGFpbmVyIC0+IGFybWhmU2NyaXB0ICJFeGVjdXRlcyIKICAgICAgICB1YnVudHVDb250YWluZXIgLT4gdWJ1bnR1U2NyaXB0ICJFeGVjdXRlcyIKICAgICAgIAogICAgICAgICMgQnVpbGQgc2NyaXB0IGV4ZWN1dGlvbgogICAgICAgIG1hY29zV29ya2Zsb3cgLT4gbWFjb3NTY3JpcHQgIkV4ZWN1dGVzIiB7CiAgICAgICAgICAgIHRhZyAid29ya2Zsb3ciCiAgICAgICAgfQoKCiAgICAgICAgIyBCdWlsZCBvdXRwdXRzCiAgICAgICAgdWJ1bnR1U2NyaXB0IC0+IHVidW50dVBhY2thZ2UgIkdlbmVyYXRlcyIKICAgICAgICB3aW5kb3dzU2NyaXB0IC0+IHdpbmRvd3NJbnN0YWxsZXIgIkdlbmVyYXRlcyIKICAgICAgICBmbGF0cGFrU2NyaXB0IC0+IGxpbnV4RmxhdHBhayAiR2VuZXJhdGVzIgogICAgICAgIGFwcGltYWdlU2NyaXB0IC0+IGxpbnV4QXBwSW1hZ2UgIkdlbmVyYXRlcyIKICAgICAgICBhcm02NFNjcmlwdCAtPiBhcm02NEFwcEltYWdlICJHZW5lcmF0ZXMiCiAgICAgICAgYXJtaGZTY3JpcHQgLT4gYXJtaGZBcHBJbWFnZSAiR2VuZXJhdGVzIgogICAgICAgIG1hY29zU2NyaXB0IC0+IG1hY29zRE1HICJHZW5lcmF0ZXMiCgogICAgICAgICMgQXJ0aWZhY3Qgc3RvcmFnZQogICAgICAgIHdpbmRvd3NJbnN0YWxsZXIgLT4gYXJ0aWZhY3RTdG9yZSAiVXBsb2FkcyB0byAoY29udGludW91cyByZWxlYXNlKSIKICAgICAgICBsaW51eEZsYXRwYWsgLT4gYXJ0aWZhY3RTdG9yZSAiVXBsb2FkcyB0byAoY29udGludW91cyByZWxlYXNlKSIKICAgICAgICBsaW51eEFwcEltYWdlIC0+IGFydGlmYWN0U3RvcmUgIlVwbG9hZHMgdG8gKGFydGlmYWN0cykiCiAgICAgICAgYXJtNjRBcHBJbWFnZSAtPiBhcnRpZmFjdFN0b3JlICJVcGxvYWRzIHRvIChhcnRpZmFjdHMpIgogICAgICAgIGFybWhmQXBwSW1hZ2UgLT4gYXJ0aWZhY3RTdG9yZSAiVXBsb2FkcyB0byAoYXJ0aWZhY3RzKSIKICAgICAgICBtYWNvc0RNRyAtPiBhcnRpZmFjdFN0b3JlICJVcGxvYWRzIHRvIChhcnRpZmFjdHMpIgoKICAgICAgICAjIERlcGVuZGVuY2llcyB3aXRoaW4gU2NvcHkKICAgICAgICBzY29weUFwcCAtPiBsaWJpaW8gIlVzZXMgZm9yIGhhcmR3YXJlIGNvbW11bmljYXRpb24iCiAgICAgICAgc2NvcHlBcHAgLT4gZ251cmFkaW8gIlVzZXMgZm9yIHNpZ25hbCBwcm9jZXNzaW5nIgogICAgICAgIHNjb3B5QXBwIC0+IGxpYm0yayAiVXNlcyBmb3IgQURBTE0yMDAwIHN1cHBvcnQiCiAgICAgICAgc2NvcHlBcHAgLT4gcXd0ICJVc2VzIGZvciBwbG90dGluZyIKICAgICAgICBzY29weUFwcCAtPiBsaWJzaWdyb2sgIlVzZXMgZm9yIHByb3RvY29sIGRlY29kaW5nIgoKCiAgICAgICAgIyBVc2VycwogICAgICAgIGRldmVsb3BlciA9IHBlcnNvbiAiRGV2ZWxvcGVyIiAiU2NvcHkgZGV2ZWxvcGVyIgogICAgICAgIGVuZFVzZXIgPSBwZXJzb24gIkVuZCBVc2VyIiAiRW5naW5lZXIgdXNpbmcgU2NvcHkgZm9yIHNpZ25hbCBhbmFseXNpcyIKCiAgICAgICAgZGV2ZWxvcGVyIC0+IGdpdGh1YiAiQ29tbWl0cyBjb2RlIgogICAgICAgIGRldmVsb3BlciAtPiBzY29weSAiRGV2ZWxvcHMiCiAgICAgICAgZW5kVXNlciAtPiBhcnRpZmFjdFN0b3JlICJEb3dubG9hZHMiCgogICAgICAgICMgRGVwbG95bWVudCBlbnZpcm9ubWVudHMKICAgICAgICBidWlsZEVudmlyb25tZW50ID0gZGVwbG95bWVudEVudmlyb25tZW50ICJNdWx0aS1QbGF0Zm9ybSBCdWlsZCBFbnZpcm9ubWVudCIgewogICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiR2l0SHViIEFjdGlvbnMgSW5mcmFzdHJ1Y3R1cmUiICJHaXRIdWItaG9zdGVkIENJL0NEIHBsYXRmb3JtIiAiR2l0SHViIEFjdGlvbnMiIHsKICAgICAgICAgICAgICAgIGRlcGxveW1lbnROb2RlICJXaW5kb3dzIFJ1bm5lciIgIldpbmRvd3MgMjAyMiIgIk1pY3Jvc29mdCBXaW5kb3dzIiB7CiAgICAgICAgICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIk1pbkdXIERvY2tlciBDb250YWluZXIiICJjcmlzdGlhbmJpbmRlYS9zY29weTItbWluZ3c2NCIgIk1TWVMyL01pbkdXNjQiIHsKICAgICAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySW5zdGFuY2Ugd2luZG93c1NjcmlwdAogICAgICAgICAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSBzY29weUFwcCAiV2luZG93cyBCdWlsZCIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiTGludXggUnVubmVyIiAiVWJ1bnR1IDIyLjA0IiAiVWJ1bnR1IExpbnV4IiB7CiAgICAgICAgICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIkZsYXRwYWsgQ29udGFpbmVyIiAiY3Jpc3RpYW5iaW5kZWEvc2NvcHkyLWZsYXRwYWsiICJGbGF0cGFrIFJ1bnRpbWUiIHsKICAgICAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySW5zdGFuY2UgZmxhdHBha1NjcmlwdAogICAgICAgICAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSBzY29weUFwcCAiRmxhdHBhayBCdWlsZCIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIkFwcEltYWdlIENvbnRhaW5lciIgImNyaXN0aWFuYmluZGVhL3Njb3B5Mi14ODZfNjQtYXBwaW1hZ2UiICJVYnVudHUgQ29udGFpbmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIGFwcGltYWdlU2NyaXB0CiAgICAgICAgICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIHNjb3B5QXBwICJBcHBJbWFnZSBCdWlsZCIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIlVidW50dSBDb250YWluZXIiICJjcmlzdGlhbmJpbmRlYS9zY29weTItdWJ1bnR1IiAiRGV2ZWxvcG1lbnQgRW52aXJvbm1lbnQiIHsKICAgICAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySW5zdGFuY2UgdWJ1bnR1U2NyaXB0CiAgICAgICAgICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIHNjb3B5QXBwICJVYnVudHUgQnVpbGQiCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIGRlcGxveW1lbnROb2RlICJBUk02NCBDb250YWluZXIiICJjcmlzdGlhbmJpbmRlYS9zY29weTItYXJtNjQtYXBwaW1hZ2UiICJDcm9zcy1jb21waWxhdGlvbiIgewogICAgICAgICAgICAgICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiQVJNNjQgU3lzcm9vdCIgImFhcmNoNjQtbGludXgtZ251IiAiQ2hyb290IEVudmlyb25tZW50IiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSBhcm02NFNjcmlwdCAiQVJNNjQgQnVpbGQiCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSBzY29weUFwcCAiQVJNNjQgQmluYXJ5IgogICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIGRlcGxveW1lbnROb2RlICJBUk1IRiBDb250YWluZXIiICJjcmlzdGlhbmJpbmRlYS9zY29weTItYXJtaGYtYXBwaW1hZ2UiICJDcm9zcy1jb21waWxhdGlvbiIgewogICAgICAgICAgICAgICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiQVJNSEYgU3lzcm9vdCIgImFybS1saW51eC1nbnVlYWJpaGYiICJDaHJvb3QgRW52aXJvbm1lbnQiIHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIGFybWhmU2NyaXB0ICJBUk1IRiBCdWlsZCIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIHNjb3B5QXBwICJBUk1IRiBCaW5hcnkiCiAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIkF6dXJlIERldk9wcyBJbmZyYXN0cnVjdHVyZSIgIk1pY3Jvc29mdCBjbG91ZCBDSS9DRCBwbGF0Zm9ybSIgIkF6dXJlIERldk9wcyIgewogICAgICAgICAgICAgICAgZGVwbG95bWVudE5vZGUgIm1hY09TIEFnZW50IiAibWFjT1MiICJtYWNPUyB4ODZfNjQiIHsKICAgICAgICAgICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiSG9tZWJyZXcgRW52aXJvbm1lbnQiICJQYWNrYWdlIE1hbmFnZXIiICJtYWNPUyBOYXRpdmUiIHsKICAgICAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySW5zdGFuY2UgbWFjb3NTY3JpcHQKICAgICAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySW5zdGFuY2Ugc2NvcHlBcHAgIm1hY09TIEJ1aWxkIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQogICAgICAgIH0KCiAgICAgICAgZGlzdHJpYnV0aW9uRW52aXJvbm1lbnQgPSBkZXBsb3ltZW50RW52aXJvbm1lbnQgIkFydGlmYWN0IERpc3RyaWJ1dGlvbiBFbnZpcm9ubWVudCIgewogICAgICAgICAgICBkZXBsb3ltZW50Tm9kZSAiR2l0SHViIFJlbGVhc2VzIiAiQXJ0aWZhY3QgU3RvcmFnZSBhbmQgRGlzdHJpYnV0aW9uIiAiR2l0SHViIiB7CiAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSB3aW5kb3dzSW5zdGFsbGVyCiAgICAgICAgICAgICAgICBjb250YWluZXJJbnN0YW5jZSBsaW51eEZsYXRwYWsKICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIGxpbnV4QXBwSW1hZ2UKICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIGFybTY0QXBwSW1hZ2UKICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIGFybWhmQXBwSW1hZ2UKICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIHVidW50dVBhY2thZ2UKICAgICAgICAgICAgICAgIGNvbnRhaW5lckluc3RhbmNlIG1hY29zRE1HCiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICB9CgogICAgdmlld3MgewogICAgICAgIHN5c3RlbUxhbmRzY2FwZSAiU3lzdGVtTGFuZHNjYXBlIiAiT3ZlcmFsbCBTY29weSBkZXBsb3ltZW50IGVjb3N5c3RlbSIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICAgICAgZXhjbHVkZSAicmVsYXRpb25zaGlwLnRhZz09d29ya2Zsb3ciCiAgICAgICAgfQoKICAgICAgICBjb250YWluZXIgY2ljZFBsYXRmb3JtICJDSUNEUGxhdGZvcm0iICJDSS9DRCBydW5uaW5nIHBsYXRmb3JtcyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICB9CgogICAgICAgIGNvbnRhaW5lciBjaWNkICJDSUNEQ29udGFpbmVycyIgIkNJL0NEIHdvcmtmbG93IGNvbnRhaW5lcnMiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGV4Y2x1ZGUgY2ljZFBsYXRmb3JtCiAgICAgICAgICAgIGluY2x1ZGUgZ2l0aHViQWN0aW9ucyBhenVyZURldk9wcwogICAgICAgIH0KCiAgICAgICAgY29udGFpbmVyIGRlcGxveW1lbnRUYXJnZXRzICJEZXBsb3ltZW50VGFyZ2V0cyIgIkZpbmFsIGRlcGxveW1lbnQgYXJ0aWZhY3RzIiB7CiAgICAgICAgICAgIGluY2x1ZGUgKgogICAgICAgIH0KCiAgICAgICAgZGVwbG95bWVudCBzY29weSBidWlsZEVudmlyb25tZW50ICJCdWlsZERlcGxveW1lbnQiICJNdWx0aS1wbGF0Zm9ybSBidWlsZCBpbmZyYXN0cnVjdHVyZSBzaG93aW5nIGFsbCBjb21waWxhdGlvbiBlbnZpcm9ubWVudHMiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgfQoKICAgICAgICBkZXBsb3ltZW50ICogZGlzdHJpYnV0aW9uRW52aXJvbm1lbnQgIkFydGlmYWN0RGlzdHJpYnV0aW9uIiAiRmluYWwgYXJ0aWZhY3QgZGlzdHJpYnV0aW9uIHNob3dpbmcgYWxsIGdlbmVyYXRlZCBwYWNrYWdlcyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICB9CgogICAgICAgIGR5bmFtaWMgY2ljZCAiQnVpbGRQcm9jZXNzIiAiQnVpbGQgcHJvY2VzcyBmbG93IiB7CiAgICAgICAgICAgIGRldmVsb3BlciAtPiBnaXRodWIgIlB1c2ggY29kZSIKCiAgICAgICAgICAgIGdpdGh1YiAtPiBnaXRodWJBY3Rpb25zICJ0cmlnZ2VycyBHaXRIdWIgQWN0aW9ucyB3b3JrZmxvd3MiCiAgICAgICAgICAgIGdpdGh1YiAtPiBhenVyZURldk9wcyAidHJpZ2dlcnMgQXp1cmUgd29ya2Zsb3dzIgoKICAgICAgICAgICAgZ2l0aHViQWN0aW9ucyAtPiB3aW5kb3dzV29ya2Zsb3cgIlRyaWdnZXIgV2luZG93cyBidWlsZCIKICAgICAgICAgICAgZ2l0aHViQWN0aW9ucyAtPiBsaW51eEZsYXRwYWtXb3JrZmxvdyAiVHJpZ2dlciBMaW51eCBidWlsZHMiCiAgICAgICAgICAgIGdpdGh1YkFjdGlvbnMgLT4gbGludXhBcHBJbWFnZVdvcmtmbG93ICJUcmlnZ2VyIExpbnV4IEFwcEltYWdlIGJ1aWxkcyIKICAgICAgICAgICAgZ2l0aHViQWN0aW9ucyAtPiB1YnVudHVXb3JrZmxvdyAiVHJpZ2dlciBVYnVudHUgYnVpbGRzIgogICAgICAgICAgICBnaXRodWJBY3Rpb25zIC0+IGFybTY0V29ya2Zsb3cgIlRyaWdnZXIgQVJNNjQgYnVpbGRzIgogICAgICAgICAgICBnaXRodWJBY3Rpb25zIC0+IGFybWhmV29ya2Zsb3cgIlRyaWdnZXIgQVJNSEYgYnVpbGRzIgogICAgICAgICAgICBhenVyZURldk9wcyAtPiBtYWNvc1dvcmtmbG93ICJUcmlnZ2VyIE1hY09TIGJ1aWxkcyIKCiAgICAgICAgICAgIHdpbmRvd3NXb3JrZmxvdyAtPiBtaW5nd0NvbnRhaW5lciAiVXNlcyIKICAgICAgICAgICAgbWluZ3dDb250YWluZXIgLT4gd2luZG93c1NjcmlwdCAiRXhlY3V0ZSBXaW5kb3dzIGJ1aWxkIgogICAgICAgICAgICBsaW51eEZsYXRwYWtXb3JrZmxvdyAtPiBmbGF0cGFrQ29udGFpbmVyICJVc2VzIgogICAgICAgICAgICBmbGF0cGFrQ29udGFpbmVyIC0+IGZsYXRwYWtTY3JpcHQgIkV4ZWN1dGUgRmxhdHBhayBidWlsZCIKICAgICAgICAgICAgbGludXhBcHBJbWFnZVdvcmtmbG93IC0+IHg4NkNvbnRhaW5lciAiVXNlcyIKICAgICAgICAgICAgeDg2Q29udGFpbmVyIC0+IGFwcGltYWdlU2NyaXB0ICJFeGVjdXRlIEFwcEltYWdlIGJ1aWxkIgogICAgICAgICAgICB1YnVudHVXb3JrZmxvdyAtPiB1YnVudHVDb250YWluZXIgIlVzZXMiCiAgICAgICAgICAgIHVidW50dUNvbnRhaW5lciAtPiB1YnVudHVTY3JpcHQgIkV4ZWN1dGUgVWJ1bnR1IGJ1aWxkIgogICAgICAgICAgICBhcm02NFdvcmtmbG93IC0+IGFybTY0Q29udGFpbmVyICJVc2VzIgogICAgICAgICAgICBhcm02NENvbnRhaW5lciAtPiBhcm02NFNjcmlwdCAiRXhlY3V0ZSBBUk02NCBidWlsZHMiCiAgICAgICAgICAgIGFybWhmV29ya2Zsb3cgLT4gYXJtaGZDb250YWluZXIgIlVzZXMiCiAgICAgICAgICAgIGFybWhmQ29udGFpbmVyIC0+IGFybWhmU2NyaXB0ICJFeGVjdXRlIEFSTUhGIGJ1aWxkcyIKICAgICAgICAgICAgbWFjb3NXb3JrZmxvdyAtPiBtYWNvc1NjcmlwdCAiRXhlY3V0ZSBtYWNPUyBidWlsZCIKICAgICAgICAgICAgCiAgICAgICAgICAgIHdpbmRvd3NTY3JpcHQgLT4gd2luZG93c0luc3RhbGxlciAiR2VuZXJhdGUgaW5zdGFsbGVyIgogICAgICAgICAgICBhcHBpbWFnZVNjcmlwdCAtPiBsaW51eEFwcEltYWdlICJHZW5lcmF0ZSBBcHBJbWFnZSIKICAgICAgICAgICAgdWJ1bnR1U2NyaXB0IC0+IHVidW50dVBhY2thZ2UgIkdlbmVyYXRlIFVidW50dSBidWlsZCIKICAgICAgICAgICAgZmxhdHBha1NjcmlwdCAtPiBsaW51eEZsYXRwYWsgIkdlbmVyYXRlIEZsYXRwYWsiCiAgICAgICAgICAgIGFybTY0U2NyaXB0IC0+IGFybTY0QXBwSW1hZ2UgIkdlbmVyYXRlIEFSTTY0IEFwcEltYWdlIgogICAgICAgICAgICBhcm1oZlNjcmlwdCAtPiBhcm1oZkFwcEltYWdlICJHZW5lcmF0ZSBBUk1IRiBBcHBJbWFnZSIKICAgICAgICAgICAgbWFjb3NTY3JpcHQgLT4gbWFjb3NETUcgIkdlbmVyYXRlIERNRyIKICAgICAgICAgICAgCiAgICAgICAgICAgIHdpbmRvd3NJbnN0YWxsZXIgLT4gYXJ0aWZhY3RTdG9yZSAiVXBsb2FkIGFydGlmYWN0cyIKICAgICAgICAgICAgbGludXhBcHBJbWFnZSAtPiBhcnRpZmFjdFN0b3JlICJVcGxvYWQgYXJ0aWZhY3RzIgogICAgICAgICAgICBhcm02NEFwcEltYWdlIC0+IGFydGlmYWN0U3RvcmUgIlVwbG9hZCBhcnRpZmFjdHMiCiAgICAgICAgICAgIGFybWhmQXBwSW1hZ2UgLT4gYXJ0aWZhY3RTdG9yZSAiVXBsb2FkIGFydGlmYWN0cyIKICAgICAgICAgICAgbGludXhGbGF0cGFrIC0+IGFydGlmYWN0U3RvcmUgIlVwbG9hZCBhcnRpZmFjdHMiCiAgICAgICAgICAgIG1hY29zRE1HIC0+IGFydGlmYWN0U3RvcmUgIlVwbG9hZCBtYWNPUyBhcnRpZmFjdHMiCiAgICAgICAgICAgIAogICAgICAgIH0KCiAgICAgICAgc3R5bGVzIHsKICAgICAgICAgICAgZWxlbWVudCAiU29mdHdhcmUgU3lzdGVtIiB7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kICMxMTY4YmQKICAgICAgICAgICAgICAgIGNvbG9yICNmZmZmZmYKICAgICAgICAgICAgICAgIHNoYXBlIFJvdW5kZWRCb3gKICAgICAgICAgICAgfQogICAgICAgICAgICBlbGVtZW50ICJDb250YWluZXIiIHsKICAgICAgICAgICAgICAgIGJhY2tncm91bmQgIzQzOGRkNQogICAgICAgICAgICAgICAgY29sb3IgI2ZmZmZmZgogICAgICAgICAgICAgICAgc2hhcGUgUm91bmRlZEJveAogICAgICAgICAgICB9CiAgICAgICAgICAgIGVsZW1lbnQgIlBlcnNvbiIgewogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMDg0MjdiCiAgICAgICAgICAgICAgICBjb2xvciAjZmZmZmZmCiAgICAgICAgICAgICAgICBzaGFwZSBQZXJzb24KICAgICAgICAgICAgfQogICAgICAgICAgICBlbGVtZW50ICJFeHRlcm5hbCIgewogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjOTk5OTk5CiAgICAgICAgICAgICAgICBjb2xvciAjZmZmZmZmCiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIHJlbGF0aW9uc2hpcCAiUmVsYXRpb25zaGlwIiB7CiAgICAgICAgICAgICAgICBkYXNoZWQgZmFsc2UKICAgICAgICAgICAgfQogICAgICAgICAgICByZWxhdGlvbnNoaXAgIkFzeW5jIiB7CiAgICAgICAgICAgICAgICBkYXNoZWQgdHJ1ZQogICAgICAgICAgICB9CiAgICAgICAgfQogICAgfQp9"
+  },
+  "views" : {
+    "configuration" : {
+      "branding" : { },
+      "lastSavedView" : "BuildDeployment",
+      "metadataSymbols" : "SquareBrackets",
+      "styles" : {
+        "elements" : [ {
+          "background" : "#438dd5",
+          "color" : "#ffffff",
+          "shape" : "RoundedBox",
+          "tag" : "Container"
+        }, {
+          "background" : "#999999",
+          "color" : "#ffffff",
+          "tag" : "External"
+        }, {
+          "background" : "#08427b",
+          "color" : "#ffffff",
+          "shape" : "Person",
+          "tag" : "Person"
+        }, {
+          "background" : "#1168bd",
+          "color" : "#ffffff",
+          "shape" : "RoundedBox",
+          "tag" : "Software System"
+        } ],
+        "relationships" : [ {
+          "dashed" : true,
+          "tag" : "Async"
+        }, {
+          "dashed" : false,
+          "tag" : "Relationship"
+        } ]
+      },
+      "terminology" : { }
+    },
+    "containerViews" : [ {
+      "description" : "CI/CD running platforms",
+      "dimensions" : {
+        "height" : 1900,
+        "width" : 1640
+      },
+      "elements" : [ {
+        "id" : "1",
+        "x" : 594,
+        "y" : 142
+      }, {
+        "id" : "12",
+        "x" : 969,
+        "y" : 742
+      }, {
+        "id" : "13",
+        "x" : 219,
+        "y" : 742
+      }, {
+        "id" : "14",
+        "x" : 594,
+        "y" : 1342
+      } ],
+      "externalSoftwareSystemBoundariesVisible" : false,
+      "key" : "CICDPlatform",
+      "name" : "Container View: CI/CD Platform",
+      "order" : 2,
+      "relationships" : [ {
+        "id" : "45"
+      }, {
+        "id" : "47"
+      }, {
+        "id" : "49"
+      }, {
+        "id" : "63"
+      } ],
+      "softwareSystemId" : "11"
+    }, {
+      "description" : "CI/CD workflow containers",
+      "dimensions" : {
+        "height" : 2705,
+        "width" : 5281
+      },
+      "elements" : [ {
+        "id" : "2",
+        "x" : 225,
+        "y" : 1713
+      }, {
+        "id" : "12",
+        "x" : 2084,
+        "y" : 163
+      }, {
+        "id" : "13",
+        "x" : 4600,
+        "y" : 200
+      }, {
+        "id" : "15",
+        "x" : 219,
+        "y" : 1061
+      }, {
+        "id" : "16",
+        "x" : 969,
+        "y" : 1061
+      }, {
+        "id" : "17",
+        "x" : 1719,
+        "y" : 1061
+      }, {
+        "id" : "18",
+        "x" : 2469,
+        "y" : 1061
+      }, {
+        "id" : "19",
+        "x" : 3219,
+        "y" : 1061
+      }, {
+        "id" : "20",
+        "x" : 3969,
+        "y" : 1061
+      }, {
+        "id" : "21",
+        "x" : 4610,
+        "y" : 1078
+      }, {
+        "id" : "22",
+        "x" : 4280,
+        "y" : 1698
+      }, {
+        "id" : "29",
+        "x" : 4280,
+        "y" : 2148
+      } ],
+      "externalSoftwareSystemBoundariesVisible" : false,
+      "key" : "CICDContainers",
+      "name" : "Container View: CI/CD Infrastructure",
+      "order" : 3,
+      "relationships" : [ {
+        "id" : "111",
+        "vertices" : [ {
+          "x" : 4834,
+          "y" : 2300
+        } ]
+      }, {
+        "id" : "48"
+      }, {
+        "id" : "52"
+      }, {
+        "id" : "54"
+      }, {
+        "id" : "56"
+      }, {
+        "id" : "58"
+      }, {
+        "id" : "60"
+      }, {
+        "id" : "62"
+      }, {
+        "id" : "66"
+      }, {
+        "id" : "67",
+        "vertices" : [ {
+          "x" : 1165,
+          "y" : 1683
+        } ]
+      }, {
+        "id" : "68",
+        "vertices" : [ {
+          "x" : 1850,
+          "y" : 1668
+        } ]
+      }, {
+        "id" : "69",
+        "vertices" : [ {
+          "x" : 2490,
+          "y" : 1688
+        } ]
+      }, {
+        "id" : "70",
+        "vertices" : [ {
+          "x" : 2650,
+          "y" : 1753
+        } ]
+      }, {
+        "id" : "71",
+        "vertices" : [ {
+          "x" : 2665,
+          "y" : 1838
+        } ]
+      }, {
+        "id" : "72"
+      }, {
+        "id" : "74"
+      }, {
+        "id" : "78"
+      }, {
+        "id" : "81"
+      }, {
+        "id" : "84"
+      }, {
+        "id" : "87"
+      }, {
+        "id" : "90"
+      } ],
+      "softwareSystemId" : "14"
+    }, {
+      "description" : "Final deployment artifacts",
+      "dimensions" : {
+        "height" : 1900,
+        "width" : 5390
+      },
+      "elements" : [ {
+        "id" : "3",
+        "x" : 2470,
+        "y" : 1342
+      }, {
+        "id" : "29",
+        "x" : 2470,
+        "y" : 142
+      }, {
+        "id" : "38",
+        "x" : 4720,
+        "y" : 742
+      }, {
+        "id" : "39",
+        "x" : 3970,
+        "y" : 742
+      }, {
+        "id" : "40",
+        "x" : 3220,
+        "y" : 742
+      }, {
+        "id" : "41",
+        "x" : 2470,
+        "y" : 742
+      }, {
+        "id" : "42",
+        "x" : 1720,
+        "y" : 742
+      }, {
+        "id" : "43",
+        "x" : 970,
+        "y" : 742
+      }, {
+        "id" : "44",
+        "x" : 220,
+        "y" : 742
+      } ],
+      "externalSoftwareSystemBoundariesVisible" : false,
+      "key" : "DeploymentTargets",
+      "name" : "Container View: Deployment Targets",
+      "order" : 4,
+      "relationships" : [ {
+        "id" : "116",
+        "vertices" : [ {
+          "x" : 1570,
+          "y" : 638
+        } ]
+      }, {
+        "id" : "120",
+        "vertices" : [ {
+          "x" : 4570,
+          "y" : 638
+        } ]
+      }, {
+        "id" : "123",
+        "vertices" : [ {
+          "x" : 3820,
+          "y" : 638
+        } ]
+      }, {
+        "id" : "126"
+      }, {
+        "id" : "129"
+      }, {
+        "id" : "132"
+      }, {
+        "id" : "135",
+        "vertices" : [ {
+          "x" : 820,
+          "y" : 638
+        } ]
+      }, {
+        "id" : "136",
+        "vertices" : [ {
+          "x" : 4570,
+          "y" : 1146
+        } ]
+      }, {
+        "id" : "138",
+        "vertices" : [ {
+          "x" : 3820,
+          "y" : 1146
+        } ]
+      }, {
+        "id" : "139"
+      }, {
+        "id" : "140"
+      }, {
+        "id" : "141"
+      }, {
+        "id" : "142",
+        "vertices" : [ {
+          "x" : 820,
+          "y" : 1146
+        } ]
+      } ],
+      "softwareSystemId" : "37"
+    } ],
+    "deploymentViews" : [ {
+      "description" : "Multi-platform build infrastructure showing all compilation environments",
+      "dimensions" : {
+        "height" : 1642,
+        "width" : 3335
+      },
+      "elements" : [ {
+        "id" : "153",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "154",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "155",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "157",
+        "x" : 2014,
+        "y" : 517
+      }, {
+        "id" : "158",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "159",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "161",
+        "x" : 1419,
+        "y" : 787
+      }, {
+        "id" : "162",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "164",
+        "x" : 854,
+        "y" : 787
+      }, {
+        "id" : "165",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "167",
+        "x" : 259,
+        "y" : 787
+      }, {
+        "id" : "168",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "169",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "171",
+        "x" : 1119,
+        "y" : 227
+      }, {
+        "id" : "172",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "173",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "175",
+        "x" : 499,
+        "y" : 222
+      }, {
+        "id" : "176",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "177",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "178",
+        "x" : 175,
+        "y" : 175
+      }, {
+        "id" : "180",
+        "x" : 2624,
+        "y" : 464
+      } ],
+      "environment" : "Multi-Platform Build Environment",
+      "key" : "BuildDeployment",
+      "name" : "Deployment View: Scopy - Multi-Platform Build Environment",
+      "order" : 5,
+      "softwareSystemId" : "4"
+    }, {
+      "description" : "Final artifact distribution showing all generated packages",
+      "dimensions" : {
+        "height" : 1204,
+        "width" : 1880
+      },
+      "elements" : [ {
+        "id" : "181",
+        "x" : 0,
+        "y" : 0
+      }, {
+        "id" : "182",
+        "x" : 715,
+        "y" : 163
+      }, {
+        "id" : "183",
+        "x" : 220,
+        "y" : 168
+      }, {
+        "id" : "184",
+        "x" : 715,
+        "y" : 548
+      }, {
+        "id" : "185",
+        "x" : 1210,
+        "y" : 165
+      }, {
+        "id" : "186",
+        "x" : 220,
+        "y" : 545
+      }, {
+        "id" : "187",
+        "x" : 1205,
+        "y" : 548
+      }, {
+        "id" : "188",
+        "x" : 1205,
+        "y" : 548
+      } ],
+      "environment" : "Artifact Distribution Environment",
+      "key" : "ArtifactDistribution",
+      "name" : "Deployment View: Artifact Distribution Environment",
+      "order" : 6
+    } ],
+    "dynamicViews" : [ {
+      "description" : "Build process flow",
+      "dimensions" : {
+        "height" : 4419,
+        "width" : 6050
+      },
+      "elementId" : "14",
+      "elements" : [ {
+        "id" : "1",
+        "x" : 900,
+        "y" : 2262
+      }, {
+        "id" : "3",
+        "x" : 5400,
+        "y" : 1662
+      }, {
+        "id" : "12",
+        "x" : 1650,
+        "y" : 1962
+      }, {
+        "id" : "13",
+        "x" : 1650,
+        "y" : 2562
+      }, {
+        "id" : "15",
+        "x" : 2400,
+        "y" : 162
+      }, {
+        "id" : "16",
+        "x" : 2400,
+        "y" : 762
+      }, {
+        "id" : "17",
+        "x" : 2400,
+        "y" : 1362
+      }, {
+        "id" : "18",
+        "x" : 2400,
+        "y" : 1962
+      }, {
+        "id" : "19",
+        "x" : 2400,
+        "y" : 2562
+      }, {
+        "id" : "20",
+        "x" : 2400,
+        "y" : 3162
+      }, {
+        "id" : "21",
+        "x" : 2400,
+        "y" : 3762
+      }, {
+        "id" : "23",
+        "x" : 3150,
+        "y" : 162
+      }, {
+        "id" : "24",
+        "x" : 3150,
+        "y" : 762
+      }, {
+        "id" : "25",
+        "x" : 3150,
+        "y" : 1362
+      }, {
+        "id" : "26",
+        "x" : 3150,
+        "y" : 1962
+      }, {
+        "id" : "27",
+        "x" : 3150,
+        "y" : 2562
+      }, {
+        "id" : "28",
+        "x" : 3150,
+        "y" : 3162
+      }, {
+        "id" : "30",
+        "x" : 3900,
+        "y" : 162
+      }, {
+        "id" : "31",
+        "x" : 3900,
+        "y" : 762
+      }, {
+        "id" : "32",
+        "x" : 3900,
+        "y" : 1362
+      }, {
+        "id" : "33",
+        "x" : 3900,
+        "y" : 1962
+      }, {
+        "id" : "34",
+        "x" : 3900,
+        "y" : 2562
+      }, {
+        "id" : "35",
+        "x" : 3900,
+        "y" : 3162
+      }, {
+        "id" : "36",
+        "x" : 3900,
+        "y" : 3762
+      }, {
+        "id" : "38",
+        "x" : 4650,
+        "y" : 162
+      }, {
+        "id" : "39",
+        "x" : 4650,
+        "y" : 762
+      }, {
+        "id" : "40",
+        "x" : 4650,
+        "y" : 1362
+      }, {
+        "id" : "41",
+        "x" : 4650,
+        "y" : 1962
+      }, {
+        "id" : "42",
+        "x" : 4650,
+        "y" : 2562
+      }, {
+        "id" : "43",
+        "x" : 4650,
+        "y" : 3162
+      }, {
+        "id" : "44",
+        "x" : 4650,
+        "y" : 3762
+      }, {
+        "id" : "148",
+        "x" : 200,
+        "y" : 2212
+      } ],
+      "externalBoundariesVisible" : false,
+      "key" : "BuildProcess",
+      "name" : "Dynamic View: CI/CD Infrastructure",
+      "order" : 7,
+      "relationships" : [ {
+        "description" : "Push code",
+        "id" : "150",
+        "order" : "1",
+        "response" : false
+      }, {
+        "description" : "triggers GitHub Actions workflows",
+        "id" : "45",
+        "order" : "2",
+        "response" : false
+      }, {
+        "description" : "triggers Azure workflows",
+        "id" : "47",
+        "order" : "3",
+        "response" : false
+      }, {
+        "description" : "Trigger Windows build",
+        "id" : "48",
+        "order" : "4",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 2296,
+          "y" : 612
+        } ]
+      }, {
+        "description" : "Trigger Linux builds",
+        "id" : "52",
+        "order" : "5",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 2296,
+          "y" : 1212
+        } ]
+      }, {
+        "description" : "Trigger Linux AppImage builds",
+        "id" : "54",
+        "order" : "6",
+        "response" : false
+      }, {
+        "description" : "Trigger Ubuntu builds",
+        "id" : "60",
+        "order" : "7",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 2204,
+          "y" : 2412
+        }, {
+          "x" : 2296,
+          "y" : 3012
+        } ]
+      }, {
+        "description" : "Trigger ARM64 builds",
+        "id" : "56",
+        "order" : "8",
+        "response" : false
+      }, {
+        "description" : "Trigger ARMHF builds",
+        "id" : "58",
+        "order" : "9",
+        "response" : false
+      }, {
+        "description" : "Trigger MacOS builds",
+        "id" : "62",
+        "order" : "10",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 2296,
+          "y" : 3612
+        } ]
+      }, {
+        "description" : "Uses",
+        "id" : "73",
+        "order" : "11",
+        "response" : false
+      }, {
+        "description" : "Execute Windows build",
+        "id" : "92",
+        "order" : "12",
+        "response" : false
+      }, {
+        "description" : "Uses",
+        "id" : "77",
+        "order" : "13",
+        "response" : false
+      }, {
+        "description" : "Execute Flatpak build",
+        "id" : "95",
+        "order" : "14",
+        "response" : false
+      }, {
+        "description" : "Uses",
+        "id" : "80",
+        "order" : "15",
+        "response" : false
+      }, {
+        "description" : "Execute AppImage build",
+        "id" : "98",
+        "order" : "16",
+        "response" : false
+      }, {
+        "description" : "Uses",
+        "id" : "89",
+        "order" : "17",
+        "response" : false
+      }, {
+        "description" : "Execute Ubuntu build",
+        "id" : "107",
+        "order" : "18",
+        "response" : false
+      }, {
+        "description" : "Uses",
+        "id" : "83",
+        "order" : "19",
+        "response" : false
+      }, {
+        "description" : "Execute ARM64 builds",
+        "id" : "101",
+        "order" : "20",
+        "response" : false
+      }, {
+        "description" : "Uses",
+        "id" : "86",
+        "order" : "21",
+        "response" : false
+      }, {
+        "description" : "Execute ARMHF builds",
+        "id" : "104",
+        "order" : "22",
+        "response" : false
+      }, {
+        "description" : "Execute macOS build",
+        "id" : "110",
+        "order" : "23",
+        "response" : false
+      }, {
+        "description" : "Generate installer",
+        "id" : "118",
+        "order" : "24",
+        "response" : false
+      }, {
+        "description" : "Generate AppImage",
+        "id" : "124",
+        "order" : "25",
+        "response" : false
+      }, {
+        "description" : "Generate Ubuntu build",
+        "id" : "114",
+        "order" : "26",
+        "response" : false
+      }, {
+        "description" : "Generate Flatpak",
+        "id" : "121",
+        "order" : "27",
+        "response" : false
+      }, {
+        "description" : "Generate ARM64 AppImage",
+        "id" : "127",
+        "order" : "28",
+        "response" : false
+      }, {
+        "description" : "Generate ARMHF AppImage",
+        "id" : "130",
+        "order" : "29",
+        "response" : false
+      }, {
+        "description" : "Generate DMG",
+        "id" : "133",
+        "order" : "30",
+        "response" : false
+      }, {
+        "description" : "Upload artifacts",
+        "id" : "136",
+        "order" : "31",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 5204,
+          "y" : 612
+        } ]
+      }, {
+        "description" : "Upload artifacts",
+        "id" : "139",
+        "order" : "32",
+        "response" : false
+      }, {
+        "description" : "Upload artifacts",
+        "id" : "140",
+        "order" : "33",
+        "response" : false
+      }, {
+        "description" : "Upload artifacts",
+        "id" : "141",
+        "order" : "34",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 5204,
+          "y" : 2412
+        } ]
+      }, {
+        "description" : "Upload artifacts",
+        "id" : "138",
+        "order" : "35",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 5204,
+          "y" : 1212
+        } ]
+      }, {
+        "description" : "Upload macOS artifacts",
+        "id" : "142",
+        "order" : "36",
+        "response" : false,
+        "vertices" : [ {
+          "x" : 5204,
+          "y" : 3612
+        } ]
+      } ]
+    } ],
+    "systemLandscapeViews" : [ {
+      "description" : "Overall Scopy deployment ecosystem",
+      "dimensions" : {
+        "height" : 1700,
+        "width" : 6075
+      },
+      "elements" : [ {
+        "id" : "1",
+        "x" : 925,
+        "y" : 543
+      }, {
+        "id" : "2",
+        "x" : 3175,
+        "y" : 243
+      }, {
+        "id" : "3",
+        "x" : 5425,
+        "y" : 518
+      }, {
+        "id" : "4",
+        "x" : 925,
+        "y" : 1143
+      }, {
+        "id" : "11",
+        "x" : 1677,
+        "y" : 540
+      }, {
+        "id" : "14",
+        "x" : 2425,
+        "y" : 543
+      }, {
+        "id" : "22",
+        "x" : 3175,
+        "y" : 843
+      }, {
+        "id" : "29",
+        "x" : 3925,
+        "y" : 843
+      }, {
+        "id" : "37",
+        "x" : 4675,
+        "y" : 843
+      }, {
+        "id" : "148",
+        "x" : 200,
+        "y" : 793
+      }, {
+        "id" : "149",
+        "x" : 4700,
+        "y" : 143
+      } ],
+      "enterpriseBoundaryVisible" : true,
+      "key" : "SystemLandscape",
+      "name" : "System Landscape View",
+      "order" : 1,
+      "relationships" : [ {
+        "id" : "117"
+      }, {
+        "id" : "137"
+      }, {
+        "id" : "150"
+      }, {
+        "id" : "151"
+      }, {
+        "id" : "152"
+      }, {
+        "id" : "46"
+      }, {
+        "id" : "51"
+      }, {
+        "id" : "65"
+      }, {
+        "id" : "72"
+      }, {
+        "id" : "76"
+      } ]
+    } ]
+  }
+}

--- a/docs/architecture/diagrams/export-structurizr.sh
+++ b/docs/architecture/diagrams/export-structurizr.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Structurizr Static Site Generator for GitHub Actions
+# Generates interactive HTML diagrams from workspace.dsl files
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="${SCRIPT_DIR}/_build"
+STRUCTURIZR_CLI_VERSION="2025.11.09"
+STRUCTURIZR_CLI="${SCRIPT_DIR}/structurizr.sh"
+
+echo "Building Structurizr static sites..."
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+# Download Structurizr CLI if not present
+if [ ! -f "${STRUCTURIZR_CLI}" ]; then
+    echo "Downloading Structurizr CLI v${STRUCTURIZR_CLI_VERSION}..."
+    curl -fsSL "https://github.com/structurizr/cli/releases/download/v${STRUCTURIZR_CLI_VERSION}/structurizr-cli.zip" \
+        -o "${SCRIPT_DIR}/structurizr-cli.zip"
+
+    echo "Extracting Structurizr CLI..."
+    cd "${SCRIPT_DIR}"
+    unzip -q structurizr-cli.zip
+    chmod +x structurizr.sh
+    rm -f structurizr-cli.zip
+    cd - > /dev/null
+fi
+
+# Function to export workspace
+export_workspace() {
+    local workspace_dir="$1"
+    local workspace_name="$2"
+    local workspace_title="$3"
+
+    if [ ! -d "${workspace_dir}" ] || [ ! -f "${workspace_dir}/workspace.dsl" ]; then
+        echo "Skipping ${workspace_title} - workspace not found"
+        return 0
+    fi
+
+    echo "Exporting ${workspace_title}..."
+
+    local output_path="${OUTPUT_DIR}/${workspace_name}"
+    mkdir -p "${output_path}"
+
+    (
+        cd "${workspace_dir}"
+        "${STRUCTURIZR_CLI}" export \
+            -workspace workspace.json \
+            -format static \
+            -output "${output_path}"
+    )
+
+    echo "${workspace_title} exported to ${workspace_name}/"
+}
+
+# Export both workspaces
+export_workspace "${SCRIPT_DIR}/app_diagrams" "app-architecture" "Application Architecture"
+export_workspace "${SCRIPT_DIR}/deployment_diagrams" "deployment-architecture" "Deployment Architecture"
+
+echo "Structurizr static sites generated in ${OUTPUT_DIR}"
+
+# Copy diagrams to Sphinx build directory if it exists
+SPHINX_HTML_DIR="${SCRIPT_DIR}/../../_build/html"
+if [ -d "${SPHINX_HTML_DIR}" ]; then
+    echo "Copying diagrams to Sphinx build directory..."
+    mkdir -p "${SPHINX_HTML_DIR}/architecture/diagrams"
+    cp -r "${OUTPUT_DIR}"/* "${SPHINX_HTML_DIR}/architecture/diagrams/"
+    echo "Diagrams copied to ${SPHINX_HTML_DIR}/architecture/diagrams/"
+fi
+
+# GitHub Actions outputs
+if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+    echo "structurizr_output_path=${OUTPUT_DIR}" >> "$GITHUB_OUTPUT"
+fi

--- a/docs/architecture/index.rst
+++ b/docs/architecture/index.rst
@@ -1,0 +1,163 @@
+.. _architecture:
+
+Software Architecture
+=====================
+
+This section provides comprehensive documentation of Scopy's software architecture
+using interactive diagrams. The architecture is documented using Structurizr DSL
+and includes both application and deployment views.
+
+Interactive Diagram Workspaces 
+------------------------------
+
+Application Architecture
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The application architecture workspace provides detailed views of Scopy's internal
+structure, including:
+
+* **Infrastructure Layer**: Application coordination, preferences, logging, and crash reporting
+* **Core Business Logic**: Device management, plugin system, and package management
+* **UI Framework**: Window management, common widgets, and presentation components
+* **Plugin Packages**: M2K, SWIOT, AD936X, ADRV9002, IMU, PQMon and generic plugins
+* **Supporting Libraries**: IIO utilities, GNU Radio widgets, and common utilities
+
+.. tip::
+
+  **View Interactive Application Architecture**
+
+  `Open Application Architecture Diagrams <diagrams/app-architecture/index.html>`_
+
+  Explore 15+ component views showing relationships between infrastructure,
+  core business logic, UI components, and plugin packages.
+
+Deployment Architecture
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The deployment architecture workspace documents the CI/CD pipeline and
+multi-platform build process:
+
+* **Build Infrastructure**: GitHub Actions and Azure DevOps workflows
+* **Docker Environments**: Pre-configured build containers for each platform
+* **Platform Support**: Windows (MinGW), Linux (Flatpak, AppImage), macOS (DMG), ARM platforms
+* **Artifact Distribution**: Automated package creation and GitHub Releases distribution
+
+.. tip::
+
+  **View Interactive Deployment Architecture**
+
+  `Open Deployment Architecture Diagrams <diagrams/deployment-architecture/index.html>`_
+
+  Understand the complete build and deployment pipeline from source code to distributed packages across multiple platforms.
+
+System Context
+--------------
+
+Overview
+~~~~~~~~
+
+Scopy is a multi-functional software toolset with strong capabilities for
+signal analysis, designed to work with Analog Devices hardware evaluation boards.
+
+External Systems
+~~~~~~~~~~~~~~~~
+
+**Hardware Integration**
+
+* **ADI Hardware Devices**: ADALM2000, AD936X, ADRV9002, AD-SWIOT1L-SL, and other evaluation boards
+* **IIO Framework**: Linux Industrial I/O subsystem providing hardware abstraction layer
+
+**Software Ecosystem**
+
+* **GNU Radio**: Signal processing backend for advanced DSP operations
+* **Operating Systems**: Cross-platform support for Linux, Windows, and macOS
+* **File System**: Local and network storage for data, configurations, and logs
+
+Core Components
+---------------
+
+Application Infrastructure
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Application Coordinator**
+  Central orchestration of application startup, shutdown, and lifecycle management
+
+**Device Management**
+  Unified interface for hardware device discovery, connection, and communication
+
+**Plugin System**
+  Dynamic loading and management of device-specific functionality through packages
+
+**Package Manager**
+  Installation and distribution system for plugin packages
+
+**Preferences Management**
+  Centralized configuration storage and user settings persistence
+
+Plugin Architecture
+~~~~~~~~~~~~~~~~~~~
+
+Scopy uses a modular plugin-based architecture where functionality is organized
+into specialized packages:
+
+**Generic Plugins**
+  * ADC Plugin - Interface with IIO ADCs using buffer mechanisms
+  * DAC Plugin - Interface with IIO DACs using buffer or DDS mechanisms
+  * DataLogger Plugin - Data monitoring and logging capabilities
+  * Debugger Plugin - IIO context examination and attribute modification
+  * JESD Status Plugin - JESD204 interface status monitoring
+  * Register Map Plugin - Direct device register access
+
+**Device-Specific Packages**
+  * **M2K Package**: ADALM2000 (M2K) device support with oscilloscope, signal generator, logic analyzer
+  * **SWIOT Package**: AD-SWIOT1L-SL platform support for industrial IoT applications
+  * **AD936X Package**: AD936X transceiver family support for RF applications
+  * **ADRV9002 Package**: ADRV9002 Jupiter transceiver with dual-channel RF capabilities
+  * **IMU Package**: Inertial measurement unit evaluation and analysis tools
+  * **PQMon Package**: Power quality monitoring and analysis capabilities
+
+CI/CD Pipeline
+--------------
+
+Build Infrastructure
+~~~~~~~~~~~~~~~~~~~~
+
+**GitHub Actions Workflows**
+  * Windows MinGW builds with MSYS2 environment
+  * Linux Flatpak sandboxed package creation
+  * Linux AppImage portable application builds
+  * ARM64/ARMHF cross-compilation for embedded platforms
+  * Ubuntu development builds for testing
+
+**Azure DevOps**
+  * macOS DMG package creation using Homebrew dependencies
+
+**Docker Infrastructure**
+  * Pre-configured build environments for each target platform
+  * Consistent dependency management across build systems
+  * Reproducible builds with version-controlled containers
+
+Deployment Targets
+~~~~~~~~~~~~~~~~~~
+
+**Platform Coverage**
+  * Windows: Setup executable (.exe) installer
+  * Linux: Flatpak packages (.flatpak) and AppImage executables (.AppImage)
+  * macOS: Disk image packages (.dmg)
+  * ARM platforms: Cross-compiled AppImage executables for ARM64 and ARMHF
+
+**Distribution**
+  * Automated artifact publishing to GitHub Releases
+  * Version-controlled release management
+  * Multi-platform simultaneous deployment
+
+Source Documentation
+--------------------
+
+The architecture diagrams are generated from version-controlled Structurizr DSL files:
+
+* ``docs/architecture/diagrams/app_diagrams/workspace.json`` - Application architecture definition
+* ``docs/architecture/diagrams/deployment_diagrams/workspace.json`` - Deployment architecture definition
+
+These files are automatically processed during documentation builds to generate
+the interactive diagram websites accessible through the links above.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Contents
    plugins/index
    developer_guide/index
    tests/index
+   architecture/index
 
 
    user_guide/preferences


### PR DESCRIPTION
## Overview
- Set up comprehensive architecture documentation using Structurizr DSL (https://docs.structurizr.com/).
- Add application and deployment diagram workspaces with detailed component views.
- Integrating the generated architecture documentation into Scopy’s github pages by using the Structurizr CLI to export diagrams as a static site (https://docs.structurizr.com/static).

## Testing  
To avoid impacting the existing Scopy github pages documentation, a separate repository was created to host and validate the generated static site. You can preview the **Software Architecture** section here: https://andreidanila1.github.io/docs-test/architecture/index.html