### PR TITLE
dds: various fixes for start/stop/resetting scales and frequencies.

### DIFF
--- a/packages/generic-plugins/plugins/dac/include/dac/dacplugin.h
+++ b/packages/generic-plugins/plugins/dac/include/dac/dacplugin.h
@@ -49,6 +49,8 @@ public:
 	QString version() override;
 	QString description() override;
 	QString pkgName() override;
+	void initPreferences() override;
+	bool loadPreferencesPage() override;
 
 public Q_SLOTS:
 	bool onConnect() override;

--- a/packages/generic-plugins/plugins/dac/src/bufferdacaddon.cpp
+++ b/packages/generic-plugins/plugins/dac/src/bufferdacaddon.cpp
@@ -271,6 +271,9 @@ BufferDacAddon::BufferDacAddon(DacDataModel *model, QWidget *parent)
 		chnBtn->button()->setVisible(false);
 		connect(chnBtn->checkBox(), &QCheckBox::toggled, this,
 			[=, this](bool toggled) { m_model->enableBufferChannel(node->getUuid(), toggled); });
+		connect(this, &BufferDacAddon::refreshChannelBtns, this, [=, this]() {
+			m_model->enableBufferChannel(node->getUuid(), chnBtn->checkBox()->isChecked());
+		});
 		channelsContainerLayout->addWidget(chnBtn);
 
 		QWidget *chnMenu = createMenu(node);
@@ -399,7 +402,13 @@ void BufferDacAddon::updateGuiStrategyWidget()
 	}
 }
 
-void BufferDacAddon::enable(bool enable) { m_model->enableBuffer(enable); }
+void BufferDacAddon::enable()
+{
+	m_model->enableBuffer();
+	refreshChannelBtns();
+}
+
+void BufferDacAddon::disable() { m_model->disableBuffer(); }
 
 void BufferDacAddon::setRunning(bool toggled)
 {
@@ -511,3 +520,5 @@ QWidget *BufferDacAddon::createMenu(TxNode *node)
 	layScroll->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
 	return w;
 }
+
+bool BufferDacAddon::isRunnable() { return true; }

--- a/packages/generic-plugins/plugins/dac/src/bufferdacaddon.h
+++ b/packages/generic-plugins/plugins/dac/src/bufferdacaddon.h
@@ -44,12 +44,15 @@ class BufferDacAddon : public DacAddon
 public:
 	BufferDacAddon(DacDataModel *model, QWidget *parent = nullptr);
 	virtual ~BufferDacAddon();
-	virtual void enable(bool enable);
+	virtual void enable();
+	virtual void disable();
 	virtual void setRunning(bool running);
+	virtual bool isRunnable() override;
 
 Q_SIGNALS:
 	void log(QString log);
 	void toggleCyclic(bool toggled);
+	void refreshChannelBtns();
 
 public Q_SLOTS:
 	void dataReload();

--- a/packages/generic-plugins/plugins/dac/src/dacaddon.cpp
+++ b/packages/generic-plugins/plugins/dac/src/dacaddon.cpp
@@ -35,7 +35,9 @@ DacAddon::DacAddon(QWidget *parent)
 
 DacAddon::~DacAddon() {}
 
-void DacAddon::enable(bool enable) {}
+void DacAddon::enable() {}
+
+void DacAddon::disable() {}
 
 QMap<QString, MenuControlButton *> DacAddon::getChannelBtns() { return m_channelBtns; }
 
@@ -44,3 +46,5 @@ QMap<QString, QWidget *> DacAddon::getChannelMenus() { return m_channelMenus; }
 void DacAddon::setRunning(bool running) { m_isRunning = running; }
 
 bool DacAddon::isRunning() { return m_isRunning; }
+
+bool DacAddon::isRunnable() { return false; }

--- a/packages/generic-plugins/plugins/dac/src/dacaddon.h
+++ b/packages/generic-plugins/plugins/dac/src/dacaddon.h
@@ -34,11 +34,13 @@ class DacAddon : public QWidget
 public:
 	DacAddon(QWidget *parent = nullptr);
 	virtual ~DacAddon();
-	virtual void enable(bool enable);
+	virtual void enable();
+	virtual void disable();
 	virtual QMap<QString, MenuControlButton *> getChannelBtns();
 	virtual QMap<QString, QWidget *> getChannelMenus();
 	virtual void setRunning(bool running);
 	virtual bool isRunning();
