### PR TITLE
SWIOT fix

### DIFF
--- a/packages/swiot/plugins/swiot/src/ad74413r/ad74413r.cpp
+++ b/packages/swiot/plugins/swiot/src/ad74413r/ad74413r.cpp
@@ -442,6 +442,10 @@ void Ad74413r::setupChannelBtn(MenuControlButton *btn, PlotChannel *ch, QString 
 
 void Ad74413r::setupChannel(int chnlIdx, QString function)
 {
+	bool lazyLoading = Preferences::GetInstance()->get("iiowidgets_use_lazy_loading").toBool();
+	if(lazyLoading) {
+		Preferences::GetInstance()->set("iiowidgets_use_lazy_loading", false);
+	}
 	if(function.compare("no_config") != 0) {
 		QString chnlId(function + " " + QString::number(chnlIdx + 1));
 		QPen chPen = QPen(QColor(StyleHelper::getChannelColor(chnlIdx)), 1);
@@ -516,6 +520,7 @@ void Ad74413r::setupChannel(int chnlIdx, QString function)
 	if(m_currentChannelSelected == 4) {
 		m_swiotAdLogic->initDiagnosticChannels();
 	}
+	Preferences::GetInstance()->set("iiowidgets_use_lazy_loading", lazyLoading);
 }
 
 void Ad74413r::setupChannelsMenuControlBtn(MenuControlButton *btn, QString name)


### PR DESCRIPTION
The acquisition sample rate was not updated when enabling a channel due to lazy loading delaying the read of each channel's sampling frequency. Without this fix, the user must open each channel menu to trigger IIOWidget loading before enabling the desired channels and starting the acquisition.