### PR TITLE
ADC: Frequency markers crash fix

### DIFF
--- a/gui/src/plotmarkercontroller.cpp
+++ b/gui/src/plotmarkercontroller.cpp
@@ -285,7 +285,11 @@ void MarkerPanel::deleteChannel(QString name)
 
 void MarkerPanel::updateChannel(QString name, QList<PlotMarkerController::MarkerInfo> mi)
 {
-	dynamic_cast<MarkerLabel *>(m_map[name])->updateInfo(mi);
+	MarkerLabel *label = dynamic_cast<MarkerLabel *>(m_map[name]);
+	if(!label)
+		return;
+
+	label->updateInfo(mi);
 	setFixedHeight(25 + mi.count() * 20);
 }
 

--- a/packages/generic-plugins/plugins/adc/src/adcfftinstrumentcontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcfftinstrumentcontroller.cpp
@@ -194,18 +194,23 @@ void ADCFFTInstrumentController::createIIOFloatChannel(AcqTreeNode *node)
 		m_defaultRealCh = c;
 		m_plotComponentManager->selectChannel(c);
 	}
+
+	QString markerName = c->name();
+	if(griiofcn && griiofcn->treeParent()) {
+		markerName = griiofcn->treeParent()->name() + ":" + c->name();
+	}
+
 	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [=]() {
 		auto info = c->markerController()->markerInfo();
-		QString name = c->name();
-		m_plotComponentManager->markerPanel()->updateChannel(name, info);
+		m_plotComponentManager->markerPanel()->updateChannel(markerName, info);
 	});
 
 	auto markerController = dynamic_cast<FFTPlotComponentChannel *>(c->plotChannelCmpt())->markerController();
 	connect(markerController, &PlotMarkerController::markerEnabled, this, [=](bool b) {
 		if(b) {
-			m_plotComponentManager->markerPanel()->newChannel(c->name(), c->pen());
+			m_plotComponentManager->markerPanel()->newChannel(markerName, c->pen());
 		} else {
-			m_plotComponentManager->markerPanel()->deleteChannel(c->name());
+			m_plotComponentManager->markerPanel()->deleteChannel(markerName);
 		}
 
 		int markerCount = m_plotComponentManager->markerPanel()->markerCount();
@@ -258,17 +263,22 @@ void ADCFFTInstrumentController::createIIOComplexChannel(AcqTreeNode *node_I, Ac
 		m_defaultComplexCh = c;
 	}
 
+	QString markerName = c->name();
+	if(griiofcn_I && griiofcn_I->treeParent()) {
+		markerName = griiofcn_I->treeParent()->name() + ":" + c->name();
+	}
+
 	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [=]() {
 		auto info = c->markerController()->markerInfo();
-		m_plotComponentManager->markerPanel()->updateChannel(c->name(), info);
+		m_plotComponentManager->markerPanel()->updateChannel(markerName, info);
 	});
 
 	auto markerController = dynamic_cast<FFTPlotComponentChannel *>(c->plotChannelCmpt())->markerController();
 	connect(markerController, &PlotMarkerController::markerEnabled, this, [=](bool b) {
 		if(b) {
-			m_plotComponentManager->markerPanel()->newChannel(c->name(), c->pen());
+			m_plotComponentManager->markerPanel()->newChannel(markerName, c->pen());
 		} else {
-			m_plotComponentManager->markerPanel()->deleteChannel(c->name());
+			m_plotComponentManager->markerPanel()->deleteChannel(markerName);
 		}
 
 		int markerCount = m_plotComponentManager->markerPanel()->markerCount();


### PR DESCRIPTION
this also includes device name in markers names to avoid maker labels being overwritten