### PR TITLE
Adc menus icon and qsplitter fix

### DIFF
--- a/gui/include/gui/widgets/menucontrolbutton.h
+++ b/gui/include/gui/widgets/menucontrolbutton.h
@@ -67,6 +67,7 @@ public:
 	void setDoubleClickToOpenMenu(bool b);
 	void setOpenMenuChecksThis(bool b);
 	void enableToolTip(bool en);
+	void setIconEnabled(bool en);
 
 	QCheckBox *checkBox();
 	QPushButton *button();
@@ -90,6 +91,7 @@ private:
 	QCheckBox *m_chk;
 	QLabel *m_label;
 	QPushButton *m_btn;
+	QLabel *m_icon;
 	CheckboxStyle m_cs;
 	QMetaObject::Connection dblClickToOpenMenu;
 	QMetaObject::Connection openMenuChecksThis;

--- a/gui/res/icons/splitter_grip_h.svg
+++ b/gui/res/icons/splitter_grip_h.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11" height="36" viewBox="0 0 11 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- left triangle -->
+  <polygon points="4,13 0,18 4,23" fill="#848B95"/>
+  <!-- right triangle -->
+  <polygon points="7,13 11,18 7,23" fill="#848B95"/>
+</svg>

--- a/gui/res/icons/splitter_grip_v.svg
+++ b/gui/res/icons/splitter_grip_v.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36" height="11" viewBox="0 0 36 11" xmlns="http://www.w3.org/2000/svg">
+  <!-- up triangle -->
+  <polygon points="13,4 18,0 23,4" fill="#848B95"/>
+  <!-- down triangle -->
+  <polygon points="13,7 18,11 23,7" fill="#848B95"/>
+</svg>

--- a/gui/res/resources.qrc
+++ b/gui/res/resources.qrc
@@ -16,6 +16,8 @@
         <file>icons/close_hovered.svg</file>
         <file>icons/gate_handle.svg</file>
         <file>icons/h_cursor_handle.svg</file>
+        <file>icons/splitter_grip_h.svg</file>
+        <file>icons/splitter_grip_v.svg</file>
         <file>icons/handle_down_arrow.svg</file>
         <file>icons/handle_right_arrow.svg</file>
         <file>icons/handle_left_arrow.svg</file>

--- a/gui/src/widgets/menucontrolbutton.cpp
+++ b/gui/src/widgets/menucontrolbutton.cpp
@@ -45,10 +45,20 @@ MenuControlButton::MenuControlButton(QWidget *parent)
 	m_color = Style::getAttribute(json::theme::interactive_primary_idle);
 	m_cs = CS_SQUARE;
 
