### PR TITLE
Fix M2K crash on disconnect

### DIFF
--- a/gui/src/symbol_controller.cpp
+++ b/gui/src/symbol_controller.cpp
@@ -58,8 +58,6 @@ SymbolController::SymbolController(QwtPlot *plot)
 
 SymbolController::~SymbolController()
 {
-	// Ensure event filter is removed to prevent use-after-free
-	setEnabled(false);
 	// d_overlay gets destroyed with parent
 }
 


### PR DESCRIPTION
gui/SymbolController: Remove setEnabled from destructor.

The destructor called setEnabled(false) which invoked plot->canvas()->removeEventFilter(this) on an already-destroyed canvas widget during QwtPlot teardown. Qt automatically removes event filters when either object is destroyed, making the manual removal unnecessary.