+	virtual bool isRunnable();
 Q_SIGNALS:
 	void running(bool enabled);
 	void requestChannelMenu(QString uuid);

--- a/packages/generic-plugins/plugins/dac/src/dacdatamanager.cpp
+++ b/packages/generic-plugins/plugins/dac/src/dacdatamanager.cpp
@@ -58,21 +58,20 @@ DacDataManager::DacDataManager(struct iio_device *dev, QWidget *parent)
 	StyleHelper::BackgroundWidget(m_mode);
 	auto cb = m_mode->combo();
 	connect(cb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=, this](int idx) {
+		auto mode = cb->itemData(idx).toInt();
 		auto current = dynamic_cast<DacAddon *>(dacAddonStack->currentWidget());
 		if(current) {
-			current->enable(false);
+			current->disable();
 		}
 
-		auto mode = cb->itemData(idx).toInt();
 		auto next = dynamic_cast<DacAddon *>(dacAddonStack->get(QString::number(mode)));
 		if(next) {
-			next->enable(true);
+			next->enable();
 			Q_EMIT running(next->isRunning());
 		}
 		dacAddonStack->show(QString::number(mode));
 	});
 
-	setupDacMode("Disabled", DAC_DISABLED);
 	setupDacMode("Buffer", DAC_BUFFER);
 	setupDacMode("DDS", DAC_DDS);
 	Q_EMIT m_mode->combo()->currentIndexChanged(0);

--- a/packages/generic-plugins/plugins/dac/src/dacdatamanager.h
+++ b/packages/generic-plugins/plugins/dac/src/dacdatamanager.h
@@ -45,7 +45,6 @@ class DacDataManager : public QWidget
 public:
 	typedef enum
 	{
-		DAC_DISABLED,
 		DAC_BUFFER,
 		DAC_DDS
 	} DacMode;

--- a/packages/generic-plugins/plugins/dac/src/dacdatamodel.cpp
+++ b/packages/generic-plugins/plugins/dac/src/dacdatamodel.cpp
@@ -23,6 +23,8 @@
 #include "txnode.h"
 #include "dac_logging_categories.h"
 
+#include <pluginbase/preferences.h>
+
 #include <algorithm>
 
 #include <QtConcurrentRun>
@@ -35,7 +37,6 @@ DacDataModel::DacDataModel(struct iio_device *dev, QObject *parent)
 	: QObject(parent)
 	, m_ddsTxs({})
 	, m_bufferTxs({})
-	, m_activeDds(false)
 	, m_activeBuffer(false)
 	, m_buffer(nullptr)
 	, m_cyclicBuffer(true)
@@ -94,30 +95,28 @@ bool DacDataModel::isBufferCapable() const { return m_isBufferCapable; }
 
 bool DacDataModel::isDds() const { return m_isDds; }
 