+	m_icon = new QLabel(this);
+	int iconSize = Style::getDimension(json::global::unit_1);
+	QString iconPath =
+		":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) + "/icons/preferences.svg";
+	m_icon->setPixmap(Style::getPixmap(iconPath, Style::getAttribute(json::theme::content_default))
+				  .scaled(iconSize, iconSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+	m_icon->setAttribute(Qt::WA_TransparentForMouseEvents);
+	m_icon->hide();
+
 	lay->addWidget(m_chk);
 	lay->addWidget(m_label);
 	lay->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
 	lay->addWidget(m_btn);
+	lay->addWidget(m_icon);
 	applyStylesheet();
 
 	connect(this, &QAbstractButton::toggled, this, [=](bool b) {
@@ -57,6 +67,11 @@ MenuControlButton::MenuControlButton(QWidget *parent)
 		if(m_cs == CS_CIRCLE) {
 			Style::setStyle(m_chk, style::properties::checkbox::circleCB, b ? "selected" : "idle", true);
 		}
+
+		int iconSize = Style::getDimension(json::global::unit_1);
+		QColor iconColor = Style::getAttribute(b ? json::theme::content_inverse : json::theme::content_default);
+		m_icon->setPixmap(Style::getPixmap(iconPath, iconColor)
+					  .scaled(iconSize, iconSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 	}); // Hackish - QStyle should be implemented
 
 	dblClickToOpenMenu = QMetaObject::Connection();
@@ -116,6 +131,8 @@ void MenuControlButton::enableToolTip(bool en)
 	m_toolTip = en;
 	m_label->setToolTip(en ? m_label->text() : "");
 }
+
+void MenuControlButton::setIconEnabled(bool en) { m_icon->setVisible(en); }
 
 void MenuControlButton::mouseDoubleClickEvent(QMouseEvent *e)
 {

--- a/gui/style/qss/generic/global.qss
+++ b/gui/style/qss/generic/global.qss
@@ -7,12 +7,31 @@ QWidget {
     font-weight: normal;
 }
 
-QSplitter { color: &content_default& }
-QSplitter::handle:horizontal { width: 6px; }
-QSplitter::handle:vertical { height: 6px; }
-QSplitter::handle:hover { background-color: &background_secondary&; }
-QSplitter::handle:pressed { background-color: &background_secondary&; }
-QSplitter::handle:disabled { background-color: transparent; }
+QSplitter {
+    background-color: &background_subtle&;
+}
+QSplitter::handle:horizontal {
+    width: 11px;
+    background-color: transparent;
+    image: url(:/gui/icons/splitter_grip_h.svg);
+}
+QSplitter::handle:vertical {
+    height: 11px;
+    background-color: transparent;
+    image: url(:/gui/icons/splitter_grip_v.svg);
+}
+QSplitter::handle:horizontal:hover,
+QSplitter::handle:vertical:hover {
+    background-color: &interactive_subtle_hover&;
+}
+QSplitter::handle:horizontal:pressed,
+QSplitter::handle:vertical:pressed {
+    background-color: &interactive_primary_idle&;
+}
+QSplitter::handle:disabled {
+    background-color: transparent;
+    image: none;
+}
 
 QTextBrowser {
     border: none;
@@ -94,16 +113,6 @@ QLineEdit {
     border-radius: &radius_interactive&;
     padding: 0 &padding_interactive& 0 &padding_interactive&;
     selection-background-color: &interactive_subtle_pressed&;
-}
-
-QSplitter {
-    background-color: &background_subtle&;
-}
-QSplitter::handle:horizontal {
-    width: &unit_0_5&;
-}
-QSplitter::handle:vertical {
-    height: &unit_0_5&;
 }
 
 QLabel {

--- a/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
@@ -91,9 +91,19 @@ void ADCInstrument::setupToolLayout()
 	m_splitter->setStretchFactor(0, 0);
 	m_splitter->setStretchFactor(1, 1);
 	m_splitter->setStretchFactor(2, 0);
-	m_splitter->setSizes(QList<int>() << 210 << 600 << 310);
+	const int right_splitter_size = 310;
+	m_splitter->setSizes(QList<int>() << 210 << 600 << right_splitter_size);
 
 	tool->addWidgetToCentralContainerHelper(m_splitter);
+
+	connect(rightStack, &QStackedWidget::currentChanged, this, [=](int) {
+		if(m_splitter->sizes().at(2) == 0) {
+			QList<int> sizes = m_splitter->sizes();
+			sizes[1] -= right_splitter_size;
+			sizes[2] = right_splitter_size;
+			m_splitter->setSizes(sizes);
+		}
+	});
 
 	rightMenuBtnGrp = new SemiExclusiveButtonGroup(this);
 	tool->topContainerMenuControl()->setVisible(false);

--- a/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
@@ -103,12 +103,12 @@ void ADCInstrument::setupToolLayout()
 
 	m_settingsBtn = new MenuControlButton(this);
 	m_settingsBtn->setName("General Settings");
+
 	m_settingsBtn->setOpenMenuChecksThis(true);
 	m_settingsBtn->setDoubleClickToOpenMenu(false);
 	m_settingsBtn->checkBox()->setVisible(false);
-	m_settingsBtn->button()->setCheckable(true);
-	m_settingsBtn->button()->setAttribute(Qt::WA_TransparentForMouseEvents);
-	connect(m_settingsBtn, &QAbstractButton::toggled, m_settingsBtn->button(), &QAbstractButton::setChecked);
+	m_settingsBtn->button()->setVisible(false);
+	m_settingsBtn->setIconEnabled(true);
 
 	InfoBtn *infoBtn = new InfoBtn(this);
 	m_printBtn = new PrintBtn(this);
@@ -229,9 +229,8 @@ void ADCInstrument::addChannel(MenuControlButton *btn, ChannelComponent *ch, Com
 	c->add(btn);
 	channelGroup->addButton(btn);
 	btn->enableToolTip(true);
-	btn->button()->setCheckable(true);
-	btn->button()->setAttribute(Qt::WA_TransparentForMouseEvents);
-	connect(btn, &QAbstractButton::toggled, btn->button(), &QAbstractButton::setChecked);
+	btn->button()->setVisible(false);
+	btn->setIconEnabled(true);
 
 	QString id = ch->name() + QString::number(uuid++);
 	QWidget *ch_widget = dynamic_cast<QWidget *>(ch);


### PR DESCRIPTION
QSplitter style fix for windows (splitter handle used to not have an icon)