### PR TITLE
browsemenu: Remove scripting (tme) top line from browse menu.

### DIFF
--- a/core/src/browsemenu.cpp
+++ b/core/src/browsemenu.cpp
@@ -87,6 +87,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 	m_scriptingBtn->installEventFilter(this);
 
 	auto scriptingMenuLine = createHLine(m_content);
+	scriptingMenuLine->setVisible(scriptingEnabled);
 
 	// Connect to preference changes for scripting button
 	Preferences *prefs = Preferences::GetInstance();


### PR DESCRIPTION
You can see the bug in the red box.

<img width="240" height="732" alt="Screenshot from 2026-06-29 10-50-22" src="https://github.com/user-attachments/assets/8060c465-b20d-45e3-8646-97fdbead4525" />