-void DacDataModel::enableBuffer(bool enabled)
+void DacDataModel::disableBuffer()
 {
-	qDebug(CAT_DAC_DATA) << QString("Enable buffer %1").arg(enabled);
-	if(m_isDds && enabled) {
-		enableDds(false);
-	}
-	if(m_isBufferCapable) {
-		m_activeBuffer = enabled;
-		if(!enabled) {
-			stop();
+	qDebug(CAT_DAC_DATA) << QString("Disable buffer.");
+	if(m_isBufferCapable && m_activeBuffer) {
+		for(auto node : qAsConst(m_bufferTxs)) {
+			enableBufferChannel(node->getUuid(), false);
 		}
+	}
+}
+
+void DacDataModel::enableBuffer()
+{
+	qDebug(CAT_DAC_DATA) << QString("Enable buffer.");
+	if(m_isBufferCapable) {
+		m_activeBuffer = true;
 	}
 }
 
 void DacDataModel::enableDds(bool enable)
 {
 	qDebug(CAT_DAC_DATA) << QString("Enable DDS %1").arg(enable);
-	if(m_isBufferCapable && m_activeBuffer && enable) {
-		for(auto node : qAsConst(m_bufferTxs)) {
-			enableBufferChannel(node->getUuid(), false);
-		}
-	}
 	if(m_isDds) {
-		m_activeDds = enable;
 		for(auto tx : qAsConst(m_ddsTxs)) {
 			tx->enableDds(enable);
 		}
@@ -633,6 +632,13 @@ QString DacDataModel::generateToneName(QString chnId)
 	return name;
 }
 
-void DacDataModel::deinitBufferDac() { enableBuffer(false); }
+void DacDataModel::deinitBufferDac() { disableBuffer(); }
 
-void DacDataModel::deinitDdsDac() { enableDds(false); }
+void DacDataModel::deinitDdsDac()
+{
+	auto reset = Preferences::GetInstance()->get("dac_reset_dds_on_disconnect").toBool();
+	if(!reset) {
+		return;
+	}
+	enableDds(false);
+}

--- a/packages/generic-plugins/plugins/dac/src/dacdatamodel.h
+++ b/packages/generic-plugins/plugins/dac/src/dacdatamodel.h
@@ -46,7 +46,8 @@ public:
 	bool isDds() const;
 
 	void enableDds(bool enable);
-	void enableBuffer(bool enabled);
+	void disableBuffer();
+	void enableBuffer();
 
 	QMap<QString, TxNode *> getBufferTxs() const;
 	QMap<QString, TxNode *> getDdsTxs() const;
@@ -96,7 +97,6 @@ private:
 	bool m_repeatFileBuffer;
 	int m_decimation;
 
-	bool m_activeDds;
 	bool m_activeBuffer;
 
 	const QString toneId = "altvoltage";

--- a/packages/generic-plugins/plugins/dac/src/dacplugin.cpp
+++ b/packages/generic-plugins/plugins/dac/src/dacplugin.cpp
@@ -28,6 +28,7 @@
 #include <QLabel>
 #include <deviceiconbuilder.h>
 #include <menusectionwidget.h>
+#include <preferenceshelper.h>
 #include <style.h>
 
 #include <iioutil/connectionprovider.h>
@@ -36,6 +37,43 @@
 
 using namespace scopy;
 using namespace scopy::dac;
+
+void DACPlugin::initPreferences()
+{
+	Preferences *p = Preferences::GetInstance();
+	p->init("dac_reset_dds_on_connect", false);
+	p->init("dac_reset_dds_on_disconnect", true);
+}
+
+bool DACPlugin::loadPreferencesPage()
+{
+	Preferences *p = Preferences::GetInstance();
+
+	m_preferencesPage = new QWidget();
+	QVBoxLayout *layout = new QVBoxLayout(m_preferencesPage);
+
+	MenuSectionCollapseWidget *generalSection = new MenuSectionCollapseWidget(
+		"General", MenuCollapseSection::MHCW_NONE, MenuCollapseSection::MHW_BASEWIDGET);
+	generalSection->contentLayout()->setSpacing(10);
+	layout->addWidget(generalSection);
+	layout->setSpacing(0);
+	layout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
+
+	auto resetOnConnect = PREFERENCE_CHECK_BOX(p, "dac_reset_dds_on_connect", "Reset DDS on connect",
+						   "Reset all DDS settings when connecting to the device. "
+						   "Disable if another application is actively using the DDS.",
+						   generalSection);
+
+	auto resetOnDisconnect = PREFERENCE_CHECK_BOX(p, "dac_reset_dds_on_disconnect", "Reset DDS on disconnect",
+						      "Reset all DDS settings when disconnecting from the device. "
+						      "Disable if another application needs the DDS to keep running.",
+						      generalSection);
+
+	generalSection->contentLayout()->addWidget(resetOnConnect);
+	generalSection->contentLayout()->addWidget(resetOnDisconnect);
+
+	return true;
+}
 
 bool DACPlugin::compatible(QString m_param, QString category)
 {

--- a/packages/generic-plugins/plugins/dac/src/ddsdacaddon.cpp
+++ b/packages/generic-plugins/plugins/dac/src/ddsdacaddon.cpp
@@ -26,6 +26,7 @@
 #include "txtone.h"
 #include "dac_logging_categories.h"
 
+#include <pluginbase/preferences.h>
 #include <gui/widgets/menucontrolbutton.h>
 #include <gui/widgets/menucombo.h>
 #include <gui/mapstackedwidget.h>
@@ -125,11 +126,18 @@ QWidget *DdsDacAddon::setupDdsTx(TxNode *txNode)
 		auto mode = cb->itemData(idx).toInt();
 		ddsModeStack->show(QString::number(mode));
 		TxMode *current = dynamic_cast<TxMode *>(ddsModeStack->get(QString::number(mode)));
-		if(current) {
-			setRunning(mode != TxMode::DISABLED);
-			current->read();
+		if(!current) {
+			return;
 		}
+		current->enable(mode != TxMode::DISABLED);
+		current->read();
 	});
+
+	bool reset = Preferences::GetInstance()->get("dac_reset_dds_on_connect").toBool();
+	if(reset) {
+		ddsModeCombo->combo()->setCurrentIndex(TxMode::DISABLED);
+		dynamic_cast<TxMode *>(ddsModeStack->get(QString::number(TxMode::DISABLED)))->enable(false);
+	}
 
 	ddsModeSection->contentLayout()->addWidget(ddsModeCombo);
 	txHeaderLay->addWidget(txLabelSection, 1);
@@ -138,7 +146,7 @@ QWidget *DdsDacAddon::setupDdsTx(TxNode *txNode)
 
 	txLay->addWidget(txHeader);
 	txLay->addWidget(ddsModeStack);
-	m_txWidgets.insert(tx, ddsModeStack);
+	m_txWidgets.insert(tx, {ddsModeStack, ddsModeCombo});
 
 	return tx;
 }
@@ -151,18 +159,20 @@ QWidget *DdsDacAddon::setupTxMode(TxNode *txNode, unsigned int mode)
 
 DdsDacAddon::~DdsDacAddon() {}
 
-void DdsDacAddon::enable(bool enable)
+void DdsDacAddon::enable()
 {
-	for(auto tx : qAsConst(m_txWidgets)) {
-		dynamic_cast<TxMode *>(tx->currentWidget())->enable(enable);
+	for(auto it = m_txWidgets.constBegin(); it != m_txWidgets.constEnd(); ++it) {
+		int activeTones = dynamic_cast<TxMode *>(it->stack->currentWidget())->load();
+		it->combo->combo()->setCurrentIndex(activeTones);
 	}
 }
 
 void DdsDacAddon::setRunning(bool toggled)
 {
-	m_isRunning = toggled;
-	enable(m_isRunning);
-	Q_EMIT running(m_isRunning);
+	bool reset = Preferences::GetInstance()->get("dac_reset_dds_on_connect").toBool();
+	if(reset) {
+		disable();
+	}
 }
 
 TxMode::TxMode(TxNode *node, unsigned int mode, QWidget *parent)
@@ -223,14 +233,59 @@ void TxMode::read()
 	}
 }
 
+int TxMode::load()
+{
+	int activeTones = 0;
+	bool anyDds = m_node->readDds();
+	if(!anyDds) {
+		return activeTones;
+	}
+
+	read();
+	auto emitterChannel = m_txChannels.at(0);
+	for(int toneIdx = 1; toneIdx <= emitterChannel->toneCount(); toneIdx++) {
+		TxTone *tone = emitterChannel->tone(toneIdx);
+		if(tone->scale().toDouble() != 0) {
+			activeTones = toneIdx;
+		}
+	}
+
+	bool independent = false;
+	for(int chIdx = 1; chIdx < m_txChannels.size(); chIdx++) {
+		for(int toneIdx = 1; toneIdx <= emitterChannel->toneCount(); toneIdx++) {
+			TxTone *emitterTone = emitterChannel->tone(toneIdx);
+			TxTone *otherTone = m_txChannels.at(chIdx)->tone(toneIdx);
+			if(!emitterTone || !otherTone)
+				continue;
+			if(emitterTone->frequency() != otherTone->frequency() ||
+			   emitterTone->scale() != otherTone->scale()) {
+				independent = true;
+				break;
+			}
+		}
+		if(independent) {
+			break;
+		}
+	}
+
+	if(independent) {
+		activeTones = TxMode::INDEPENDENT_IQ_CTRL;
+	}
+	return activeTones;
+}
+
 void TxMode::enable(bool enabled)
 {
-	if(m_mode == TxMode::DISABLED && enabled) {
+	if(m_mode == TxMode::DISABLED) {
+		// Set the "raw" attr to 0 or 1
+		m_node->enableDds(false);
+
+		// Write all the scale attrs to 0 to reset the scales
+		// for all tones in all channels
+		for(int chIdx = 0; chIdx < m_txChannels.size(); chIdx++) {
+			Q_EMIT m_txChannels[chIdx]->resetChannelScales();
+		}
 		return;
-	}
-	// Write all the scale attrs to IIO
-	for(int chIdx = 0; chIdx < m_txChannels.size(); chIdx++) {
-		Q_EMIT m_txChannels[chIdx]->resetChannelScales();
 	}
 
 	// Set the "raw" attr to 0 or 1

--- a/packages/generic-plugins/plugins/dac/src/ddsdacaddon.h
+++ b/packages/generic-plugins/plugins/dac/src/ddsdacaddon.h
@@ -32,18 +32,25 @@ namespace dac {
 class DacDataModel;
 class TxNode;
 class TxChannel;
+
+struct TxWidgets
+{
+	MapStackedWidget *stack;
+	MenuCombo *combo;
+};
+
 class DdsDacAddon : public DacAddon
 {
 	Q_OBJECT
 public:
 	DdsDacAddon(DacDataModel *model, QWidget *parent = nullptr);
 	virtual ~DdsDacAddon();
-	virtual void enable(bool enable);
+	virtual void enable();
 	virtual void setRunning(bool running);
 
 private:
 	DacDataModel *m_model;
-	QMap<QWidget *, MapStackedWidget *> m_txWidgets;
+	QMap<QWidget *, TxWidgets> m_txWidgets;
 	QWidget *setupDdsTx(TxNode *txNode);
 	QWidget *setupTxMode(TxNode *txNode, unsigned int mode);
 };
@@ -60,11 +67,12 @@ public:
 		DISABLED = 0,
 		ONE_TONE = 1,
 		TWO_TONES = 2,
-		INDEPENDENT_IQ_CTRL
+		INDEPENDENT_IQ_CTRL = 3
 	} DdsMode;
 
 	void read();
 	void enable(bool enable);
+	int load();
 
 private:
 	TxNode *m_node;

--- a/packages/generic-plugins/plugins/dac/src/txnode.cpp
+++ b/packages/generic-plugins/plugins/dac/src/txnode.cpp
@@ -71,6 +71,32 @@ unsigned int TxNode::getFormatBits() const { return m_fmtBits; }
 
 bool TxNode::getFormatSigned() const { return m_fmtSigned; }
 
+bool TxNode::readDds() const
+{
+	if(m_channel) {
+		if(iio_channel_get_type(m_channel) == IIO_ALTVOLTAGE) {
+			bool value = false;
+			int ret = iio_channel_attr_read_bool(m_channel, "raw", &value);
+			if(ret < 0) {
+				qDebug(CAT_DAC_DATA) << QString("Can't read DDS channel raw, error: %1").arg(ret);
+				return false;
+			}
+			return value;
+		}
+		return false;
+	}
+
+	if(m_childNodes.size() != 0) {
+		for(auto node : qAsConst(m_childNodes)) {
+			if(node->readDds()) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 bool TxNode::enableDds(bool enable)
 {
 	qDebug(CAT_DAC_DATA) << QString("Try enable:%1 DDS TXNode %2").arg(enable).arg(m_txUuid);

--- a/packages/generic-plugins/plugins/dac/src/txnode.h
+++ b/packages/generic-plugins/plugins/dac/src/txnode.h
@@ -48,6 +48,7 @@ public:
 	bool getFormatSigned() const;
 
 	bool enableDds(bool enable);
+	bool readDds() const;
 
 	const QColor &getColor() const;
 	void setColor(const QColor &newColor);


### PR DESCRIPTION
If a different application configured the DDS to run, Scopy should allow the user to select the non resetting startup and shutdown in order not to break the other configurations.

Changes to check or fix:

- [x] Using the on_connect/on_shutdown preference, Scopy should not reset the scales and "raw" enables of DDS channels. This can be tested by connecting the IIO-OSC and then connecting/disconnecting Scopy while the OSC generates a Tone.
- [x] Switching between DDS modes no longer resets the scale to -Inf, disabling the DDS channels. Again, this can be tested with the IIO OSC running in the background, while Scopy switches between modes just for configuration visualizing purposes, without messing up the initial config.
- [x] Scopy reads the config values when switching from Buffer/Disabled to DDS mode, such that it can detect if any Tone are configured and automatically switch the TX to that TONE.


