### PR TITLE
adrv9009: fix menu tool list for multidevice adrv9009

### DIFF
--- a/packages/adrv9009/plugins/adrv9009plugin/src/adrv9009plugin.cpp
+++ b/packages/adrv9009/plugins/adrv9009plugin/src/adrv9009plugin.cpp
@@ -243,6 +243,12 @@ bool Adrv9009Plugin::onDisconnect()
 		m_widgetGroup = nullptr;
 	}
 
+	while(m_toolList.size() > 2) {
+		ToolMenuEntry *entry = m_toolList.takeLast();
+		delete entry;
+	}
+	Q_EMIT toolListChanged();
+
 	// Close connection
 	ConnectionProvider *cp = ConnectionProvider::GetInstance();
 	cp->close(m_param);


### PR DESCRIPTION
When connecting to the multidevice version we dinamically create new tools 
Those need to be removed on disconnect to clean the menu