### PR TITLE
ADC: add settings button in channel widget

### DIFF
--- a/gui/src/channelcomponent.cpp
+++ b/gui/src/channelcomponent.cpp
@@ -102,7 +102,8 @@ void ChannelComponent::createMenuControlButton(ChannelComponent *c, QWidget *par
 	c->m_ctrl->setOpenMenuChecksThis(true);
 	c->m_ctrl->setDoubleClickToOpenMenu(true);
 	c->m_ctrl->setColor(c->pen().color());
-	c->m_ctrl->button()->setVisible(false);
+	c->m_ctrl->button()->setVisible(true);
+	c->m_ctrl->button()->setCheckable(false);
 	c->m_ctrl->setCheckable(true);
 
 	connect(c->m_ctrl->checkBox(), &QCheckBox::toggled, c, [=](bool b) {

--- a/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
@@ -208,6 +208,7 @@ void ADCInstrument::addChannel(MenuControlButton *btn, ChannelComponent *ch, Com
 
 	rightStack->add(id, ch_widget);
 
+	connect(btn->button(), &QPushButton::pressed, this, [=]() { Q_EMIT btn->clicked(true); });
 	connect(btn, &QAbstractButton::clicked, this, [=](bool b) {
 		if(b) {
 			switchToChannelMenu(id, true);


### PR DESCRIPTION
This may improve the UX so users find it more intuitive to press the channel widget to open its settings