### PR TITLE
ci: macos fix annotation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,50 +61,50 @@ jobs:
       if: github.event_name != 'workflow_dispatch'
       uses: ./.github/workflows/get_docker_tag.yml
 
-    ubuntu-qt6-build:
-      needs: docker_tag
-      if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
-      uses: ./.github/workflows/ubuntubuild.yml
-      with:
-        docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
-      secrets:
-        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+    # ubuntu-qt6-build:
+    #   needs: docker_tag
+    #   if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
+    #   uses: ./.github/workflows/ubuntubuild.yml
+    #   with:
+    #     docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
+    #   secrets:
+    #     CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
 
-    appimage-x86_64-qt6:
-      needs: docker_tag
-      if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
-      uses: ./.github/workflows/appimage-x86_64.yml
-      with:
-        docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
-      secrets:
-        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+    # appimage-x86_64-qt6:
+    #   needs: docker_tag
+    #   if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
+    #   uses: ./.github/workflows/appimage-x86_64.yml
+    #   with:
+    #     docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
+    #   secrets:
+    #     CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
 
-    mingw-qt6:
-      needs: docker_tag
-      if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
-      uses: ./.github/workflows/mingwbuild.yml
-      with:
-        docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
-      secrets:
-        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+    # mingw-qt6:
+    #   needs: docker_tag
+    #   if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
+    #   uses: ./.github/workflows/mingwbuild.yml
+    #   with:
+    #     docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
+    #   secrets:
+    #     CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
 
-    arm64-qt6:
-      needs: docker_tag
-      if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
-      uses: ./.github/workflows/appimage-arm64.yml
-      with:
-        docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
-      secrets:
-        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+    # arm64-qt6:
+    #   needs: docker_tag
+    #   if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
+    #   uses: ./.github/workflows/appimage-arm64.yml
+    #   with:
+    #     docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
+    #   secrets:
+    #     CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
 
-    armhf-qt6:
-      needs: docker_tag
-      if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
-      uses: ./.github/workflows/appimage-armhf.yml
-      with:
-        docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
-      secrets:
-        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+    # armhf-qt6:
+    #   needs: docker_tag
+    #   if: always() && (needs.docker_tag.result == 'success' || needs.docker_tag.result == 'skipped')
+    #   uses: ./.github/workflows/appimage-armhf.yml
+    #   with:
+    #     docker_tag: ${{ inputs.docker_tag || needs.docker_tag.outputs.docker_tag }}
+    #   secrets:
+    #     CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
 
     macos-qt6:
       uses: ./.github/workflows/macosbuild.yml

--- a/ci/macOS/install_macos_deps.sh
+++ b/ci/macOS/install_macos_deps.sh
@@ -141,6 +141,12 @@ install_packages() {
 
 		brew update
 
+		# Remove pre-installed third-party taps that cause CI annotation warnings
+		# Must run AFTER brew update (which re-registers them) but BEFORE brew upgrade/install (which emit the warnings)
+		brew untap --force aws/tap 2>/dev/null || true
+		brew untap --force azure/bicep 2>/dev/null || true
+		brew untap --force hashicorp/tap 2>/dev/null || true
+
 		if [ "$major_version" -gt 12 ]; then
 			brew uninstall --force xcodes 2>/dev/null || true
 			brew upgrade --display-times || true #ignore homebrew upgrade errors
@@ -148,12 +154,6 @@ install_packages() {
 			# Note: libtool (v2.4.7) is pre-installed by default, but it can be updated to v2.5.3
 			PACKAGES="$PACKAGES libtool"
 		fi
-
-		# Remove pre-installed third-party taps that cause CI annotation warnings
-		# Must run AFTER brew update/upgrade — those commands re-register taps with installed formulae
-		brew untap --force aws/tap 2>/dev/null || true
-		brew untap --force azure/bicep 2>/dev/null || true
-		brew untap --force hashicorp/tap 2>/dev/null || true
 	fi
 
 

--- a/ci/macOS/install_macos_deps.sh
+++ b/ci/macOS/install_macos_deps.sh
@@ -138,10 +138,16 @@ install_packages() {
 		export HOMEBREW_NO_AUTO_UPDATE=1
 	else
 		echo "Installing packages fresh..."
+
+		# Remove pre-installed third-party taps that cause CI annotation warnings
+		brew untap aws/tap 2>/dev/null || true
+		brew untap azure/bicep 2>/dev/null || true
+		brew untap hashicorp/tap 2>/dev/null || true
+
 		brew update
 
 		if [ "$major_version" -gt 12 ]; then
-			brew pin xcodes 2>/dev/null || true
+			brew uninstall --force xcodes 2>/dev/null || true
 			brew upgrade --display-times || true #ignore homebrew upgrade errors
 			# Workaround: Install or update libtool package only if macOS version is greater than 12
 			# Note: libtool (v2.4.7) is pre-installed by default, but it can be updated to v2.5.3

--- a/ci/macOS/install_macos_deps.sh
+++ b/ci/macOS/install_macos_deps.sh
@@ -139,11 +139,6 @@ install_packages() {
 	else
 		echo "Installing packages fresh..."
 
-		# Remove pre-installed third-party taps that cause CI annotation warnings
-		brew untap aws/tap 2>/dev/null || true
-		brew untap azure/bicep 2>/dev/null || true
-		brew untap hashicorp/tap 2>/dev/null || true
-
 		brew update
 
 		if [ "$major_version" -gt 12 ]; then
@@ -153,6 +148,12 @@ install_packages() {
 			# Note: libtool (v2.4.7) is pre-installed by default, but it can be updated to v2.5.3
 			PACKAGES="$PACKAGES libtool"
 		fi
+
+		# Remove pre-installed third-party taps that cause CI annotation warnings
+		# Must run AFTER brew update/upgrade — those commands re-register taps with installed formulae
+		brew untap --force aws/tap 2>/dev/null || true
+		brew untap --force azure/bicep 2>/dev/null || true
+		brew untap --force hashicorp/tap 2>/dev/null || true
 	fi
 
 


### PR DESCRIPTION
some runner deps are causing warnings, they are not needed by Scopy so I removed them