### PR TITLE
ci/windows: workaround for docker errors inside windows runners

### DIFF
--- a/.github/workflows/mingwbuild.yml
+++ b/.github/workflows/mingwbuild.yml
@@ -15,6 +15,14 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: Docker issue workaround # This is the recommended workaround for the issue described here: https://github.com/actions/runner-images/issues/13729
+      id: docker-workaround
+      run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+          Start-Service -Name "docker"
+          }
+
     - name: Pull the Docker Image
       run: docker pull cristianbindea/scopy2-mingw64:${{ inputs.docker_tag }}
 


### PR DESCRIPTION
This PR is the recommended workaround for the issue described here: https://github.com/actions/runner-images/issues/13729

Currently there is a chance that the Windows Runner starts with the Docker Service turned off due to an Hyper-V error. This results in an workflow fail when trying to execute any docker command.

`failed to connect to the docker API at npipe:////./pipe/docker_engine; check if the path is correct and if the daemon is running: open //./pipe/docker_engine: The system cannot find the file specified. `

This commit checks for Docker Service status and restarts it if is not running.