### PR TITLE
core: standardize on C++20 and raise CMake min version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 enable_testing()
 
 project(scopy VERSION 2.3.0 LANGUAGES CXX)
@@ -55,7 +55,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_compile_definitions(QT_MESSAGELOGCONTEXT)

--- a/ci/arm/cmake_toolchain_armhf.cmake
+++ b/ci/arm/cmake_toolchain_armhf.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 # Cross-compilation toolchain for armhf (ARM32 hard-float) from x86_64 Uses Ubuntu cross-compiler with Kuiper Linux
 # sysroot

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE common)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE core)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/core/src/browsemenu.cpp
+++ b/core/src/browsemenu.cpp
@@ -65,7 +65,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 	homeBtn->setChecked(true);
 	homeBtn->setIconSize(QSize(32, 32));
 	homeBtn->setStyleSheet("text-align: left");
-	connect(homeBtn, &QPushButton::clicked, this, [=]() { Q_EMIT requestTool(HOME_ID); });
+	connect(homeBtn, &QPushButton::clicked, this, [this]() { Q_EMIT requestTool(HOME_ID); });
 	connect(this, &BrowseMenu::collapsed, homeBtn,
 		[this, homeBtn](bool collapsed) { hideBtnText(homeBtn, tr("Home"), collapsed); });
 	m_btnsMap[HOME_ID] = homeBtn;
@@ -80,7 +80,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 	m_scriptingBtn->setChecked(false);
 
 	m_btnsMap[SCRIPTING_ID] = m_scriptingBtn;
-	connect(m_scriptingBtn, &QPushButton::clicked, this, [=]() { Q_EMIT requestTool(SCRIPTING_ID); });
+	connect(m_scriptingBtn, &QPushButton::clicked, this, [this]() { Q_EMIT requestTool(SCRIPTING_ID); });
 	bool scriptingEnabled = Preferences::get("general_scripting_enabled").toBool();
 	m_scriptingBtn->setVisible(scriptingEnabled);
 
@@ -91,7 +91,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 
 	// Connect to preference changes for scripting button
 	Preferences *prefs = Preferences::GetInstance();
-	connect(prefs, &Preferences::preferenceChanged, this, [=](QString key, QVariant val) {
+	connect(prefs, &Preferences::preferenceChanged, this, [this, scriptingMenuLine](QString key, QVariant val) {
 		if(key == "general_scripting_enabled") {
 			bool enabled = val.toBool();
 			m_scriptingBtn->setVisible(enabled);
@@ -122,7 +122,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 					":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) +
 						"/icons/preferences.svg",
 					m_content);
-	connect(pkgBtn, &QPushButton::clicked, this, [=]() { Q_EMIT requestTool(PACKAGE_ID); });
+	connect(pkgBtn, &QPushButton::clicked, this, [this]() { Q_EMIT requestTool(PACKAGE_ID); });
 	pkgBtn->setCheckable(true);
 	m_btnsMap[PACKAGE_ID] = pkgBtn;
 
@@ -130,7 +130,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 						":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) +
 							"/icons/preferences.svg",
 						m_content);
-	connect(preferencesBtn, &QPushButton::clicked, this, [=]() { Q_EMIT requestTool(PREFERENCES_ID); });
+	connect(preferencesBtn, &QPushButton::clicked, this, [this]() { Q_EMIT requestTool(PREFERENCES_ID); });
 	preferencesBtn->setCheckable(true);
 	m_btnsMap[PREFERENCES_ID] = preferencesBtn;
 
@@ -141,7 +141,7 @@ BrowseMenu::BrowseMenu(QWidget *parent)
 	aboutBtn->setIconSize(
 		QSize(Style::getDimension(json::global::unit_2), Style::getDimension(json::global::unit_2)));
 	aboutBtn->setCheckable(true);
-	connect(aboutBtn, &QPushButton::clicked, this, [=]() { Q_EMIT requestTool(ABOUT_ID); });
+	connect(aboutBtn, &QPushButton::clicked, this, [this]() { Q_EMIT requestTool(ABOUT_ID); });
 	m_btnsMap[ABOUT_ID] = aboutBtn;
 
 	QLabel *logo = createScopyLogo(m_content);

--- a/core/src/deviceimpl.cpp
+++ b/core/src/deviceimpl.cpp
@@ -265,8 +265,8 @@ void DeviceImpl::loadBadges()
 	forgetBtn->setMaximumSize(25, 25);
 	forgetBtn->setIcon(QPixmap(":/gui/icons/orange_close.svg"));
 	connect(forgetBtn, &QPushButton::clicked, this, &DeviceImpl::forget);
-	connect(this, &DeviceImpl::connecting, this, [=]() { forgetBtn->setEnabled(false); });
-	connect(this, &DeviceImpl::connected, this, [=]() { forgetBtn->setEnabled(true); });
+	connect(this, &DeviceImpl::connecting, this, [forgetBtn]() { forgetBtn->setEnabled(false); });
+	connect(this, &DeviceImpl::connected, this, [forgetBtn]() { forgetBtn->setEnabled(true); });
 	HoverWidget *forgetHover = new HoverWidget(forgetBtn, m_icon, m_icon);
 	forgetHover->setStyleSheet("background-color: transparent; border: 0px;");
 	forgetHover->setAnchorPos(HoverPosition::HP_BOTTOMRIGHT);

--- a/core/src/deviceloader.cpp
+++ b/core/src/deviceloader.cpp
@@ -48,7 +48,7 @@ void DeviceLoader::asyncInit()
 	QThread *th = new QThread();
 	connect(
 		th, &QThread::started, d,
-		[=]() {
+		[this, th]() {
 			// initializer thread
 			d->init();
 			th->quit(); // this replicates QThread::create behaviour of exiting the event loop after
@@ -57,7 +57,7 @@ void DeviceLoader::asyncInit()
 		Qt::QueuedConnection);
 
 #else
-	QThread *th = QThread::create([=] {
+	QThread *th = QThread::create([this] {
 		// initializer thread
 		d->init();
 	});
@@ -69,7 +69,7 @@ void DeviceLoader::asyncInit()
 
 	connect(
 		th, &QThread::destroyed, this,
-		[=]() {
+		[this]() {
 			;
 			// back to main thread
 			d->moveToThread(QThread::currentThread());

--- a/core/src/devicemanager.cpp
+++ b/core/src/devicemanager.cpp
@@ -76,7 +76,7 @@ QString DeviceManager::createDevice(QString category, QString param, bool async,
 	DeviceImpl *d = DeviceFactory::build(param, category);
 	DeviceLoader *dl = new DeviceLoader(d, this);
 
-	connect(dl, &DeviceLoader::initialized, this, [=]() {
+	connect(dl, &DeviceLoader::initialized, this, [this, d, plugins]() {
 		QList<Plugin *> availablePlugins = d->plugins();
 		if(!plugins.isEmpty()) {
 			for(Plugin *p : std::as_const(availablePlugins)) {
@@ -141,11 +141,11 @@ QString DeviceManager::reloadDevice(QString id, QStringList plugins)
 
 void DeviceManager::connectDeviceToManager(DeviceImpl *d)
 {
-	connect(d, &DeviceImpl::connecting, this, [=]() { connectingDevice(d->id()); });
-	connect(d, &DeviceImpl::connected, this, [=]() { connectDevice(d->id()); });
-	connect(d, &DeviceImpl::disconnecting, this, [=]() { disconnectingDevice(d->id()); });
-	connect(d, &DeviceImpl::disconnected, this, [=]() { disconnectDevice(d->id()); });
-	connect(d, &DeviceImpl::forget, this, [=]() { removeDeviceById(d->id()); });
+	connect(d, &DeviceImpl::connecting, this, [this, d]() { connectingDevice(d->id()); });
+	connect(d, &DeviceImpl::connected, this, [this, d]() { connectDevice(d->id()); });
+	connect(d, &DeviceImpl::disconnecting, this, [this, d]() { disconnectingDevice(d->id()); });
+	connect(d, &DeviceImpl::disconnected, this, [this, d]() { disconnectDevice(d->id()); });
+	connect(d, &DeviceImpl::forget, this, [this, d]() { removeDeviceById(d->id()); });
 	connect(d, &DeviceImpl::requestReload, this, &DeviceManager::reloadDevice);
 	connect(d, &DeviceImpl::requestedRestart, this, QOverload<>::of(&DeviceManager::restartDevice));
 	connect(d, &DeviceImpl::toolListChanged, this, &DeviceManager::changeToolListDevice);

--- a/core/src/iiotabwidget.cpp
+++ b/core/src/iiotabwidget.cpp
@@ -144,12 +144,13 @@ void IioTabWidget::setupConnections()
 		m_serialDescriptionLabel->setText(m_serialPortsNames[crtText]);
 		Q_EMIT uriChanged(getSerialPath());
 	});
-	connect(m_baudRateCb->combo(), &QComboBox::textActivated, this, [=]() { Q_EMIT uriChanged(getSerialPath()); });
-	connect(m_serialFrameEdit, &QLineEdit::returnPressed, this, [=]() { Q_EMIT uriChanged(getSerialPath()); });
+	connect(m_baudRateCb->combo(), &QComboBox::textActivated, this,
+		[this]() { Q_EMIT uriChanged(getSerialPath()); });
+	connect(m_serialFrameEdit, &QLineEdit::returnPressed, this, [this]() { Q_EMIT uriChanged(getSerialPath()); });
 	connect(this, &IioTabWidget::uriChanged, this, &IioTabWidget::updateUri);
-	connect(m_uriEdit, &QLineEdit::returnPressed, this, [=]() { Q_EMIT m_btnVerify->clicked(); });
+	connect(m_uriEdit, &QLineEdit::returnPressed, this, [this]() { Q_EMIT m_btnVerify->clicked(); });
 	connect(m_uriEdit, &QLineEdit::textChanged, this,
-		[=](QString uri) { m_btnVerify->setEnabled(!uri.isEmpty()); });
+		[this](QString uri) { m_btnVerify->setEnabled(!uri.isEmpty()); });
 }
 
 QStringList IioTabWidget::computeBackendsList()
@@ -170,7 +171,7 @@ QCheckBox *IioTabWidget::createBackendCheckBox(QString backEnd, QWidget *parent)
 {
 	QCheckBox *cb = new QCheckBox(backEnd, m_filterWidget);
 	cb->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-	connect(cb, &QCheckBox::toggled, this, [=](bool en) {
+	connect(cb, &QCheckBox::toggled, this, [this, backEnd](bool en) {
 		if(en) {
 			m_scanParamsList.push_back(backEnd + ":");
 		} else {

--- a/core/src/scopyaboutpage.cpp
+++ b/core/src/scopyaboutpage.cpp
@@ -89,13 +89,13 @@ void ScopyAboutPage::initNavigationWidget(QTextBrowser *browser)
 	backwardButton->setEnabled(false);
 	connect(backwardButton, &QPushButton::clicked, browser, &QTextBrowser::backward);
 	connect(browser, &QTextBrowser::backwardAvailable, backwardButton,
-		[=](bool available) { backwardButton->setEnabled(available); });
+		[backwardButton](bool available) { backwardButton->setEnabled(available); });
 
 	QPushButton *forwardButton = navWidget->getForwardBtn();
 	forwardButton->setEnabled(false);
 	connect(forwardButton, &QPushButton::clicked, browser, &QTextBrowser::forward);
 	connect(browser, &QTextBrowser::forwardAvailable, forwardButton,
-		[=](bool available) { forwardButton->setEnabled(available); });
+		[forwardButton](bool available) { forwardButton->setEnabled(available); });
 
 	HoverWidget *hover = new HoverWidget(navWidget, browser, browser);
 	hover->setAnchorPos(HoverPosition::HP_TOPRIGHT);

--- a/core/src/scopyhomeaddpage.cpp
+++ b/core/src/scopyhomeaddpage.cpp
@@ -74,7 +74,7 @@ ScopyHomeAddPage::ScopyHomeAddPage(QWidget *parent)
 
 	connect(m_emuWidget, &EmuWidget::emuDeviceAvailable, this, &ScopyHomeAddPage::onEmuDeviceAvailable);
 
-	connect(m_stackedWidget, &QStackedWidget::currentChanged, this, [=]() {
+	connect(m_stackedWidget, &QStackedWidget::currentChanged, this, [this]() {
 		if(m_stackedWidget->currentWidget() == m_addPage) {
 			m_addBtn->setFocus();
 		}
@@ -147,7 +147,7 @@ void ScopyHomeAddPage::deviceLoaderInitialized()
 		pluginDescription->checkBox()->setChecked(p->enabled());
 		m_pluginBrowserSection->contentLayout()->addWidget(pluginDescription);
 		m_pluginDescriptionList.push_back(pluginDescription);
-		connect(pluginDescription->checkBox(), &QCheckBox::toggled, this, [=](bool en) { p->setEnabled(en); });
+		connect(pluginDescription->checkBox(), &QCheckBox::toggled, this, [p](bool en) { p->setEnabled(en); });
 	}
 	m_stackedWidget->setCurrentWidget(m_addPage);
 	Q_EMIT verifyFinished(true);

--- a/core/src/scopyhomepage.cpp
+++ b/core/src/scopyhomepage.cpp
@@ -61,8 +61,9 @@ ScopyHomePage::ScopyHomePage(QWidget *parent)
 	connect(db, &DeviceBrowser::requestDevice, this, [this](QString dev, int) { Q_EMIT requestDevice(dev); });
 	connect(this, &ScopyHomePage::deviceAddedToUi, add, &ScopyHomeAddPage::deviceAddedToUi);
 
-	connect(add, &ScopyHomeAddPage::requestDevice, this, [=](QString id) { Q_EMIT db->requestDevice(id, -1); });
-	connect(add, &ScopyHomeAddPage::newDeviceAvailable, this, [=](DeviceImpl *d) { Q_EMIT newDeviceAvailable(d); });
+	connect(add, &ScopyHomeAddPage::requestDevice, this, [db](QString id) { Q_EMIT db->requestDevice(id, -1); });
+	connect(add, &ScopyHomeAddPage::newDeviceAvailable, this,
+		[this](DeviceImpl *d) { Q_EMIT newDeviceAvailable(d); });
 
 	connect(db, &DeviceBrowser::displayNameChanged, this, &ScopyHomePage::displayNameChanged);
 }

--- a/core/src/scopymainwindow.cpp
+++ b/core/src/scopymainwindow.cpp
@@ -152,7 +152,7 @@ ScopyMainWindow::ScopyMainWindow(QWidget *parent)
 	ScopySplashscreen::showMessage("Loading homepage");
 	hp = new ScopyHomePage(this);
 	m_sbc = new ScanButtonController(scanCycle, hp->scanControlBtn(), this);
-	connect(hp->scanBtn(), &QPushButton::clicked, this, [=]() { scanTask->run(); });
+	connect(hp->scanBtn(), &QPushButton::clicked, this, [this]() { scanTask->run(); });
 
 	DeviceAutoConnect::initPreferences();
 	dm = new DeviceManager(this);
@@ -187,10 +187,10 @@ ScopyMainWindow::ScopyMainWindow(QWidget *parent)
 
 	connect(dm, &DeviceManager::deviceConnecting, hp, &ScopyHomePage::connectingDevice);
 
-	connect(dm, &DeviceManager::deviceConnecting, this, [=]() { handleScanner(); });
-	connect(dm, &DeviceManager::deviceConnected, this, [=]() { handleScanner(); });
-	connect(dm, &DeviceManager::deviceDisconnecting, this, [=]() { handleScanner(); });
-	connect(dm, &DeviceManager::deviceDisconnected, this, [=]() { handleScanner(); });
+	connect(dm, &DeviceManager::deviceConnecting, this, [this]() { handleScanner(); });
+	connect(dm, &DeviceManager::deviceConnected, this, [this]() { handleScanner(); });
+	connect(dm, &DeviceManager::deviceDisconnecting, this, [this]() { handleScanner(); });
+	connect(dm, &DeviceManager::deviceDisconnected, this, [this]() { handleScanner(); });
 	connect(dm, &DeviceManager::deviceConnecting, this, [this](const QString &deviceId) {
 		Device *d = dm->getDevice(deviceId);
 		if(d && d->param().contains("usb:")) {
@@ -575,7 +575,7 @@ void ScopyMainWindow::loadOpenGL()
 			"Please visit the <a "
 			"href=https://wiki.analog.com/university/tools/m2k/scopy-troubleshooting> Wiki "
 			"Analog page</a> for troubleshooting.");
-		connect(restarter, &RestartDialog::restartButtonClicked, [=] {
+		connect(restarter, &RestartDialog::restartButtonClicked, [restarter] {
 			ApplicationRestarter::triggerRestart();
 			restarter->deleteLater();
 		});

--- a/core/src/scopypreferencespage.cpp
+++ b/core/src/scopypreferencespage.cpp
@@ -114,7 +114,7 @@ void ScopyPreferencesPage::updateSessionDevices(QMap<QString, QStringList> devic
 			devCb->setChecked(Preferences::get(prefId).toBool());
 			m_connDevices[uri] = devCb;
 			m_autoConnectWidget->contentLayout()->insertWidget(btnIdx, devCb);
-			connect(devCb, &QCheckBox::toggled, this, [=](bool en) {
+			connect(devCb, &QCheckBox::toggled, this, [uri, prefId, devices](bool en) {
 				if(en) {
 					DeviceAutoConnect::addDevice(uri, devices[uri]);
 				} else {
@@ -152,7 +152,7 @@ void ScopyPreferencesPage::initRestartWidget()
 
 	connect(btn, &QPushButton::clicked, btn, []() { ApplicationRestarter::triggerRestart(); });
 	connect(Preferences::GetInstance(), &Preferences::restartRequired, this,
-		[=]() { restartWidget->setVisible(true); });
+		[this]() { restartWidget->setVisible(true); });
 }
 
 QWidget *ScopyPreferencesPage::buildSaveSessionPreference()
@@ -172,7 +172,7 @@ QWidget *ScopyPreferencesPage::buildSaveSessionPreference()
 	Style::setStyle(navigateBtn, style::properties::button::borderButton);
 	navigateBtn->setMaximumWidth(Style::getDimension(json::global::unit_5));
 	connect(navigateBtn, &QPushButton::clicked, this,
-		[=]() { QDesktopServices::openUrl(QUrl("file:" + scopy::config::settingsFolderPath())); });
+		[]() { QDesktopServices::openUrl(QUrl("file:" + scopy::config::settingsFolderPath())); });
 	lay->addWidget(navigateBtn);
 	return w;
 }

--- a/core/src/scriptingtool.cpp
+++ b/core/src/scriptingtool.cpp
@@ -75,10 +75,10 @@ ScriptingTool::ScriptingTool(QWidget *parent)
 	Style::setStyle(m_codeEditor, style::properties::widget::basicComponent);
 	Style::setStyle(m_codeEditor, style::properties::widget::border_interactive);
 
-	connect(loadBtn, &QPushButton::clicked, this, [=]() { loadFile(); });
-	connect(saveBtn, &QPushButton::clicked, this, [=]() { saveToFile(); });
-	connect(saveAsBtn, &QPushButton::clicked, this, [=]() { saveFileAs(); });
-	connect(m_runBtn, &QPushButton::clicked, this, [=]() { evaluateCode(m_codeEditor->toPlainText()); });
+	connect(loadBtn, &QPushButton::clicked, this, [this]() { loadFile(); });
+	connect(saveBtn, &QPushButton::clicked, this, [this]() { saveToFile(); });
+	connect(saveAsBtn, &QPushButton::clicked, this, [this]() { saveFileAs(); });
+	connect(m_runBtn, &QPushButton::clicked, this, [this]() { evaluateCode(m_codeEditor->toPlainText()); });
 
 	m_console = new QPlainTextEdit(m_tool);
 	m_console->setReadOnly(true);

--- a/core/src/toolmenumanager.cpp
+++ b/core/src/toolmenumanager.cpp
@@ -320,7 +320,7 @@ void ToolMenuManager::initToolMenuHeaderWidget(MenuCollapseHeader *header, const
 	Style::setStyle(header, style::properties::widget::ledBorder, isConnected);
 	thw->deviceBtn()->setCheckable(dInfo.hasConfigPage);
 	menuBtnGroup->addButton(thw->deviceBtn());
-	connect(thw->deviceBtn(), &QPushButton::toggled, this, [=](bool en) {
+	connect(thw->deviceBtn(), &QPushButton::toggled, this, [this, header, dInfo](bool en) {
 		if(en) {
 			Style::setStyle(header, style::properties::widget::deviceHeaderWidget, "selected");
 			Q_EMIT requestToolSelect(dInfo.id);
@@ -349,7 +349,8 @@ ToolMenuItem *ToolMenuManager::createToolMenuItem(ToolMenuEntry *tme, QWidget *p
 	toolMenuItem->onCollapsed(m_collapsed);
 	connect(toolMenuItem->getToolRunBtn(), &QPushButton::toggled, tme, &ToolMenuEntry::runToggled);
 	connect(toolMenuItem->getToolRunBtn(), &QPushButton::clicked, tme, &ToolMenuEntry::runClicked);
-	connect(toolMenuItem, &QPushButton::clicked, this, [=]() { Q_EMIT requestToolSelect(toolMenuItem->getId()); });
+	connect(toolMenuItem, &QPushButton::clicked, this,
+		[this, toolMenuItem]() { Q_EMIT requestToolSelect(toolMenuItem->getId()); });
 	connect(toolMenuItem, &ToolMenuItem::doubleclick, this, [this, tme]() { setTmeAttached(tme); });
 	connect(tme, &ToolMenuEntry::updateToolEntry, toolMenuItem, &ToolMenuItem::updateItem);
 	connect(this, &ToolMenuManager::toolStackChanged, toolMenuItem, &ToolMenuItem::selectCrtItem);

--- a/core/src/whatsnewoverlay.cpp
+++ b/core/src/whatsnewoverlay.cpp
@@ -60,7 +60,7 @@ WhatsNewOverlay::WhatsNewOverlay(QWidget *parent)
 	optionsControlLayout->addWidget(showAgain);
 
 	Preferences *p = Preferences::GetInstance();
-	connect(showAgain, &QCheckBox::toggled, this, [=](bool en) {
+	connect(showAgain, &QCheckBox::toggled, this, [p](bool en) {
 		p->set("general_dont_show_whats_new", en);
 		if(en) {
 			p->set("scopy_git_version", QString(SCOPY_VERSION_GIT));
@@ -73,10 +73,10 @@ WhatsNewOverlay::WhatsNewOverlay(QWidget *parent)
 	m_versionCb = new QComboBox(optionsoverlayControlWidget);
 
 	connect(m_versionCb, qOverload<int>(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { m_carouselWidget->setCurrentIndex(idx); });
+		[this](int idx) { m_carouselWidget->setCurrentIndex(idx); });
 
 	QPushButton *okButton = new QPushButton("Ok", optionsoverlayControlWidget);
-	connect(okButton, &QPushButton::clicked, this, [=]() { this->deleteLater(); });
+	connect(okButton, &QPushButton::clicked, this, [this]() { this->deleteLater(); });
 	Style::setStyle(okButton, style::properties::button::basicButton, true, true);
 	optionsControlLayout->addWidget(okButton);
 
@@ -202,11 +202,12 @@ void WhatsNewOverlay::generateVersionPage(QString filePath)
 				htmlPageButton->setChecked(true);
 			}
 
-			connect(htmlPageButton, &QPushButton::toggled, this, [=](bool toggled) {
-				if(toggled) {
-					versionCarouselWithControls->setCurrentIndex(i);
-				}
-			});
+			connect(htmlPageButton, &QPushButton::toggled, this,
+				[versionCarouselWithControls, i](bool toggled) {
+					if(toggled) {
+						versionCarouselWithControls->setCurrentIndex(i);
+					}
+				});
 
 			carouselControlayout->addWidget(htmlPageButton, 0, Qt::AlignBottom);
 			m_carouselButtons->addButton(htmlPageButton, i);
@@ -224,13 +225,13 @@ void WhatsNewOverlay::generateVersionPage(QString filePath)
 			new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Expanding));
 		carouselControlayout->addWidget(next);
 
-		connect(previous, &QPushButton::clicked, this, [=]() {
+		connect(previous, &QPushButton::clicked, this, [m_carouselButtons, numberOfPages]() {
 			int currentIndex = m_carouselButtons->checkedId();
 			int previousIndex = (currentIndex - 1 + numberOfPages) % numberOfPages;
 			m_carouselButtons->button(previousIndex)->setChecked(true);
 		});
 
-		connect(next, &QPushButton::clicked, this, [=]() {
+		connect(next, &QPushButton::clicked, this, [m_carouselButtons, numberOfPages]() {
 			int currentIndex = m_carouselButtons->checkedId();
 			int nextIndex = (currentIndex + 1) % numberOfPages;
 			m_carouselButtons->button(nextIndex)->setChecked(true);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/gr-util/CMakeLists.txt
+++ b/gr-util/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE gr-util)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/gr-util/test/CMakeLists.txt
+++ b/gr-util/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 set(SCOPY_MODULE gui)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
 
@@ -26,7 +26,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/gui/src/channelcomponent.cpp
+++ b/gui/src/channelcomponent.cpp
@@ -117,7 +117,7 @@ void ChannelComponent::createMenuControlButton(ChannelComponent *c, QWidget *par
 	c->m_ctrl->button()->setCheckable(false);
 	c->m_ctrl->setCheckable(true);
 
-	connect(c->m_ctrl->checkBox(), &QCheckBox::toggled, c, [=](bool b) {
+	connect(c->m_ctrl->checkBox(), &QCheckBox::toggled, c, [c](bool b) {
 		if(b) {
 			c->enable();
 		} else {

--- a/gui/src/cursorcontroller.cpp
+++ b/gui/src/cursorcontroller.cpp
@@ -83,32 +83,32 @@ void CursorController::connectSignals(CursorSettings *cursorSettings)
 		&CursorController::readoutsDragToggled);
 
 	//  update session in case the settings are conncted to multiple controllers
-	connect(cursorSettings, &CursorSettings::sessionUpdated, this, [=]() { setVisible(isVisible()); });
+	connect(cursorSettings, &CursorSettings::sessionUpdated, this, [this]() { setVisible(isVisible()); });
 	cursorSettings->updateSession();
 
 	// cursor movement
-	connect(y1Cursor, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(y1Cursor, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		if(yLock) {
 			y2Cursor->setPositionSilent(pos - yLockGap);
 			plotCursorReadouts->setY2(y2Cursor->getPosition());
 		}
 		plotCursorReadouts->setY1(pos);
 	});
-	connect(y2Cursor, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(y2Cursor, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		if(yLock) {
 			y1Cursor->setPositionSilent(pos + yLockGap);
 			plotCursorReadouts->setY1(y1Cursor->getPosition());
 		}
 		plotCursorReadouts->setY2(pos);
 	});
-	connect(x1Cursor, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(x1Cursor, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		if(xLock) {
 			x2Cursor->setPositionSilent(pos - LockGap);
 			plotCursorReadouts->setX2(x2Cursor->getPosition());
 		}
 		plotCursorReadouts->setX1(pos);
 	});
-	connect(x2Cursor, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(x2Cursor, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		if(xLock) {
 			x1Cursor->setPositionSilent(pos + LockGap);
 			plotCursorReadouts->setX1(x1Cursor->getPosition());
@@ -223,14 +223,14 @@ void CursorController::syncXCursorControllers(CursorController *ctrl1, CursorCon
 	ctrl2->x2Cursor->setPosition(ctrl1->x2Cursor->getPosition());
 
 	// connect ctrl1 to ctrl2
-	connect(ctrl1->x1Cursor, &PlotAxisHandle::scalePosChanged, ctrl2->x1Cursor, [=](double pos) {
+	connect(ctrl1->x1Cursor, &PlotAxisHandle::scalePosChanged, ctrl2->x1Cursor, [ctrl1, ctrl2](double pos) {
 		ctrl1->x1Cursor->blockSignals(true);
 		ctrl2->x1Cursor->setPosition(pos);
 		ctrl1->x1Cursor->blockSignals(false);
 		ctrl2->x1Cursor->repaint();
 		ctrl2->m_plot->repaint();
 	});
-	connect(ctrl1->x2Cursor, &PlotAxisHandle::scalePosChanged, ctrl2->x2Cursor, [=](double pos) {
+	connect(ctrl1->x2Cursor, &PlotAxisHandle::scalePosChanged, ctrl2->x2Cursor, [ctrl1, ctrl2](double pos) {
 		ctrl1->x2Cursor->blockSignals(true);
 		ctrl2->x2Cursor->setPosition(pos);
 		ctrl1->x2Cursor->blockSignals(false);
@@ -239,14 +239,14 @@ void CursorController::syncXCursorControllers(CursorController *ctrl1, CursorCon
 	});
 
 	// connect ctrl2 to ctrl1
-	connect(ctrl2->x1Cursor, &PlotAxisHandle::scalePosChanged, ctrl1->x1Cursor, [=](double pos) {
+	connect(ctrl2->x1Cursor, &PlotAxisHandle::scalePosChanged, ctrl1->x1Cursor, [ctrl1, ctrl2](double pos) {
 		ctrl2->x1Cursor->blockSignals(true);
 		ctrl1->x1Cursor->setPosition(pos);
 		ctrl2->x1Cursor->blockSignals(false);
 		ctrl1->x1Cursor->repaint();
 		ctrl1->m_plot->repaint();
 	});
-	connect(ctrl2->x2Cursor, &PlotAxisHandle::scalePosChanged, ctrl1->x2Cursor, [=](double pos) {
+	connect(ctrl2->x2Cursor, &PlotAxisHandle::scalePosChanged, ctrl1->x2Cursor, [ctrl1, ctrl2](double pos) {
 		ctrl2->x2Cursor->blockSignals(true);
 		ctrl1->x2Cursor->setPosition(pos);
 		ctrl2->x2Cursor->blockSignals(false);

--- a/gui/src/homepage_controls.cpp
+++ b/gui/src/homepage_controls.cpp
@@ -42,9 +42,9 @@ HomepageControls::~HomepageControls() {}
 
 void HomepageControls::connectSignals()
 {
-	connect(controls->getBackwardBtn(), &QPushButton::clicked, this, [=]() { Q_EMIT goLeft(); });
-	connect(controls->getForwardBtn(), &QPushButton::clicked, this, [=]() { Q_EMIT goRight(); });
-	connect(controls->getOpenBtn(), &QPushButton::clicked, this, [=]() { Q_EMIT openFile(); });
+	connect(controls->getBackwardBtn(), &QPushButton::clicked, this, [this]() { Q_EMIT goLeft(); });
+	connect(controls->getForwardBtn(), &QPushButton::clicked, this, [this]() { Q_EMIT goRight(); });
+	connect(controls->getOpenBtn(), &QPushButton::clicked, this, [this]() { Q_EMIT openFile(); });
 }
 
 void HomepageControls::enableLeft(bool en) { controls->getBackwardBtn()->setEnabled(en); }

--- a/gui/src/plotaxishandle.cpp
+++ b/gui/src/plotaxishandle.cpp
@@ -44,20 +44,20 @@ PlotAxisHandle::~PlotAxisHandle()
 void PlotAxisHandle::init()
 {
 	m_handle = new AxisHandle(m_axis->axisId(), HandlePos::SOUTH_OR_EAST, m_plot);
-	connect(m_plot, &QObject::destroyed, this, [=]() { m_handle = nullptr; });
+	connect(m_plot, &QObject::destroyed, this, [this]() { m_handle = nullptr; });
 	m_pos = pixelToScale(m_handle->getPos());
 
 	connect(m_plotWidget, &PlotWidget::canvasSizeChanged, this, &PlotAxisHandle::updatePos);
 	connect(m_plotWidget, &PlotWidget::plotScaleChanged, this, &PlotAxisHandle::updatePos);
 	connect(m_axis, &PlotAxis::axisScaleUpdated, this, &PlotAxisHandle::updatePos);
 
-	connect(this, &PlotAxisHandle::updatePos, this, [=]() {
+	connect(this, &PlotAxisHandle::updatePos, this, [this]() {
 		if(scaleToPixel(m_pos) != m_handle->getPos()) {
 			setPositionSilent(m_pos);
 		}
 	});
 
-	connect(m_handle, &AxisHandle::pixelPosChanged, this, [=](int pos) {
+	connect(m_handle, &AxisHandle::pixelPosChanged, this, [this](int pos) {
 		if(pos != scaleToPixel(m_pos)) {
 			Q_EMIT scalePosChanged(pixelToScale(pos));
 			m_pos = pixelToScale(pos);

--- a/gui/src/plotcursors.cpp
+++ b/gui/src/plotcursors.cpp
@@ -56,7 +56,7 @@ void PlotCursors::initUI()
 
 void PlotCursors::connectSignals()
 {
-	connect(this, &PlotCursors::update, this, [=]() {
+	connect(this, &PlotCursors::update, this, [this]() {
 		Q_EMIT m_yCursors.first->updatePos();
 		Q_EMIT m_yCursors.second->updatePos();
 		Q_EMIT m_xCursors.first->updatePos();
@@ -66,17 +66,17 @@ void PlotCursors::connectSignals()
 		}
 	});
 
-	connect(m_xCursors.first, &PlotAxisHandle::scalePosChanged, this, [=]() {
+	connect(m_xCursors.first, &PlotAxisHandle::scalePosChanged, this, [this]() {
 		if(m_tracking) {
 			displayIntersection();
 		}
 	});
-	connect(m_xCursors.second, &PlotAxisHandle::scalePosChanged, this, [=]() {
+	connect(m_xCursors.second, &PlotAxisHandle::scalePosChanged, this, [this]() {
 		if(m_tracking) {
 			displayIntersection();
 		}
 	});
-	connect(m_plot, &PlotWidget::channelSelected, this, [=](PlotChannel *ch) {
+	connect(m_plot, &PlotWidget::channelSelected, this, [this](PlotChannel *ch) {
 		PlotAxis *xAxis = m_plot->xAxis();
 		PlotAxis *yAxis = m_plot->xAxis();
 

--- a/gui/src/plotmanagercombobox.cpp
+++ b/gui/src/plotmanagercombobox.cpp
@@ -48,7 +48,7 @@ PlotManagerCombobox::PlotManagerCombobox(PlotManager *man, ChannelComponent *c, 
 	uint32_t uuid = c->plotChannelCmpt()->plotComponent()->uuid();
 	m_combo->setCurrentIndex(findIndexFromUuid(uuid));
 
-	connect(m_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(m_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this, man](int idx) {
 		uint32_t uuid = m_combo->itemData(idx).toULongLong();
 		man->moveChannel(m_ch, uuid);
 		man->replot();

--- a/gui/src/plotnavigator.cpp
+++ b/gui/src/plotnavigator.cpp
@@ -138,8 +138,8 @@ void PlotNavigator::initResetButton()
 	m_resetButton->setIcon(icon);
 	m_resetButton->hide();
 
-	connect(m_resetButton, &QPushButton::clicked, this, [=]() { Q_EMIT reset(); });
-	connect(this, &PlotNavigator::rectChanged, this, [=]() { m_resetButton->setVisible(isZoomed()); });
+	connect(m_resetButton, &QPushButton::clicked, this, [this]() { Q_EMIT reset(); });
+	connect(this, &PlotNavigator::rectChanged, this, [this]() { m_resetButton->setVisible(isZoomed()); });
 
 	m_resetHover = new HoverWidget(m_resetButton, m_plot->canvas(), m_plot->canvas());
 	m_resetHover->setAnchorPos(HoverPosition::HP_BOTTOMRIGHT);
@@ -218,26 +218,26 @@ void PlotNavigator::addNavigators(QwtAxisId axisId)
 	nav->zoomer = zoomer;
 	m_navigators->insert(nav);
 
-	connect(magnifier, &PlotMagnifier::zoomedRect, this, [=](const QRectF &rect) {
+	connect(magnifier, &PlotMagnifier::zoomedRect, this, [this, nav](const QRectF &rect) {
 		addRectToHistory(nav, rect, navigationType::Magnify);
 		Q_EMIT rectChanged(rect, navigationType::Magnify);
 	});
-	connect(magnifier, &PlotMagnifier::pannedRect, this, [=](const QRectF &rect) {
+	connect(magnifier, &PlotMagnifier::pannedRect, this, [this, nav](const QRectF &rect) {
 		addRectToHistory(nav, rect, navigationType::Pan);
 		Q_EMIT rectChanged(rect, navigationType::Pan);
 	});
-	connect(zoomer, &PlotZoomer::zoomed, this, [=](const QRectF &rect) {
+	connect(zoomer, &PlotZoomer::zoomed, this, [this, nav](const QRectF &rect) {
 		addRectToHistory(nav, rect, navigationType::Zoom);
 		Q_EMIT rectChanged(rect, navigationType::Zoom);
 	});
 
 	connect(magnifier, &PlotMagnifier::reset, this,
-		[=]() { Q_EMIT rectChanged(zoomer->zoomBase(), navigationType::None); });
+		[this, zoomer]() { Q_EMIT rectChanged(zoomer->zoomBase(), navigationType::None); });
 	connect(zoomer, &PlotZoomer::reset, this,
-		[=]() { Q_EMIT rectChanged(zoomer->zoomBase(), navigationType::None); });
+		[this, zoomer]() { Q_EMIT rectChanged(zoomer->zoomBase(), navigationType::None); });
 
 	if(m_plotWidget) {
-		connect(m_plotWidget->plotAxisFromId(axisId), &PlotAxis::axisScaleUpdated, this, [=]() {
+		connect(m_plotWidget->plotAxisFromId(axisId), &PlotAxis::axisScaleUpdated, this, [this, axisId]() {
 			if(m_autoBase) {
 				setBaseRect(axisId);
 				if(m_resetOnNewBase)
@@ -382,7 +382,7 @@ void PlotNavigator::addAxis(PlotAxis *axis)
 		setBaseRect(axisId);
 	}
 	// Connect axis scale updates for auto-base rect
-	connect(axis, &PlotAxis::axisScaleUpdated, this, [=]() {
+	connect(axis, &PlotAxis::axisScaleUpdated, this, [this, axisId]() {
 		if(m_autoBase) {
 			setBaseRect(axisId);
 			if(m_resetOnNewBase)
@@ -617,17 +617,17 @@ bool PlotNavigator::getResetOnNewBase() { return m_resetOnNewBase; }
 void PlotNavigator::syncNavigators(PlotNavigator *pNav1, Navigator *nav1, PlotNavigator *pNav2, Navigator *nav2)
 {
 	// connect nav1 to nav2
-	connect(nav1->zoomer, &PlotZoomer::zoomed, pNav2, [=](const QRectF &rect) {
+	connect(nav1->zoomer, &PlotZoomer::zoomed, pNav2, [nav2, pNav2](const QRectF &rect) {
 		nav2->zoomer->silentZoom(rect);
 		pNav2->addRectToHistory(nav2, rect, navigationType::Zoom);
 		Q_EMIT pNav2->rectChanged(rect, navigationType::Zoom);
 	});
-	connect(nav1->magnifier, &PlotMagnifier::zoomedRect, pNav2, [=](const QRectF &rect) {
+	connect(nav1->magnifier, &PlotMagnifier::zoomedRect, pNav2, [nav2, pNav2](const QRectF &rect) {
 		nav2->zoomer->silentZoom(rect);
 		pNav2->addRectToHistory(nav2, rect, navigationType::Magnify);
 		Q_EMIT pNav2->rectChanged(rect, navigationType::Magnify);
 	});
-	connect(nav1->magnifier, &PlotMagnifier::pannedRect, pNav2, [=](const QRectF &rect) {
+	connect(nav1->magnifier, &PlotMagnifier::pannedRect, pNav2, [nav2, pNav2](const QRectF &rect) {
 		nav2->zoomer->silentZoom(rect);
 		pNav2->addRectToHistory(nav2, rect, navigationType::Pan);
 		Q_EMIT pNav2->rectChanged(rect, navigationType::Pan);
@@ -636,17 +636,17 @@ void PlotNavigator::syncNavigators(PlotNavigator *pNav1, Navigator *nav1, PlotNa
 	connect(pNav1, &PlotNavigator::reset, nav2->zoomer, &PlotZoomer::reset);
 
 	// connect nav2 to nav1
-	connect(nav2->zoomer, &PlotZoomer::zoomed, pNav1, [=](const QRectF &rect) {
+	connect(nav2->zoomer, &PlotZoomer::zoomed, pNav1, [nav1, pNav1](const QRectF &rect) {
 		nav1->zoomer->silentZoom(rect);
 		pNav1->addRectToHistory(nav1, rect, navigationType::Zoom);
 		Q_EMIT pNav1->rectChanged(rect, navigationType::Zoom);
 	});
-	connect(nav2->magnifier, &PlotMagnifier::zoomedRect, pNav1, [=](const QRectF &rect) {
+	connect(nav2->magnifier, &PlotMagnifier::zoomedRect, pNav1, [nav1, pNav1](const QRectF &rect) {
 		nav1->zoomer->silentZoom(rect);
 		pNav1->addRectToHistory(nav1, rect, navigationType::Magnify);
 		Q_EMIT pNav1->rectChanged(rect, navigationType::Magnify);
 	});
-	connect(nav2->magnifier, &PlotMagnifier::pannedRect, pNav1, [=](const QRectF &rect) {
+	connect(nav2->magnifier, &PlotMagnifier::pannedRect, pNav1, [nav1, pNav1](const QRectF &rect) {
 		nav1->zoomer->silentZoom(rect);
 		pNav1->addRectToHistory(nav1, rect, navigationType::Pan);
 		Q_EMIT pNav1->rectChanged(rect, navigationType::Pan);
@@ -698,7 +698,7 @@ void PlotNavigator::syncPlotNavigators(PlotNavigator *pNav1, PlotNavigator *pNav
 	syncPlotNavigatorAxes(pNav1, pNav2, axes);
 
 	// sync future axes
-	connect(pNav1, &PlotNavigator::addedNavigator, pNav1, [=](Navigator *nav1) {
+	connect(pNav1, &PlotNavigator::addedNavigator, pNav1, [pNav1, pNav2](Navigator *nav1) {
 		for(Navigator *nav2 : *pNav2->navigators()) {
 			if((nav1->magnifier->isXAxisEn() && nav2->magnifier->isXAxisEn() &&
 			    nav1->magnifier->getXAxis() == nav2->magnifier->getXAxis()) ||
@@ -708,7 +708,7 @@ void PlotNavigator::syncPlotNavigators(PlotNavigator *pNav1, PlotNavigator *pNav
 			}
 		}
 	});
-	connect(pNav2, &PlotNavigator::addedNavigator, pNav2, [=](Navigator *nav2) {
+	connect(pNav2, &PlotNavigator::addedNavigator, pNav2, [pNav1, pNav2](Navigator *nav2) {
 		for(Navigator *nav1 : *pNav1->navigators()) {
 			if((nav2->magnifier->isXAxisEn() && nav1->magnifier->isXAxisEn() &&
 			    nav2->magnifier->getXAxis() == nav1->magnifier->getXAxis()) ||
@@ -741,7 +741,7 @@ void PlotNavigator::syncXNavigators(PlotNavigator *pNav1, PlotNavigator *pNav2)
 
 	// Sync navigators added to pNav1 in the future against all current and
 	// future X-axis navigators on pNav2.
-	connect(pNav1, &PlotNavigator::addedNavigator, pNav1, [=](Navigator *nav1) {
+	connect(pNav1, &PlotNavigator::addedNavigator, pNav1, [pNav1, pNav2](Navigator *nav1) {
 		if(!nav1->magnifier->isXAxisEn())
 			return;
 		for(Navigator *nav2 : *pNav2->navigators()) {
@@ -750,7 +750,7 @@ void PlotNavigator::syncXNavigators(PlotNavigator *pNav1, PlotNavigator *pNav2)
 		}
 	});
 
-	connect(pNav2, &PlotNavigator::addedNavigator, pNav2, [=](Navigator *nav2) {
+	connect(pNav2, &PlotNavigator::addedNavigator, pNav2, [pNav1, pNav2](Navigator *nav2) {
 		if(!nav2->magnifier->isXAxisEn())
 			return;
 		for(Navigator *nav1 : *pNav1->navigators()) {

--- a/gui/src/plotscales.cpp
+++ b/gui/src/plotscales.cpp
@@ -83,7 +83,7 @@ void PlotScales::initMarginScales()
 
 	setMarginScalesEn(!Preferences::GetInstance()->get("show_graticule").toBool());
 	connect(Preferences::GetInstance(), &Preferences::preferenceChanged, this,
-		[=](QString preference, QVariant value) {
+		[this](QString preference, QVariant value) {
 			if(preference == "show_graticule") {
 				setMarginScalesEn(!value.toBool());
 			}
@@ -134,7 +134,7 @@ void PlotScales::initGrid()
 
 	setGridEn(Preferences::GetInstance()->get("show_grid").toBool());
 	connect(Preferences::GetInstance(), &Preferences::preferenceChanged, this,
-		[=](QString preference, QVariant value) {
+		[this](QString preference, QVariant value) {
 			if(preference == "show_grid") {
 				setGridEn(value.toBool());
 			}
@@ -159,12 +159,12 @@ void PlotScales::initGraticule()
 
 	setGraticuleEn(Preferences::GetInstance()->get("show_graticule").toBool());
 	connect(Preferences::GetInstance(), &Preferences::preferenceChanged, this,
-		[=](QString preference, QVariant value) {
+		[this](QString preference, QVariant value) {
 			if(preference == "show_graticule") {
 				setGraticuleEn(value.toBool());
 			}
 		});
-	connect(m_plot, &PlotWidget::channelSelected, this, [=](PlotChannel *ch) {
+	connect(m_plot, &PlotWidget::channelSelected, this, [this](PlotChannel *ch) {
 		QwtAxisId xAxisId = m_plot->xAxis()->axisId();
 		QwtAxisId yAxisId = m_plot->yAxis()->axisId();
 

--- a/gui/src/plotwidget.cpp
+++ b/gui/src/plotwidget.cpp
@@ -165,7 +165,7 @@ void PlotWidget::addPlotChannel(PlotChannel *ch)
 	}
 
 	connect(ch, &PlotChannel::doReplot, this, &PlotWidget::replot);
-	connect(ch, &PlotChannel::attachCurve, this, [=](QwtPlotCurve *curve) { curve->attach(m_plot); });
+	connect(ch, &PlotChannel::attachCurve, this, [this](QwtPlotCurve *curve) { curve->attach(m_plot); });
 	m_navigator->addChannel(ch);
 	m_tracker->addChannel(ch);
 	Q_EMIT addedChannel(ch);
@@ -269,7 +269,7 @@ void PlotWidget::setupPlotInfo()
 		hDivInfo->hide();
 	}
 	connect(Preferences::GetInstance(), &Preferences::preferenceChanged, this,
-		[=](QString preference, QVariant value) {
+		[hDivInfo](QString preference, QVariant value) {
 			if(preference == "show_grid") {
 				hDivInfo->setVisible(value.toBool());
 			}

--- a/gui/src/spinbox_a.cpp
+++ b/gui/src/spinbox_a.cpp
@@ -233,7 +233,7 @@ void SpinBoxA::onLineEditTextEdited()
 bool SpinBoxA::isUnitMatched(const QString &unit, double value)
 {
 	size_t i = find_if(m_units.begin(), m_units.end(),
-			   [=](const pair<QString, double> pair) { return pair.first.at(0) == unit.at(0); }) -
+			   [unit](const pair<QString, double> pair) { return pair.first.at(0) == unit.at(0); }) -
 		m_units.begin();
 
 	if(i < m_units.size()) {

--- a/gui/src/utils.cpp
+++ b/gui/src/utils.cpp
@@ -137,7 +137,7 @@ QDockWidget *DockerUtils::createDockWidget(QMainWindow *mainWindow, QWidget *wid
 
 void DockerUtils::configureTopBar(QDockWidget *docker)
 {
-	connect(docker, &QDockWidget::topLevelChanged, [=](bool topLevel) {
+	connect(docker, &QDockWidget::topLevelChanged, [docker](bool topLevel) {
 		QString icon_path = "";
 
 		if(QIcon::themeName() == "scopy-default") {

--- a/gui/src/widgets/cursorsettings.cpp
+++ b/gui/src/widgets/cursorsettings.cpp
@@ -86,16 +86,16 @@ void CursorSettings::initUI()
 
 void CursorSettings::connectSignals()
 {
-	connect(xEn->onOffswitch(), &QAbstractButton::toggled, this, [=](bool toggled) {
+	connect(xEn->onOffswitch(), &QAbstractButton::toggled, this, [this](bool toggled) {
 		xTrack->setEnabled(toggled);
 		xLock->setEnabled(toggled);
 	});
-	connect(yEn->onOffswitch(), &QAbstractButton::toggled, this, [=](bool toggled) {
+	connect(yEn->onOffswitch(), &QAbstractButton::toggled, this, [this](bool toggled) {
 		yLock->setEnabled(toggled);
 		if(!toggled)
 			xTrack->onOffswitch()->setChecked(false);
 	});
-	connect(xTrack->onOffswitch(), &QAbstractButton::toggled, this, [=](bool toggled) {
+	connect(xTrack->onOffswitch(), &QAbstractButton::toggled, this, [this](bool toggled) {
 		if(toggled && !yEn->onOffswitch()->isChecked())
 			yEn->onOffswitch()->setChecked(true);
 

--- a/gui/src/widgets/measurementpanel.cpp
+++ b/gui/src/widgets/measurementpanel.cpp
@@ -72,7 +72,7 @@ MeasurementsPanel::MeasurementsPanel(QWidget *parent)
 	m_lay->addWidget(scrollArea);
 
 	connect(scrollArea->horizontalScrollBar(), &QAbstractSlider::rangeChanged, scrollBar,
-		[=](double min, double max) {
+		[scrollArea, scrollBar](double min, double max) {
 			auto singleStep = scrollArea->horizontalScrollBar()->singleStep();
 			scrollBar->setVisible(singleStep < (max - min));
 		});
@@ -107,19 +107,19 @@ void MeasurementsPanel::setupControlButtons()
 	m_sortByTypeBtn->setVisible(false);
 	m_hideBtn->setVisible(false);
 
-	connect(m_sortByChannelBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_sortByChannelBtn, &QPushButton::clicked, this, [this]() {
 		sort(0);
 		m_sortByChannelBtn->setVisible(false);
 		m_sortByTypeBtn->setVisible(true);
 	});
 
-	connect(m_sortByTypeBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_sortByTypeBtn, &QPushButton::clicked, this, [this]() {
 		sort(1);
 		m_sortByTypeBtn->setVisible(false);
 		m_sortByChannelBtn->setVisible(true);
 	});
 
-	connect(m_hideBtn, &QPushButton::clicked, this, [=]() { Q_EMIT hideAll(); });
+	connect(m_hideBtn, &QPushButton::clicked, this, [this]() { Q_EMIT hideAll(); });
 
 	btnLayout->addWidget(m_sortByChannelBtn);
 	btnLayout->addWidget(m_sortByTypeBtn);
@@ -196,14 +196,14 @@ void MeasurementsPanel::sort(int sortType)
 {
 
 	if(sortType == 0) {
-		std::sort(m_labels.begin(), m_labels.end(), [=](MeasurementLabel *first, MeasurementLabel *second) {
+		std::sort(m_labels.begin(), m_labels.end(), [](MeasurementLabel *first, MeasurementLabel *second) {
 			if(first->idx() == second->idx()) {
 				return first->color().name() > second->color().name();
 			}
 			return first->idx() < second->idx();
 		});
 	} else {
-		std::sort(m_labels.begin(), m_labels.end(), [=](MeasurementLabel *first, MeasurementLabel *second) {
+		std::sort(m_labels.begin(), m_labels.end(), [](MeasurementLabel *first, MeasurementLabel *second) {
 			if(first->color().name() == second->color().name()) {
 				return first->idx() < second->idx();
 			}
@@ -306,19 +306,19 @@ void StatsPanel::setupControlButtons()
 	m_sortByTypeBtn->setVisible(false);
 	m_hideBtn->setVisible(false);
 
-	connect(m_sortByChannelBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_sortByChannelBtn, &QPushButton::clicked, this, [this]() {
 		sort(0);
 		m_sortByChannelBtn->setVisible(false);
 		m_sortByTypeBtn->setVisible(true);
 	});
 
-	connect(m_sortByTypeBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_sortByTypeBtn, &QPushButton::clicked, this, [this]() {
 		sort(1);
 		m_sortByTypeBtn->setVisible(false);
 		m_sortByChannelBtn->setVisible(true);
 	});
 
-	connect(m_hideBtn, &QPushButton::clicked, this, [=]() { Q_EMIT hideAll(); });
+	connect(m_hideBtn, &QPushButton::clicked, this, [this]() { Q_EMIT hideAll(); });
 
 	btnLayout->addWidget(m_sortByChannelBtn);
 	btnLayout->addWidget(m_sortByTypeBtn);
@@ -364,14 +364,14 @@ void StatsPanel::updateOrder()
 void StatsPanel::sort(int sortType)
 {
 	if(sortType == 0) {
-		std::sort(m_labels.begin(), m_labels.end(), [=](StatsLabel *first, StatsLabel *second) {
+		std::sort(m_labels.begin(), m_labels.end(), [](StatsLabel *first, StatsLabel *second) {
 			if(first->idx() == second->idx()) {
 				return first->color().name() > second->color().name();
 			}
 			return first->idx() < second->idx();
 		});
 	} else {
-		std::sort(m_labels.begin(), m_labels.end(), [=](StatsLabel *first, StatsLabel *second) {
+		std::sort(m_labels.begin(), m_labels.end(), [](StatsLabel *first, StatsLabel *second) {
 			if(first->color().name() == second->color().name()) {
 				return first->idx() < second->idx();
 			}

--- a/gui/src/widgets/measurementsettings.cpp
+++ b/gui/src/widgets/measurementsettings.cpp
@@ -47,7 +47,7 @@ MeasurementSettings::MeasurementSettings(QWidget *parent)
 	measureSection->contentLayout()->addWidget(measurePanelSwitch);
 
 	connect(measurePanelSwitch->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { Q_EMIT enableMeasurementPanel(b); });
+		[this](bool b) { Q_EMIT enableMeasurementPanel(b); });
 
 	statsSection = new MenuSectionWidget(this);
 	Style::setStyle(statsSection, style::properties::widget::border);
@@ -55,7 +55,7 @@ MeasurementSettings::MeasurementSettings(QWidget *parent)
 	Style::setStyle(statsPanelSwitch->label(), style::properties::label::subtle, false);
 	Style::setStyle(statsPanelSwitch->label(), style::properties::label::defaultLabel);
 	connect(statsPanelSwitch->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { Q_EMIT enableStatsPanel(b); });
+		[this](bool b) { Q_EMIT enableStatsPanel(b); });
 	statsSection->contentLayout()->addWidget(statsPanelSwitch);
 
 	statsPanelSwitch->onOffswitch()->setChecked(false);
@@ -67,7 +67,7 @@ MeasurementSettings::MeasurementSettings(QWidget *parent)
 	Style::setStyle(markerPanelSwitch->label(), style::properties::label::defaultLabel, true, true);
 
 	connect(markerPanelSwitch->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { Q_EMIT enableMarkerPanel(b); });
+		[this](bool b) { Q_EMIT enableMarkerPanel(b); });
 	markerSection->contentLayout()->addWidget(markerPanelSwitch);
 
 	markerPanelSwitch->onOffswitch()->setChecked(false);
@@ -79,7 +79,7 @@ MeasurementSettings::MeasurementSettings(QWidget *parent)
 	Style::setStyle(genalyzerPanelSwitch->label(), style::properties::label::defaultLabel);
 
 	connect(genalyzerPanelSwitch->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { Q_EMIT enableGenalyzerPanel(b); });
+		[this](bool b) { Q_EMIT enableGenalyzerPanel(b); });
 	genalyzerSection->contentLayout()->addWidget(genalyzerPanelSwitch);
 
 	genalyzerPanelSwitch->onOffswitch()->setChecked(false);

--- a/gui/src/widgets/menucollapsesection.cpp
+++ b/gui/src/widgets/menucollapsesection.cpp
@@ -66,12 +66,12 @@ MenuCollapseHeader::MenuCollapseHeader(QString title, MenuCollapseSection::MenuH
 	case MenuCollapseSection::MHCW_ARROW:
 		m_ctrl = new QCheckBox(this);
 		StyleHelper::CollapseCheckbox(dynamic_cast<QCheckBox *>(m_ctrl), "menuCollapseButton");
-		connect(this, &QAbstractButton::toggled, this, [=](bool b) { m_ctrl->setChecked(b); });
+		connect(this, &QAbstractButton::toggled, this, [this](bool b) { m_ctrl->setChecked(b); });
 		m_ctrl->setChecked(true);
 		break;
 	case MenuCollapseSection::MHCW_ONOFF:
 		m_ctrl = new SmallOnOffSwitch(this);
-		connect(this, &QAbstractButton::toggled, [=](bool b) { m_ctrl->setChecked(b); });
+		connect(this, &QAbstractButton::toggled, [this](bool b) { m_ctrl->setChecked(b); });
 		m_ctrl->setChecked(true);
 		break;
 	default:

--- a/gui/src/widgets/menucontrolbutton.cpp
+++ b/gui/src/widgets/menucontrolbutton.cpp
@@ -61,7 +61,7 @@ MenuControlButton::MenuControlButton(QWidget *parent)
 	lay->addWidget(m_icon);
 	applyStylesheet();
 
-	connect(this, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(this, &QAbstractButton::toggled, this, [this, iconPath](bool b) {
 		setDynamicProperty(this, "selected", b);
 		Style::setStyle(m_label, style::properties::label::menuMedium, b ? "selected" : "idle");
 		if(m_cs == CS_CIRCLE) {
@@ -103,7 +103,7 @@ void MenuControlButton::setName(QString s)
 void MenuControlButton::setDoubleClickToOpenMenu(bool b)
 {
 	if(b) {
-		dblClickToOpenMenu = connect(this, &MenuControlButton::doubleClicked, this, [=]() {
+		dblClickToOpenMenu = connect(this, &MenuControlButton::doubleClicked, this, [this]() {
 			setChecked(true);
 			if(m_btn->isVisible()) {
 				m_btn->click();
@@ -117,7 +117,7 @@ void MenuControlButton::setDoubleClickToOpenMenu(bool b)
 void MenuControlButton::setOpenMenuChecksThis(bool b)
 {
 	if(b) {
-		openMenuChecksThis = connect(m_btn, &QAbstractButton::toggled, this, [=](bool b) {
+		openMenuChecksThis = connect(m_btn, &QAbstractButton::toggled, this, [this](bool b) {
 			if(b)
 				setChecked(true);
 		});

--- a/gui/src/widgets/menuplotaxisrangecontrol.cpp
+++ b/gui/src/widgets/menuplotaxisrangecontrol.cpp
@@ -54,8 +54,8 @@ void MenuPlotAxisRangeControl::addAxis(PlotAxis *ax)
 
 	connections[ax] << connect(m_min, &MenuSpinbox::valueChanged, ax, &PlotAxis::setMin);
 	connections[ax] << connect(m_min, &MenuSpinbox::valueChanged, this,
-				   [=](double) { Q_EMIT intervalChanged(m_min->value(), m_max->value()); });
-	connections[ax] << connect(ax, &PlotAxis::minChanged, this, [=]() {
+				   [this](double) { Q_EMIT intervalChanged(m_min->value(), m_max->value()); });
+	connections[ax] << connect(ax, &PlotAxis::minChanged, this, [this, ax]() {
 		QSignalBlocker b(m_min);
 		m_min->setValue(ax->min());
 		Q_EMIT intervalChanged(m_min->value(), m_max->value());
@@ -63,8 +63,8 @@ void MenuPlotAxisRangeControl::addAxis(PlotAxis *ax)
 
 	connections[ax] << connect(m_max, &MenuSpinbox::valueChanged, ax, &PlotAxis::setMax);
 	connections[ax] << connect(m_max, &MenuSpinbox::valueChanged, this,
-				   [=](double) { Q_EMIT intervalChanged(m_min->value(), m_max->value()); });
-	connections[ax] << connect(ax, &PlotAxis::maxChanged, this, [=]() {
+				   [this](double) { Q_EMIT intervalChanged(m_min->value(), m_max->value()); });
+	connections[ax] << connect(ax, &PlotAxis::maxChanged, this, [this, ax]() {
 		QSignalBlocker b(m_max);
 		m_max->setValue(ax->max());
 		Q_EMIT intervalChanged(m_min->value(), m_max->value());

--- a/gui/src/widgets/menuspinbox.cpp
+++ b/gui/src/widgets/menuspinbox.cpp
@@ -64,9 +64,9 @@ MenuSpinbox::MenuSpinbox(QString name, double val, QString unit, double min, dou
 	connect(m_plus, &QAbstractButton::clicked, this, &MenuSpinbox::incrementValue);
 	connect(m_minus, &QAbstractButton::clicked, this, &MenuSpinbox::decrementValue);
 
-	connect(m_edit, &QLineEdit::editingFinished, this, [=]() { userInput(m_edit->text()); });
+	connect(m_edit, &QLineEdit::editingFinished, this, [this]() { userInput(m_edit->text()); });
 
-	connect(m_scaleCb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(m_scaleCb, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
 		m_incrementStrategy->setScale(m_scaleCb->itemData(idx).toDouble());
 		userInput(m_edit->text());
 	});

--- a/gui/src/widgets/plotbufferpreviewer.cpp
+++ b/gui/src/widgets/plotbufferpreviewer.cpp
@@ -60,12 +60,12 @@ void PlotBufferPreviewer::setupBufferPreviewer()
 
 	updateDataLimits(m_plot->xAxis()->min(), m_plot->xAxis()->max());
 
-	connect(m_bufferPreviewer, &BufferPreviewer::bufferStartDrag, this, [=]() {
+	connect(m_bufferPreviewer, &BufferPreviewer::bufferStartDrag, this, [this]() {
 		// reset the buffer preview position to current visible section
 		m_lastMin = m_plot->xAxis()->visibleMin();
 	});
 
-	connect(m_bufferPreviewer, &BufferPreviewer::bufferMovedBy, this, [=](int bufferPos) {
+	connect(m_bufferPreviewer, &BufferPreviewer::bufferMovedBy, this, [this](int bufferPos) {
 		double bufferWidth = m_bufferPreviewer->width();
 		double axisWidth = m_bufferDataLimitMax - m_bufferDataLimitMin;
 		double newAxisPos = bufferPos * axisWidth / bufferWidth;
@@ -83,12 +83,12 @@ void PlotBufferPreviewer::setupBufferPreviewer()
 		updateBufferPreviewer();
 	});
 
-	connect(m_bufferPreviewer, &BufferPreviewer::bufferResetPosition, this, [=]() {
+	connect(m_bufferPreviewer, &BufferPreviewer::bufferResetPosition, this, [this]() {
 		Q_EMIT m_plot->navigator()->reset();
 		updateBufferPreviewer();
 	});
 
-	connect(m_plot->navigator(), &PlotNavigator::rectChanged, this, [=]() { updateBufferPreviewer(); });
+	connect(m_plot->navigator(), &PlotNavigator::rectChanged, this, [this]() { updateBufferPreviewer(); });
 }
 
 void PlotBufferPreviewer::updateDataLimits(double min, double max)

--- a/gui/src/widgets/plotinfowidgets.cpp
+++ b/gui/src/widgets/plotinfowidgets.cpp
@@ -130,9 +130,9 @@ FPSInfo::FPSInfo(PlotWidget *plot, QWidget *parent)
 {
 	setVisible(Preferences::GetInstance()->get("general_show_plot_fps").toBool());
 
-	connect(m_plot, &PlotWidget::newData, this, [=]() { update(QDateTime::currentMSecsSinceEpoch()); });
+	connect(m_plot, &PlotWidget::newData, this, [this]() { update(QDateTime::currentMSecsSinceEpoch()); });
 	connect(Preferences::GetInstance(), &Preferences::preferenceChanged, this,
-		[=](QString preference, QVariant value) {
+		[this](QString preference, QVariant value) {
 			if(preference == "general_show_plot_fps") {
 				setVisible(value.toBool());
 			}
@@ -166,7 +166,7 @@ void FPSInfo::update(qint64 timestamp)
 TimestampInfo::TimestampInfo(PlotWidget *plot, QWidget *parent)
 {
 	connect(plot, &PlotWidget::newData, this,
-		[=]() { setText(QDateTime::currentDateTime().time().toString("hh:mm:ss")); });
+		[this]() { setText(QDateTime::currentDateTime().time().toString("hh:mm:ss")); });
 }
 
 TimestampInfo::~TimestampInfo() {}

--- a/gui/src/widgets/popupwidget.cpp
+++ b/gui/src/widgets/popupwidget.cpp
@@ -105,7 +105,7 @@ void PopupWidget::enableCloseButton(bool en)
 		m_closeHover->setVisible(true);
 		m_closeHover->raise();
 
-		connect(m_closeButton, &QPushButton::clicked, this, [=]() { deleteLater(); });
+		connect(m_closeButton, &QPushButton::clicked, this, [this]() { deleteLater(); });
 	} else {
 		if(m_closeButton != nullptr) {
 			delete m_closeButton;

--- a/gui/src/widgets/toolbuttons.cpp
+++ b/gui/src/widgets/toolbuttons.cpp
@@ -43,7 +43,7 @@ OpenLastMenuBtn::OpenLastMenuBtn(MenuHAnim *menu, bool opened, QWidget *parent)
 		"/icons/setup3_unchecked_hover.svg";
 	setIcon(Style::getPixmap(iconPath, Style::getColor(json::theme::content_default)));
 
-	connect(this, &QPushButton::toggled, this, [=](bool toggle) {
+	connect(this, &QPushButton::toggled, this, [this, iconPath](bool toggle) {
 		const char *color = toggle ? json::theme::content_inverse : json::theme::content_default;
 		setIcon(Style::getPixmap(iconPath, Style::getColor(color)));
 	});
@@ -53,14 +53,14 @@ OpenLastMenuBtn::OpenLastMenuBtn(MenuHAnim *menu, bool opened, QWidget *parent)
 	setChecked(opened);
 	grp = new SemiExclusiveButtonGroup(this);
 	connect(this, &QPushButton::toggled, m_menu, &MenuHAnim::toggleMenu);
-	connect(grp, &SemiExclusiveButtonGroup::buttonSelected, this, [=](QAbstractButton *btn) {
+	connect(grp, &SemiExclusiveButtonGroup::buttonSelected, this, [this](QAbstractButton *btn) {
 		if(btn == nullptr) {
 			this->setChecked(false);
 		} else {
 			this->setChecked(true);
 		}
 	});
-	connect(this, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(this, &QAbstractButton::toggled, this, [this](bool b) {
 		if(b) {
 			grp->getLastButton()->setChecked(true);
 		} else {
@@ -78,7 +78,7 @@ GearBtn::GearBtn(QWidget *parent)
 		":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) + "/icons/gear_wheel.svg";
 	setIcon(Style::getPixmap(iconPath, Style::getColor(json::theme::content_default)));
 
-	connect(this, &QPushButton::toggled, this, [=](bool toggle) {
+	connect(this, &QPushButton::toggled, this, [this, iconPath](bool toggle) {
 		const char *color = toggle ? json::theme::content_inverse : json::theme::content_default;
 		setIcon(Style::getPixmap(iconPath, Style::getColor(color)));
 	});
@@ -133,9 +133,10 @@ void InfoBtn::generateInfoPopup(QWidget *parent)
 	m_popupWidget->getContinueBtn()->setText("Documentation");
 	m_popupWidget->enableCloseButton(true);
 
-	connect(m_popupWidget->getExitBtn(), &QPushButton::clicked, this, [=]() { m_popupWidget->deleteLater(); });
+	connect(m_popupWidget->getExitBtn(), &QPushButton::clicked, this, [this]() { m_popupWidget->deleteLater(); });
 
-	connect(m_popupWidget->getContinueBtn(), &QPushButton::clicked, this, [=]() { m_popupWidget->deleteLater(); });
+	connect(m_popupWidget->getContinueBtn(), &QPushButton::clicked, this,
+		[this]() { m_popupWidget->deleteLater(); });
 
 	m_popupWidget->enableTintedOverlay(true);
 	m_popupWidget->show();
@@ -167,7 +168,7 @@ RunBtn::RunBtn(QWidget *parent)
 	setChecked(false);
 	setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 	setText("Run");
-	connect(this, &QPushButton::toggled, this, [=](bool b) { setText(b ? "Stop" : "Run"); });
+	connect(this, &QPushButton::toggled, this, [this](bool b) { setText(b ? "Stop" : "Run"); });
 	Style::setStyle(this, style::properties::button::runButton);
 
 	QIcon icon1;
@@ -187,7 +188,7 @@ SingleShotBtn::SingleShotBtn(QWidget *parent)
 	setCheckable(true);
 	setChecked(false);
 	setText("Single");
-	connect(this, &QPushButton::toggled, this, [=](bool b) { setText(b ? "Stop" : "Single"); });
+	connect(this, &QPushButton::toggled, this, [this](bool b) { setText(b ? "Stop" : "Single"); });
 	Style::setStyle(this, style::properties::button::singleButton);
 
 	QIcon icon1;
@@ -207,7 +208,7 @@ AddBtn::AddBtn(QWidget *parent)
 	QString iconPath = ":/gui/icons/add.svg";
 	setIcon(Style::getPixmap(iconPath, Style::getColor(json::theme::content_default)));
 
-	connect(this, &QPushButton::toggled, this, [=](bool toggle) {
+	connect(this, &QPushButton::toggled, this, [this, iconPath](bool toggle) {
 		const char *color = toggle ? json::theme::content_inverse : json::theme::content_default;
 		setIcon(Style::getPixmap(iconPath, Style::getColor(color)));
 	});
@@ -221,7 +222,7 @@ RemoveBtn::RemoveBtn(QWidget *parent)
 	QString iconPath = ":/gui/icons/red_x.svg";
 	setIcon(Style::getPixmap(iconPath, Style::getColor(json::theme::content_default)));
 
-	connect(this, &QPushButton::toggled, this, [=](bool toggle) {
+	connect(this, &QPushButton::toggled, this, [this, iconPath](bool toggle) {
 		const char *color = toggle ? json::theme::content_inverse : json::theme::content_default;
 		setIcon(Style::getPixmap(iconPath, Style::getColor(color)));
 	});
@@ -326,7 +327,7 @@ MenuCollapseBtn::MenuCollapseBtn(Direction dir, MenuHAnim *menu, QWidget *parent
 
 	setIcon(Style::getPixmap(openIcon, Style::getColor(json::theme::content_default)));
 
-	connect(this, &QPushButton::toggled, this, [=](bool open) {
+	connect(this, &QPushButton::toggled, this, [this, openIcon, closedIcon, menu](bool open) {
 		setIcon(Style::getPixmap(open ? openIcon : closedIcon, Style::getColor(json::theme::content_default)));
 		menu->toggleMenu(open);
 	});

--- a/gui/test/CMakeLists.txt
+++ b/gui/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 function(SETUP_TESTS)
 	foreach(_testname ${ARGS})

--- a/iio-widgets/CMakeLists.txt
+++ b/iio-widgets/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE iio-widgets)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/iio-widgets/test/CMakeLists.txt
+++ b/iio-widgets/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/iioutil/CMakeLists.txt
+++ b/iioutil/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE iioutil)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/iioutil/test/CMakeLists.txt
+++ b/iioutil/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project(scopy-packages VERSION 0.1 LANGUAGES CXX)
 

--- a/packages/ad6676/CMakeLists.txt
+++ b/packages/ad6676/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad6676)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/ad6676/plugins/ad6676plugin/CMakeLists.txt
+++ b/packages/ad6676/plugins/ad6676plugin/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad6676plugin)
 
@@ -32,7 +32,7 @@ set(PLUGIN_DESCRIPTION "AD6676 Wideband IF Receiver Plugin")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC ON)

--- a/packages/ad6676/plugins/ad6676plugin/test/CMakeLists.txt
+++ b/packages/ad6676/plugins/ad6676plugin/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/ad936x/CMakeLists.txt
+++ b/packages/ad936x/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad936x)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/ad936x/plugins/ad936x/CMakeLists.txt
+++ b/packages/ad936x/plugins/ad936x/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad936x)
 
@@ -32,7 +32,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/ad936x/plugins/ad936x/src/fmcomms5/fmcomms5advanced.cpp
+++ b/packages/ad936x/plugins/ad936x/src/fmcomms5/fmcomms5advanced.cpp
@@ -156,7 +156,7 @@ Fmcomms5Advanced::Fmcomms5Advanced(iio_context *ctx, IIOWidgetGroup *group, QWid
 
 		m_syncBtn = new QPushButton("MSC Sync", this);
 		Style::setStyle(m_syncBtn, style::properties::button::basicButton);
-		connect(m_syncBtn, &QPushButton::clicked, this, [=]() {
+		connect(m_syncBtn, &QPushButton::clicked, this, [this]() {
 			// call to lib ad9361
 			ad9361_multichip_sync(m_mainDevice, &m_secondDevice, 1,
 					      FIXUP_INTERFACE_TIMING | CHECK_SAMPLE_RATES);

--- a/packages/ad936x/plugins/ad936x/src/fmcomms5/fmcomms5tab.cpp
+++ b/packages/ad936x/plugins/ad936x/src/fmcomms5/fmcomms5tab.cpp
@@ -73,7 +73,7 @@ Fmcomms5Tab::Fmcomms5Tab(iio_context *ctx, IIOWidgetGroup *group, QWidget *paren
 	layout->addWidget(calSwitchControl);
 
 	connect(calSwitchControl, QOverload<const int>::of(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { calibration->callSwitchPortsEnableCb(idx); });
+		[calibration](int idx) { calibration->callSwitchPortsEnableCb(idx); });
 
 	m_calibrateBtn = new QPushButton("Calibrate", this);
 	Style::setStyle(m_calibrateBtn, style::properties::button::basicButton);
@@ -116,7 +116,7 @@ Fmcomms5Tab::Fmcomms5Tab(iio_context *ctx, IIOWidgetGroup *group, QWidget *paren
 				     .buildSingle();
 	layout->addWidget(txPhase);
 
-	connect(m_calibrateBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_calibrateBtn, &QPushButton::clicked, this, [this, calibration, txPhase]() {
 		m_calibrateBtn->setEnabled(false);
 		calibration->calibrate();
 		m_calibrateBtn->setEnabled(true);

--- a/packages/ad936x/plugins/ad936x/test/CMakeLists.txt
+++ b/packages/ad936x/plugins/ad936x/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/ad9371/CMakeLists.txt
+++ b/packages/ad9371/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad9371)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/ad9371/plugins/ad9371plugin/CMakeLists.txt
+++ b/packages/ad9371/plugins/ad9371plugin/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad9371plugin)
 
@@ -32,7 +32,7 @@ set(PLUGIN_DESCRIPTION "AD9371 RF TRANSCEIVER CONTROL AND CONFIGURATION")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/ad9371/plugins/ad9371plugin/test/CMakeLists.txt
+++ b/packages/ad9371/plugins/ad9371plugin/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/adrv9002/CMakeLists.txt
+++ b/packages/adrv9002/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE adrv9002)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/adrv9002/plugins/adrv9002plugin/CMakeLists.txt
+++ b/packages/adrv9002/plugins/adrv9002plugin/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE adrv9002plugin)
 
@@ -34,7 +34,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/adrv9002/plugins/adrv9002plugin/test/CMakeLists.txt
+++ b/packages/adrv9002/plugins/adrv9002plugin/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/adrv9009/CMakeLists.txt
+++ b/packages/adrv9009/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE adrv9009)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/adrv9009/plugins/adrv9009plugin/CMakeLists.txt
+++ b/packages/adrv9009/plugins/adrv9009plugin/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE adrv9009plugin)
 
@@ -34,7 +34,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/adrv9009/plugins/adrv9009plugin/src/adrv9009.cpp
+++ b/packages/adrv9009/plugins/adrv9009plugin/src/adrv9009.cpp
@@ -421,7 +421,7 @@ QWidget *Adrv9009::generateCalibrationWidget(iio_device *device, QWidget *parent
 	Style::setStyle(calibrateButton, style::properties::button::basicButton);
 	calGridLayout->addWidget(calibrateButton, 1, 3);
 
-	connect(calibrateButton, &QPushButton::clicked, this, [=] {
+	connect(calibrateButton, &QPushButton::clicked, this, [this, device] {
 		// Trigger calibration
 		int ret = iio_device_attr_write_bool(device, "calibrate", true);
 		if(ret < 0) {
@@ -988,10 +988,11 @@ QWidget *Adrv9009::createFpgaRxChannelWidget(iio_device *dev, QString title, int
 
 	// Connect to phase rotation functions
 	connect(phaseSpinBox, &gui::MenuSpinbox::valueChanged, this,
-		[=](double degrees) { writePhase(dev, channelIndex, (int)degrees); });
+		[this, dev, channelIndex](double degrees) { writePhase(dev, channelIndex, (int)degrees); });
 
 	// Add to refresh handling
-	connect(this, &Adrv9009::readRequested, this, [=]() { readPhase(dev, channelIndex, phaseSpinBox); });
+	connect(this, &Adrv9009::readRequested, this,
+		[this, dev, channelIndex, phaseSpinBox]() { readPhase(dev, channelIndex, phaseSpinBox); });
 
 	mainLayout->addWidget(phaseSpinBox);
 

--- a/packages/adrv9009/plugins/adrv9009plugin/test/CMakeLists.txt
+++ b/packages/adrv9009/plugins/adrv9009plugin/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/apollo-ad9084/CMakeLists.txt
+++ b/packages/apollo-ad9084/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE apollo-ad9084)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/apollo-ad9084/plugins/ad9084/CMakeLists.txt
+++ b/packages/apollo-ad9084/plugins/ad9084/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ad9084)
 
@@ -31,7 +31,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/apollo-ad9084/plugins/ad9084/test/CMakeLists.txt
+++ b/packages/apollo-ad9084/plugins/ad9084/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/cn0357/CMakeLists.txt
+++ b/packages/cn0357/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE cn0357)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/cn0357/plugins/cn0357/CMakeLists.txt
+++ b/packages/cn0357/plugins/cn0357/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE cn0357)
 
@@ -37,7 +37,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/cn0357/plugins/cn0357/test/CMakeLists.txt
+++ b/packages/cn0357/plugins/cn0357/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/cn0540/CMakeLists.txt
+++ b/packages/cn0540/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE cn0540)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/cn0540/plugins/cn0540/CMakeLists.txt
+++ b/packages/cn0540/plugins/cn0540/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE cn0540)
 
@@ -32,7 +32,7 @@ set(PLUGIN_DESCRIPTION "CN0540 Precision Measurement System Plugin")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/daq2/CMakeLists.txt
+++ b/packages/daq2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE daq2)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/daq2/plugins/daq2/CMakeLists.txt
+++ b/packages/daq2/plugins/daq2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE daq2)
 
@@ -30,7 +30,7 @@ set(PLUGIN_DESCRIPTION "This is a plugin for DAQ2")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/extproc/CMakeLists.txt
+++ b/packages/extproc/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE extproc)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/extproc/plugins/extprocplugin/CMakeLists.txt
+++ b/packages/extproc/plugins/extprocplugin/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE extprocplugin)
 

--- a/packages/extproc/plugins/extprocplugin/res/cli/CMakeLists.txt
+++ b/packages/extproc/plugins/extprocplugin/res/cli/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project(cli_analyzer VERSION 1.0 LANGUAGES C)
 

--- a/packages/extproc/plugins/extprocplugin/test/CMakeLists.txt
+++ b/packages/extproc/plugins/extprocplugin/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/fmcomms11/CMakeLists.txt
+++ b/packages/fmcomms11/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE fmcomms11)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/fmcomms11/plugins/fmcomms11/CMakeLists.txt
+++ b/packages/fmcomms11/plugins/fmcomms11/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE fmcomms11)
 
@@ -30,7 +30,7 @@ set(PLUGIN_DESCRIPTION "This is a plugin for FMCOMMS11")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC ON)

--- a/packages/generic-plugins/CMakeLists.txt
+++ b/packages/generic-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE generic-plugins)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/generic-plugins/plugins/adc/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/adc/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE adc)
 
@@ -28,7 +28,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/generic-plugins/plugins/adc/src/adcfftinstrumentcontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcfftinstrumentcontroller.cpp
@@ -60,7 +60,7 @@ void ADCFFTInstrumentController::init()
 
 	connect(m_ui->m_cursor->button(), &QAbstractButton::toggled, hoverSettings, &HoverWidget::setVisible);
 
-	connect(m_plotComponentManager, &PlotManager::plotAdded, this, [=](uint32_t uuid) {
+	connect(m_plotComponentManager, &PlotManager::plotAdded, this, [this, m_cursorSettings](uint32_t uuid) {
 		auto fftPlt = dynamic_cast<FFTPlotComponent *>(m_plotComponentManager->plot(uuid));
 
 		auto cursorController = fftPlt->cursor();
@@ -89,7 +89,7 @@ void ADCFFTInstrumentController::init()
 	analyzeHoverSettings->setAnchorOffset(QPoint(0, -10));
 
 	connect(m_ui->m_analyze->button(), &QAbstractButton::toggled, analyzeHoverSettings, &HoverWidget::setVisible);
-	connect(m_ui->m_analyze, &QAbstractButton::toggled, this, [=](bool checked) {
+	connect(m_ui->m_analyze, &QAbstractButton::toggled, this, [this](bool checked) {
 		m_genalyzerSettings->enableAnalysis(checked);
 		m_plotComponentManager->enableGenalyzerPanel(checked);
 	});
@@ -99,12 +99,12 @@ void ADCFFTInstrumentController::init()
 
 	plotStack->add("fft", m_plotComponentManager);
 	m_ui->getRightStack()->add(m_ui->settingsMenuId, m_fftPlotSettingsComponent);
-	connect(m_fftPlotSettingsComponent, &FFTPlotManagerSettings::requestOpenMenu, [=]() {
+	connect(m_fftPlotSettingsComponent, &FFTPlotManagerSettings::requestOpenMenu, [this]() {
 		m_ui->getRightStack()->show(m_ui->settingsMenuId);
 		m_ui->m_settingsBtn->setChecked(true);
 	});
 
-	connect(m_ui->m_printBtn, &QPushButton::clicked, [=]() {
+	connect(m_ui->m_printBtn, &QPushButton::clicked, [this]() {
 		QList<PlotWidget *> plotList;
 
 		for(PlotComponent *pp : m_plotComponentManager->plots()) {
@@ -147,7 +147,7 @@ void ADCFFTInstrumentController::createIIODevice(AcqTreeNode *node)
 	addComponent(d);
 
 	connect(m_fftPlotSettingsComponent, &FFTPlotManagerSettings::samplingInfoChanged, this,
-		[=](SamplingInfo p) { d->setBufferSize(p.bufferSize); });
+		[d](SamplingInfo p) { d->setBufferSize(p.bufferSize); });
 }
 
 void ADCFFTInstrumentController::createIIOFloatChannel(AcqTreeNode *node)
@@ -181,7 +181,7 @@ void ADCFFTInstrumentController::createIIOFloatChannel(AcqTreeNode *node)
 
 	m_ui->addChannel(c->ctrl(), c, cw);
 
-	connect(c->ctrl(), &QAbstractButton::clicked, this, [=]() { m_plotComponentManager->selectChannel(c); });
+	connect(c->ctrl(), &QAbstractButton::clicked, this, [this, c]() { m_plotComponentManager->selectChannel(c); });
 
 	grtsc->addChannel(c);			   // For matching Sink To Channels
 	dc->addChannel(c);			   // used for sample rate computation
@@ -202,13 +202,13 @@ void ADCFFTInstrumentController::createIIOFloatChannel(AcqTreeNode *node)
 		markerName = griiofcn->treeParent()->name() + ":" + c->name();
 	}
 
-	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [=]() {
+	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [this, c, markerName]() {
 		auto info = c->markerController()->markerInfo();
 		m_plotComponentManager->markerPanel()->updateChannel(markerName, info);
 	});
 
 	auto markerController = dynamic_cast<FFTPlotComponentChannel *>(c->plotChannelCmpt())->markerController();
-	connect(markerController, &PlotMarkerController::markerEnabled, this, [=](bool b) {
+	connect(markerController, &PlotMarkerController::markerEnabled, this, [this, c, markerName](bool b) {
 		if(b) {
 			m_plotComponentManager->markerPanel()->newChannel(markerName, c->pen());
 		} else {
@@ -250,7 +250,7 @@ void ADCFFTInstrumentController::createIIOComplexChannel(AcqTreeNode *node_I, Ac
 
 	m_ui->addChannel(c->ctrl(), c, cw);
 
-	connect(c->ctrl(), &QAbstractButton::clicked, this, [=]() { m_plotComponentManager->selectChannel(c); });
+	connect(c->ctrl(), &QAbstractButton::clicked, this, [this, c]() { m_plotComponentManager->selectChannel(c); });
 
 	grtsc->addChannel(c);			   // For matching Sink To Channels
 	dc->addChannel(c);			   // used for sample rate computation
@@ -270,13 +270,13 @@ void ADCFFTInstrumentController::createIIOComplexChannel(AcqTreeNode *node_I, Ac
 		markerName = griiofcn_I->treeParent()->name() + ":" + c->name();
 	}
 
-	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [=]() {
+	connect(c->markerController(), &PlotMarkerController::markerInfoUpdated, this, [this, c, markerName]() {
 		auto info = c->markerController()->markerInfo();
 		m_plotComponentManager->markerPanel()->updateChannel(markerName, info);
 	});
 
 	auto markerController = dynamic_cast<FFTPlotComponentChannel *>(c->plotChannelCmpt())->markerController();
-	connect(markerController, &PlotMarkerController::markerEnabled, this, [=](bool b) {
+	connect(markerController, &PlotMarkerController::markerEnabled, this, [this, c, markerName](bool b) {
 		if(b) {
 			m_plotComponentManager->markerPanel()->newChannel(markerName, c->pen());
 		} else {
@@ -298,18 +298,18 @@ void ADCFFTInstrumentController::createIIOComplexChannel(AcqTreeNode *node_I, Ac
 
 	// Connect channel enable/disable signals to update genalyzer panel visibility
 	connect(c, &GRFFTChannelComponent::genalyzerChannelEnabled, m_plotComponentManager->genalyzerPanel(),
-		[=](const QString &channelName) {
+		[this](const QString &channelName) {
 			m_plotComponentManager->genalyzerPanel()->setChannelVisible(channelName, true);
 		});
 	connect(c, &GRFFTChannelComponent::genalyzerChannelDisabled, m_plotComponentManager->genalyzerPanel(),
-		[=](const QString &channelName) {
+		[this](const QString &channelName) {
 			m_plotComponentManager->genalyzerPanel()->setChannelVisible(channelName, false);
 		});
 	connect(c, &GRFFTChannelComponent::genalyzerChannelRenamed, m_plotComponentManager->genalyzerPanel(),
 		&GenalyzerPanel::renameChannel);
 
 	connect(c->chData(), &ChannelData::newData, this,
-		[=](const float *xData_, const float *yData_, size_t size, bool copy) {
+		[this, c](const float *xData_, const float *yData_, size_t size, bool copy) {
 			if(m_ui->m_complex->isChecked() && m_plotComponentManager->genalyzerPanel()->isVisible()) {
 				c->triggerGenalyzerAnalysis();
 			}
@@ -324,15 +324,16 @@ void ADCFFTInstrumentController::createFFTSink(AcqTreeNode *node)
 	m_dataProvider = c;
 	c->init();
 
-	connect(m_fftPlotSettingsComponent, &FFTPlotManagerSettings::samplingInfoChanged, this, [=](SamplingInfo p) {
-		if(m_started) {
-			stop();
-			c->setSamplingInfo(p);
-			start();
-		} else {
-			c->setSamplingInfo(p);
-		}
-	});
+	connect(m_fftPlotSettingsComponent, &FFTPlotManagerSettings::samplingInfoChanged, this,
+		[this, c](SamplingInfo p) {
+			if(m_started) {
+				stop();
+				c->setSamplingInfo(p);
+				start();
+			} else {
+				c->setSamplingInfo(p);
+			}
+		});
 
 	connect(c, &GRFFTSinkComponent::requestSingleShot, this, &ADCFFTInstrumentController::setSingleShot);
 	connect(c, &GRFFTSinkComponent::requestBufferSize, m_fftPlotSettingsComponent,
@@ -341,7 +342,7 @@ void ADCFFTInstrumentController::createFFTSink(AcqTreeNode *node)
 
 	connect(m_ui->m_complex, &QAbstractButton::toggled, m_fftPlotSettingsComponent,
 		&FFTPlotManagerSettings::setComplexMode);
-	connect(m_ui->m_complex, &QAbstractButton::toggled, this, [=]() {
+	connect(m_ui->m_complex, &QAbstractButton::toggled, this, [this]() {
 		bool isComplex = m_ui->m_complex->isChecked();
 		m_ui->m_analyze->setVisible(isComplex);
 		if(isComplex) {
@@ -368,7 +369,7 @@ void ADCFFTInstrumentController::createFFTSink(AcqTreeNode *node)
 		}
 	});
 
-	connect(m_ui->m_singleBtn, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_ui->m_singleBtn, &QAbstractButton::toggled, this, [this](bool b) {
 		setSingleShot(b);
 		if(b && !m_started) {
 			Q_EMIT requestStart();
@@ -381,7 +382,7 @@ void ADCFFTInstrumentController::createFFTSink(AcqTreeNode *node)
 	connect(m_ui, &ADCInstrument::requestStop, this, &ADCInstrumentController::requestStop);
 	connect(this, &ADCInstrumentController::requestStop, this, &ADCInstrumentController::stop);
 
-	connect(m_ui->m_sync, &QAbstractButton::toggled, this, [=](bool b) { c->setSyncMode(b); });
+	connect(m_ui->m_sync, &QAbstractButton::toggled, this, [c](bool b) { c->setSyncMode(b); });
 
 	connect(c, &GRFFTSinkComponent::arm, this, &ADCInstrumentController::onStart);
 	connect(c, &GRFFTSinkComponent::disarm, this, &ADCInstrumentController::onStop);
@@ -405,7 +406,7 @@ void ADCFFTInstrumentController::createImportFloatChannel(AcqTreeNode *node)
 	m_acqNodeComponentMap[ifcn] = c;
 	m_ui->addChannel(c->ctrl(), c, cw);
 
-	connect(c->ctrl(), &QAbstractButton::clicked, this, [=]() { m_plotComponentManager->selectChannel(c); });
+	connect(c->ctrl(), &QAbstractButton::clicked, this, [this, c]() { m_plotComponentManager->selectChannel(c); });
 
 	c->ctrl()->animateClick();
 
@@ -415,7 +416,7 @@ void ADCFFTInstrumentController::createImportFloatChannel(AcqTreeNode *node)
 	setupChannelMeasurement(m_plotComponentManager, c);
 
 	connect(m_otherCMCB->onOffSwitch(), &SmallOnOffSwitch::toggled, this,
-		[=](bool en) { c->ctrl()->checkBox()->setChecked(en); });
+		[c](bool en) { c->ctrl()->checkBox()->setChecked(en); });
 }
 
 bool ADCFFTInstrumentController::getComplexChannelPair(AcqTreeNode *node, AcqTreeNode **node_i, AcqTreeNode **node_q)

--- a/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcinstrument.cpp
@@ -96,7 +96,7 @@ void ADCInstrument::setupToolLayout()
 
 	tool->addWidgetToCentralContainerHelper(m_splitter);
 
-	connect(rightStack, &QStackedWidget::currentChanged, this, [=](int) {
+	connect(rightStack, &QStackedWidget::currentChanged, this, [this](int) {
 		if(m_splitter->sizes().at(2) == 0) {
 			QList<int> sizes = m_splitter->sizes();
 			sizes[1] -= right_splitter_size;
@@ -126,7 +126,7 @@ void ADCInstrument::setupToolLayout()
 	addBtn = new AddBtn(this);
 	removeBtn = new RemoveBtn(this);
 
-	connect(infoBtn, &QAbstractButton::clicked, this, [=]() {
+	connect(infoBtn, &QAbstractButton::clicked, this, []() {
 		QDesktopServices::openUrl(QUrl("https://analogdevicesinc.github.io/scopy/plugins/adc/adc.html"));
 	});
 
@@ -175,16 +175,16 @@ void ADCInstrument::setupToolLayout()
 	channelGroup = new QButtonGroup(this);
 	channelGroup->addButton(m_settingsBtn);
 
-	connect(m_settingsBtn->button(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_settingsBtn->button(), &QAbstractButton::toggled, this, [this](bool b) {
 		if(b)
 			rightStack->show(settingsMenuId);
 	});
-	connect(m_settingsBtn, &QAbstractButton::clicked, this, [=](bool b) {
+	connect(m_settingsBtn, &QAbstractButton::clicked, this, [this](bool b) {
 		if(b)
 			rightStack->show(settingsMenuId);
 	});
 
-	connect(m_runBtn, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_runBtn, &QAbstractButton::toggled, this, [this](bool b) {
 		m_runBtn->setEnabled(false);
 		if(b) {
 			Q_EMIT requestStart();
@@ -195,7 +195,7 @@ void ADCInstrument::setupToolLayout()
 
 	connect(m_tme, &ToolMenuEntry::runToggled, m_runBtn, &QAbstractButton::toggle);
 
-	connect(addBtn, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestNewInstrument(TIME); });
+	connect(addBtn, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestNewInstrument(TIME); });
 
 	connect(removeBtn, &QAbstractButton::clicked, this, &ADCInstrument::requestDeleteInstrument);
 }
@@ -221,7 +221,7 @@ void ADCInstrument::addDevice(CollapsableMenuControlButton *b, ToolComponent *de
 	QString id = dev->name() + QString::number(uuid++);
 	rightStack->add(id, dev_widget);
 
-	connect(b->getControlBtn(), &QPushButton::clicked /* Or ::toggled*/, this, [=](bool b) {
+	connect(b->getControlBtn(), &QPushButton::clicked /* Or ::toggled*/, this, [this, id](bool b) {
 		if(b) {
 			rightStack->show(id);
 		}
@@ -248,14 +248,14 @@ void ADCInstrument::addChannel(MenuControlButton *btn, ChannelComponent *ch, Com
 
 	rightStack->add(id, ch_widget);
 
-	connect(btn->button(), &QPushButton::pressed, this, [=]() { Q_EMIT btn->clicked(true); });
-	connect(btn, &QAbstractButton::clicked, this, [=](bool b) {
+	connect(btn->button(), &QPushButton::pressed, this, [btn]() { Q_EMIT btn->clicked(true); });
+	connect(btn, &QAbstractButton::clicked, this, [this, id](bool b) {
 		if(b) {
 			switchToChannelMenu(id, true);
 		}
 	});
 
-	connect(ch, &ChannelComponent::requestChannelMenu, this, [=](bool f) { switchToChannelMenu(id, f); });
+	connect(ch, &ChannelComponent::requestChannelMenu, this, [this, id](bool f) { switchToChannelMenu(id, f); });
 
 	/*setupChannelSnapshot(ch);
 	setupChannelMeasurement(ch);

--- a/packages/generic-plugins/plugins/adc/src/adcinstrumentcontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcinstrumentcontroller.cpp
@@ -52,7 +52,7 @@ ADCInstrumentController::ADCInstrumentController(ToolMenuEntry *tme, QString uri
 	m_fw = new QFutureWatcher<void>(this);
 	connect(
 		m_fw, &QFutureWatcher<void>::finished, this,
-		[=]() {
+		[this]() {
 			update();
 			if(m_refreshTimerRunning)
 				m_plotTimer->start();
@@ -137,7 +137,7 @@ void ADCInstrumentController::setSingleShot(bool b) { m_dataProvider->setSingleS
 
 void ADCInstrumentController::updateData()
 {
-	m_refillFuture = QtConcurrent::run([=]() { m_dataProvider->updateData(); });
+	m_refillFuture = QtConcurrent::run([this]() { m_dataProvider->updateData(); });
 	m_fw->setFuture(m_refillFuture);
 }
 
@@ -195,17 +195,17 @@ void ADCInstrumentController::setupChannelMeasurement(PlotManager *c, ChannelCom
 	connect(chMeasureManager, &MeasureManagerInterface::disableMeasurement, measurePanel,
 		&MeasurementsPanel::removeMeasurement);
 	connect(chMeasureManager, &MeasureManagerInterface::enableMeasurement, this,
-		[=]() { c->enableMeasurementPanel(true); });
-	connect(measurePanel, &MeasurementsPanel::hideAll, this, [=]() {
+		[c]() { c->enableMeasurementPanel(true); });
+	connect(measurePanel, &MeasurementsPanel::hideAll, this, [measurePanel, chMeasureManager]() {
 		measurePanel->setInhibitUpdates(true);
 		Q_EMIT chMeasureManager->toggleAllMeasurement(false);
 		measurePanel->setInhibitUpdates(false);
 	});
 	connect(chMeasureManager, &MeasureManagerInterface::enableStat, statsPanel, &StatsPanel::addStat);
 	connect(chMeasureManager, &MeasureManagerInterface::disableStat, statsPanel, &StatsPanel::removeStat);
-	connect(chMeasureManager, &MeasureManagerInterface::enableStat, this, [=]() { c->enableStatsPanel(true); });
+	connect(chMeasureManager, &MeasureManagerInterface::enableStat, this, [c]() { c->enableStatsPanel(true); });
 	connect(statsPanel, &StatsPanel::hideAll, chMeasureManager,
-		[=]() { Q_EMIT chMeasureManager->toggleAllStats(false); });
+		[chMeasureManager]() { Q_EMIT chMeasureManager->toggleAllStats(false); });
 }
 
 bool ADCInstrumentController::isMainInstrument() const { return m_isMainInstrument; }

--- a/packages/generic-plugins/plugins/adc/src/adcplugin.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adcplugin.cpp
@@ -350,13 +350,13 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root, GRTopBlock
 		connect(root, &AcqTreeNode::deletedChild, dynamic_cast<ADCTimeInstrumentController *>(adc),
 			&ADCTimeInstrumentController::removeChannel, Qt::QueuedConnection);
 
-		connect(ui, &ADCInstrument::requestNewInstrument, this, [=]() {
+		connect(ui, &ADCInstrument::requestNewInstrument, this, [this, grtp, t, root]() {
 			QMetaObject::invokeMethod(grtp, &GRTopBlock::suspendBuild, Qt::DirectConnection);
 			newInstrument(t, root, grtp);
 			QMetaObject::invokeMethod(grtp, &GRTopBlock::unsuspendBuild, Qt::QueuedConnection);
 		});
 
-		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [=]() {
+		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [this, ui]() {
 			ToolMenuEntry *t = nullptr;
 			for(auto tool : std::as_const(m_toolList)) {
 				if(tool->tool() == ui) {
@@ -390,13 +390,13 @@ void ADCPlugin::newInstrument(ADCInstrumentType t, AcqTreeNode *root, GRTopBlock
 		connect(root, &AcqTreeNode::deletedChild, dynamic_cast<ADCFFTInstrumentController *>(adc),
 			&ADCFFTInstrumentController::removeChannel, Qt::QueuedConnection);
 
-		connect(ui, &ADCInstrument::requestNewInstrument, this, [=]() {
+		connect(ui, &ADCInstrument::requestNewInstrument, this, [this, grtp, t, root]() {
 			QMetaObject::invokeMethod(grtp, &GRTopBlock::suspendBuild, Qt::DirectConnection);
 			newInstrument(t, root, grtp);
 			QMetaObject::invokeMethod(grtp, &GRTopBlock::unsuspendBuild, Qt::QueuedConnection);
 		});
 
-		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [=]() {
+		connect(ui, &ADCInstrument::requestDeleteInstrument, this, [this, ui]() {
 			ToolMenuEntry *t = nullptr;
 			for(auto tool : std::as_const(m_toolList)) {
 				if(tool->tool() == ui) {

--- a/packages/generic-plugins/plugins/adc/src/adctimeinstrumentcontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/adctimeinstrumentcontroller.cpp
@@ -59,7 +59,7 @@ void ADCTimeInstrumentController::init()
 
 	connect(m_ui->m_cursor->button(), &QAbstractButton::toggled, hoverSettings, &HoverWidget::setVisible);
 
-	connect(m_plotComponentManager, &PlotManager::plotAdded, this, [=](uint32_t uuid) {
+	connect(m_plotComponentManager, &PlotManager::plotAdded, this, [this, m_cursorSettings](uint32_t uuid) {
 		auto cursorController = m_plotComponentManager->plot(uuid)->cursor();
 		cursorController->connectSignals(m_cursorSettings);
 		connect(m_ui->m_cursor, &QAbstractButton::toggled, cursorController, &CursorController::setVisible);
@@ -78,12 +78,12 @@ void ADCTimeInstrumentController::init()
 	plotStack->add("time", m_plotComponentManager);
 	m_ui->getRightStack()->add(m_ui->settingsMenuId, m_timePlotSettingsComponent);
 
-	connect(m_timePlotSettingsComponent, &TimePlotManagerSettings::requestOpenMenu, [=]() {
+	connect(m_timePlotSettingsComponent, &TimePlotManagerSettings::requestOpenMenu, [this]() {
 		m_ui->getRightStack()->show(m_ui->settingsMenuId);
 		m_ui->m_settingsBtn->setChecked(true);
 	});
 
-	connect(m_ui->m_printBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_ui->m_printBtn, &QPushButton::clicked, this, [this]() {
 		QList<PlotWidget *> plotList;
 
 		for(PlotComponent *pp : m_plotComponentManager->plots()) {
@@ -132,7 +132,7 @@ void ADCTimeInstrumentController::createTimeSink(AcqTreeNode *node)
 	connect(m_timePlotSettingsComponent, &TimePlotManagerSettings::samplingInfoChanged, c,
 		&GRTimeSinkComponent::setSamplingInfo);
 
-	connect(m_ui->m_singleBtn, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_ui->m_singleBtn, &QAbstractButton::toggled, this, [this](bool b) {
 		setSingleShot(b);
 		if(b && !m_started) {
 			Q_EMIT requestStart();
@@ -145,7 +145,7 @@ void ADCTimeInstrumentController::createTimeSink(AcqTreeNode *node)
 	connect(m_ui, &ADCInstrument::requestStop, this, &ADCInstrumentController::requestStop);
 	connect(this, &ADCInstrumentController::requestStop, this, &ADCInstrumentController::stop);
 
-	connect(m_ui->m_sync, &QAbstractButton::toggled, this, [=](bool b) { c->setSyncMode(b); });
+	connect(m_ui->m_sync, &QAbstractButton::toggled, this, [c](bool b) { c->setSyncMode(b); });
 
 	connect(c, &GRTimeSinkComponent::arm, this, &ADCInstrumentController::onStart);
 	connect(c, &GRTimeSinkComponent::disarm, this, &ADCInstrumentController::onStop);
@@ -202,7 +202,7 @@ void ADCTimeInstrumentController::createIIOFloatChannel(AcqTreeNode *node)
 
 	m_ui->addChannel(c->ctrl(), c, cw);
 
-	connect(c->ctrl(), &QAbstractButton::clicked, this, [=]() { m_plotComponentManager->selectChannel(c); });
+	connect(c->ctrl(), &QAbstractButton::clicked, this, [this, c]() { m_plotComponentManager->selectChannel(c); });
 
 	grtsc->addChannel(c);			    // For matching Sink To Channels
 	dc->addChannel(c);			    // used for sample rate computation
@@ -231,7 +231,7 @@ void ADCTimeInstrumentController::createImportFloatChannel(AcqTreeNode *node)
 	m_acqNodeComponentMap[ifcn] = c;
 	m_ui->addChannel(c->ctrl(), c, cw);
 
-	connect(c->ctrl(), &QAbstractButton::clicked, this, [=]() { m_plotComponentManager->selectChannel(c); });
+	connect(c->ctrl(), &QAbstractButton::clicked, this, [this, c]() { m_plotComponentManager->selectChannel(c); });
 
 	c->ctrl()->animateClick();
 
@@ -241,7 +241,7 @@ void ADCTimeInstrumentController::createImportFloatChannel(AcqTreeNode *node)
 	setupChannelMeasurement(m_plotComponentManager, c);
 
 	connect(m_otherCMCB->onOffSwitch(), &SmallOnOffSwitch::toggled, this,
-		[=](bool en) { c->ctrl()->checkBox()->setChecked(en); });
+		[c](bool en) { c->ctrl()->checkBox()->setChecked(en); });
 }
 
 void ADCTimeInstrumentController::addChannel(AcqTreeNode *node)

--- a/packages/generic-plugins/plugins/adc/src/fftmarkercontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/fftmarkercontroller.cpp
@@ -154,7 +154,7 @@ void FFTMarkerController::initFixedMarker()
 		this->m_markerInfo.append(mi);
 		PlotAxisHandle *handle =
 			new PlotAxisHandle(m_ch->plotComponent()->plot(0), m_ch->m_plotComponent->plot(0)->xAxis());
-		connect(handle, &PlotAxisHandle::scalePosChanged, this, [=](double v) {
+		connect(handle, &PlotAxisHandle::scalePosChanged, this, [this, i](double v) {
 			m_markerInfo[i].peak.x = v;
 			computeMarkers();
 		});

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponent.cpp
@@ -84,7 +84,8 @@ FFTPlotComponent::FFTPlotComponent(QString name, uint32_t uuid, QWidget *parent)
 	m_dockableArea->addDockWrapper(m_fftDockWrapper, DockableAreaInterface::Direction_TOP);
 	m_dockableArea->addDockWrapper(m_waterfallDockWrapper, DockableAreaInterface::Direction_BOTTOM);
 
-	connect(m_plotMenu, &FFTPlotComponentSettings::requestDeletePlot, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_plotMenu, &FFTPlotComponentSettings::requestDeletePlot, this,
+		[this]() { Q_EMIT requestDeletePlot(); });
 	m_cursor = new CursorController(m_fftPlot, this);
 	int xCursorPos = Preferences::get("adc_plot_xcursor_position").toInt();
 	int yCursorPos = Preferences::get("adc_plot_ycursor_position").toInt();
@@ -127,7 +128,7 @@ void FFTPlotComponent::selectChannel(ChannelComponent *ch)
 	if(ch) {
 		m_waterfallDockWrapper->setTitle("Waterfall Plot - " + ch->name());
 		connect(ch, &ChannelComponent::nameChanged, this,
-			[=](const QString &name) { m_waterfallDockWrapper->setTitle("Waterfall Plot - " + name); });
+			[this](const QString &name) { m_waterfallDockWrapper->setTitle("Waterfall Plot - " + name); });
 	}
 }
 

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponentchannel.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponentchannel.cpp
@@ -90,7 +90,7 @@ void FFTPlotComponentChannel::initPlotComponent(PlotComponent *pc)
 	m_fftPlotAxisHandle->handle()->setBarVisibility(BarVisibility::ON_HOVER);
 	m_fftPlotAxisHandle->handle()->setColor(m_ch->pen().color());
 
-	connect(m_fftPlotAxisHandle, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(m_fftPlotAxisHandle, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		double min = m_fftPlotYAxis->min() - pos;
 		double max = m_fftPlotYAxis->max() - pos;
 		m_fftPlotYAxis->setInterval(min, max);
@@ -103,14 +103,14 @@ void FFTPlotComponentChannel::initPlotComponent(PlotComponent *pc)
 	m_fftPlotCh->setEnabled(true);
 
 	// Sync curve style changes
-	connect(m_fftPlotCh, &PlotChannel::penChanged, this, [=]() {
+	connect(m_fftPlotCh, &PlotChannel::penChanged, this, [this]() {
 		QColor color = m_fftPlotCh->pen().color();
 		m_fftPlotAxisHandle->handle()->setColor(color);
 		m_ch->ctrl()->setColor(color);
 	});
 
 	// Sync name changes from ChannelComponent to PlotChannel
-	connect(m_ch, &ChannelComponent::nameChanged, this, [=](const QString &name) {
+	connect(m_ch, &ChannelComponent::nameChanged, this, [this](const QString &name) {
 		m_fftPlotCh->setName(name);
 		m_ch->ctrl()->setName(name);
 	});

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponentsettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotcomponentsettings.cpp
@@ -60,7 +60,7 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 
 	QLineEdit *plotTitle = new QLineEdit(m_plotComponent->name());
 	Style::setStyle(plotTitle, style::properties::lineedit::menuLineEdit);
-	connect(plotTitle, &QLineEdit::textChanged, this, [=](QString s) {
+	connect(plotTitle, &QLineEdit::textChanged, this, [this](QString s) {
 		m_plotComponent->setName(s);
 		//	plotMenu->setTitle("PLOT - " + s);
 	});
@@ -91,10 +91,10 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	MenuOnOffSwitch *m_autoscaleBtn = new MenuOnOffSwitch(tr("AUTOSCALE"), plotMenu, false);
 	m_autoscaler = new PlotAutoscaler(this);
 
-	connect(m_autoscaler, &PlotAutoscaler::newMin, this, [=](double v) { m_yCtrl->setMin(v - 10); });
+	connect(m_autoscaler, &PlotAutoscaler::newMin, this, [this](double v) { m_yCtrl->setMin(v - 10); });
 	// connect(m_autoscaler, &PlotAutoscaler::newMax, m_yCtrl, &MenuPlotAxisRangeControl::setMax);
 
-	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_yCtrl->setEnabled(!b);
 		m_autoscaleEnabled = b;
 		toggleAutoScale();
@@ -105,7 +105,7 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_plotComponent->fftPlot()->yAxis()->getFormatter()->setTwoDecimalMode(false);
 
 	// Sync waterfall intensity (color axis) to the FFT Y-axis range
-	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [=](double minVal, double maxVal) {
+	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [this](double minVal, double maxVal) {
 		m_plotComponent->waterfallPlot()->setIntensityRange(minVal, maxVal);
 	});
 
@@ -124,7 +124,7 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_windowCb->combo()->addItem("No Window", gr::fft::window::WIN_RECTANGULAR);
 	m_windowCb->combo()->setCurrentIndex(0);
 
-	connect(m_windowCb->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(m_windowCb->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
 		for(auto c : std::as_const(m_channels)) {
 			if(dynamic_cast<FFTChannel *>(c)) {
 				FFTChannel *fc = dynamic_cast<FFTChannel *>(c);
@@ -142,15 +142,15 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_waterfallRows->setScaleRange(1, 1);
 	m_waterfallRows->setIncrementMode(MenuSpinbox::IS_FIXED);
 	connect(m_waterfallRows, &MenuSpinbox::valueChanged, this,
-		[=](double val) { m_plotComponent->waterfallPlot()->setNumRows((int)val); });
+		[this](double val) { m_plotComponent->waterfallPlot()->setNumRows((int)val); });
 	m_waterfallRows->setValue(200);
 
 	MenuOnOffSwitch *antialiasingSwitch = new MenuOnOffSwitch("Antialiasing", waterfallSection, false);
 	antialiasingSwitch->onOffswitch()->setChecked(true);
 	connect(antialiasingSwitch->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool on) { m_plotComponent->waterfallPlot()->setAntialiasing(on); });
+		[this](bool on) { m_plotComponent->waterfallPlot()->setAntialiasing(on); });
 
-	connect(waterfallSwitch, &QAbstractButton::toggled, this, [=](bool on) {
+	connect(waterfallSwitch, &QAbstractButton::toggled, this, [this](bool on) {
 		m_plotComponent->waterfallPlot()->setWaterfallEnabled(on);
 		m_plotComponent->waterfallDockWrapper()->setActivated(on);
 		if(!on)
@@ -162,11 +162,11 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 
 	m_deletePlot = new QPushButton("Delete Plot");
 	StyleHelper::BasicButton(m_deletePlot);
-	connect(m_deletePlot, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_deletePlot, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestDeletePlot(); });
 
 	QPushButton *exportBtn = new QPushButton("Export plot to CSV");
 	StyleHelper::BasicButton(exportBtn);
-	connect(exportBtn, &QPushButton::clicked, this, [=]() {
+	connect(exportBtn, &QPushButton::clicked, this, [this]() {
 		QString csvData = m_plotComponent->fftPlot()->generateCsvData();
 		FileManagerHelper::saveDataToFile(this, csvData, tr("Export Plot Data"));
 	});
@@ -205,14 +205,14 @@ FFTPlotComponentSettings::FFTPlotComponentSettings(FFTPlotComponent *plt, QWidge
 	m_deletePlotHover->setMaximumSize(16, 16);
 	m_deletePlotHover->setIcon(QIcon(":/gui/icons/orange_close.svg"));
 
-	connect(m_deletePlotHover, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_deletePlotHover, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestDeletePlot(); });
 
 	m_settingsPlotHover = new QPushButton("", nullptr);
 	m_settingsPlotHover->setMaximumSize(16, 16);
 	m_settingsPlotHover->setIcon(
 		QIcon(":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) + "/icons/preferences.svg"));
 
-	connect(m_settingsPlotHover, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestSettings(); });
+	connect(m_settingsPlotHover, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestSettings(); });
 
 	m_plotComponent->fftPlot()->plotButtonManager()->add(m_deletePlotHover);
 	m_plotComponent->fftPlot()->plotButtonManager()->add(m_settingsPlotHover);
@@ -244,7 +244,7 @@ void FFTPlotComponentSettings::addChannel(ChannelComponent *c)
 	if(dynamic_cast<FFTChannel *>(c)) {
 		FFTChannel *fc = dynamic_cast<FFTChannel *>(c);
 		connections[c] << connect(m_yPwrOffset, &MenuSpinbox::valueChanged, c,
-					  [=](double val) { fc->setPowerOffset(val); });
+					  [fc](double val) { fc->setPowerOffset(val); });
 		fc->setPowerOffset(m_yPwrOffset->value());
 		fc->setWindow(m_windowCb->combo()->currentData().toInt());
 	}

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotmanager.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotmanager.cpp
@@ -51,7 +51,7 @@ uint32_t FFTPlotManager::addPlot(QString name)
 
 	plt->setXInterval(m_xInterval);
 
-	connect(plt, &FFTPlotComponent::requestDeletePlot, this, [=]() {
+	connect(plt, &FFTPlotComponent::requestDeletePlot, this, [this, plt]() {
 		Q_EMIT plotRemoved(plt->uuid());
 		removePlot(plt->uuid());
 

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotmanagersettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotmanagersettings.cpp
@@ -62,19 +62,19 @@ QWidget *FFTPlotManagerSettings::createMenu(QWidget *parent)
 	m_addPlotBtn = new QPushButton("Add Plot", this);
 	StyleHelper::BasicButton(m_addPlotBtn, "AddPlotButton");
 
-	connect(m_addPlotBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_addPlotBtn, &QPushButton::clicked, this, [this]() {
 		uint32_t idx =
 			m_plotManager->addPlot("Frequency Plot " + QString::number(m_plotManager->plots().count()));
 		FFTPlotComponent *plt = m_plotManager->plot(idx);
 		addPlot(plt);
 	});
 
-	connect(m_plotManager, &PlotManager::plotRemoved, this, [=](uint32_t uuid) {
+	connect(m_plotManager, &PlotManager::plotRemoved, this, [this](uint32_t uuid) {
 		FFTPlotComponent *plt = m_plotManager->plot(uuid);
 		removePlot(plt);
 	});
 
-	connect(this, &FFTPlotManagerSettings::samplingInfoChanged, this, [=](SamplingInfo s) {
+	connect(this, &FFTPlotManagerSettings::samplingInfoChanged, this, [this](SamplingInfo s) {
 		for(auto p : m_plotManager->plots()) {
 			auto tpc = dynamic_cast<FFTPlotComponent *>(p);
 			if(tpc) {
@@ -98,7 +98,7 @@ QWidget *FFTPlotManagerSettings::createMenu(QWidget *parent)
 	m_menu->add(m_plotStack);
 
 	connect(m_plotCb->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { m_plotStack->show(QString::number(m_plotCb->combo()->currentData().toInt())); });
+		[this](int idx) { m_plotStack->show(QString::number(m_plotCb->combo()->currentData().toInt())); });
 
 	m_menu->add(m_addPlotBtn, "add", gui::MenuWidget::MA_BOTTOMLAST);
 
@@ -112,7 +112,7 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_bufferSizeSpin = new MenuSpinbox("FFT Size", 16, "samples", 0, 4000000, true, false, section);
 	m_bufferSizeSpin->setScaleRange(1, 1);
-	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setBufferSize((uint32_t)val); });
+	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setBufferSize((uint32_t)val); });
 
 	QWidget *xMinMax = new QWidget(section);
 	QHBoxLayout *xMinMaxLayout = new QHBoxLayout(xMinMax);
@@ -127,9 +127,9 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 	m_xmax->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
 
 	connect(m_xmin, &MenuSpinbox::valueChanged, this,
-		[=](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
+		[this](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
 	connect(m_xmax, &MenuSpinbox::valueChanged, this,
-		[=](double max) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
+		[this](double max) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
 
 	xMinMaxLayout->addWidget(m_xmin);
 	xMinMaxLayout->addWidget(m_xmax);
@@ -142,7 +142,7 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 	xcb->addItem("Samples", XMODE_SAMPLES);
 	xcb->addItem("Frequency - override samplerate", XMODE_OVERRIDE);
 
-	connect(xcb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(xcb, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
 		for(PlotComponent *plt : m_plotManager->plots()) {
 			auto p = dynamic_cast<FFTPlotComponent *>(plt);
 			updateXMode(idx, p->fftPlot()->xAxis(), p->waterfallPlot()->xAxis());
@@ -158,7 +158,7 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_sampleRateSpin->setValue(10);
 	m_sampleRateSpin->setEnabled(false);
-	connect(m_sampleRateSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setSampleRate(val); });
+	connect(m_sampleRateSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setSampleRate(val); });
 
 	m_freqOffsetSpin = new MenuSpinbox("Frequency Offset", 1, "Hz", 0, DBL_MAX, true, false, section);
 	InfoIconWidget::addHoveringInfoToWidget(m_freqOffsetSpin->label(),
@@ -167,8 +167,8 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_freqOffsetSpin->setValue(0);
 	m_freqOffsetSpin->setEnabled(false);
-	connect(m_freqOffsetSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setFreqOffset(val); });
-	connect(this, &FFTPlotManagerSettings::samplingInfoChanged, this, [=](SamplingInfo p) {
+	connect(m_freqOffsetSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setFreqOffset(val); });
+	connect(this, &FFTPlotManagerSettings::samplingInfoChanged, this, [this](SamplingInfo p) {
 		m_freqOffsetSpin->setValue(m_samplingInfo.freqOffset);
 		m_sampleRateSpin->setValue(m_samplingInfo.sampleRate);
 		m_bufferSizeSpin->setValue(m_samplingInfo.bufferSize);
@@ -306,7 +306,7 @@ void FFTPlotManagerSettings::addPlot(FFTPlotComponent *p)
 {
 	QWidget *plotMenu = p->plotMenu();
 
-	connect(p, &FFTPlotComponent::nameChanged, this, [=](QString newName) {
+	connect(p, &FFTPlotComponent::nameChanged, this, [this, p](QString newName) {
 		int idx = m_plotCb->combo()->findData(p->uuid());
 		m_plotCb->combo()->setItemText(idx, newName);
 	});
@@ -315,7 +315,7 @@ void FFTPlotManagerSettings::addPlot(FFTPlotComponent *p)
 	// m_menu->add(plotMenu, p->name() + QString::number(p->uuid()), gui::MenuWidget::MA_TOPLAST);
 	setPlotComboVisible();
 
-	connect(p->plotMenu(), &FFTPlotComponentSettings::requestSettings, this, [=]() {
+	connect(p->plotMenu(), &FFTPlotComponentSettings::requestSettings, this, [this, p]() {
 		int idx = m_plotCb->combo()->findData(p->uuid());
 		m_plotCb->combo()->setCurrentIndex(idx);
 		m_menu->scrollTo(m_plotCb);
@@ -324,7 +324,7 @@ void FFTPlotManagerSettings::addPlot(FFTPlotComponent *p)
 
 	// Connect complex mode changes to the plot settings
 	connect(this, &FFTPlotManagerSettings::samplingInfoChanged, p->plotMenu(),
-		[=](SamplingInfo info) { p->plotMenu()->setComplexMode(info.complexMode); });
+		[p](SamplingInfo info) { p->plotMenu()->setComplexMode(info.complexMode); });
 
 	// Set initial complex mode state
 	p->plotMenu()->setComplexMode(m_samplingInfo.complexMode);

--- a/packages/generic-plugins/plugins/adc/src/freq/fftplotmanagersettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/fftplotmanagersettings.cpp
@@ -112,7 +112,8 @@ QWidget *FFTPlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_bufferSizeSpin = new MenuSpinbox("FFT Size", 16, "samples", 0, 4000000, true, false, section);
 	m_bufferSizeSpin->setScaleRange(1, 1);
-	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setBufferSize((uint32_t)val); });
+	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this,
+		[this](double val) { setBufferSize((uint32_t)val); });
 
 	QWidget *xMinMax = new QWidget(section);
 	QHBoxLayout *xMinMaxLayout = new QHBoxLayout(xMinMax);

--- a/packages/generic-plugins/plugins/adc/src/freq/grfftchannelcomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/grfftchannelcomponent.cpp
@@ -65,13 +65,13 @@ GRFFTChannelComponent::GRFFTChannelComponent(GRIIOFloatChannelNode *node_I, GRII
 	m_grtch = new GRFFTComplexChannelSigpath(grtsc->name(), this, m_node->top()->src(),
 						 static_cast<GRIIOComplexChannelSrc *>(m_src), this);
 	connect(this, &GRFFTChannelComponent::powerOffsetChanged, this,
-		[=](double v) { dynamic_cast<GRFFTComplexChannelSigpath *>(m_grtch)->setPowerOffset(v); });
+		[this](double v) { dynamic_cast<GRFFTComplexChannelSigpath *>(m_grtch)->setPowerOffset(v); });
 
 	connect(this, &GRFFTChannelComponent::windowChanged, this,
-		[=](int w) { dynamic_cast<GRFFTComplexChannelSigpath *>(m_grtch)->setWindow(w); });
+		[this](int w) { dynamic_cast<GRFFTComplexChannelSigpath *>(m_grtch)->setWindow(w); });
 
 	connect(m_fftPlotComponentChannel->channelComponent(), &ChannelComponent::updatedSamplingInfo, this,
-		[=](SamplingInfo p) {
+		[this](SamplingInfo p) {
 			dynamic_cast<GRFFTComplexChannelSigpath *>(m_grtch)->setSampleRate(p.sampleRate);
 		});
 
@@ -96,10 +96,10 @@ GRFFTChannelComponent::GRFFTChannelComponent(GRIIOFloatChannelNode *node, FFTPlo
 	m_complex = false;
 
 	connect(this, &GRFFTChannelComponent::powerOffsetChanged, this,
-		[=](double v) { dynamic_cast<GRFFTChannelSigpath *>(m_grtch)->setPowerOffset(v); });
+		[this](double v) { dynamic_cast<GRFFTChannelSigpath *>(m_grtch)->setPowerOffset(v); });
 
 	connect(this, &GRFFTChannelComponent::windowChanged, this,
-		[=](int w) { dynamic_cast<GRFFTChannelSigpath *>(m_grtch)->setWindow(w); });
+		[this](int w) { dynamic_cast<GRFFTChannelSigpath *>(m_grtch)->setWindow(w); });
 	_init();
 }
 
@@ -154,7 +154,7 @@ QWidget *GRFFTChannelComponent::createYAxisMenu(QWidget *parent)
 	m_yCtrl = new MenuPlotAxisRangeControl(m_fftPlotComponentChannel->m_fftPlotYAxis, m_yaxisMenu);
 
 	connect(m_yaxisMenu->collapseSection()->header(), &QAbstractButton::toggled, this,
-		[=](bool b) { m_fftPlotComponentChannel->lockYAxis(!b); });
+		[this](bool b) { m_fftPlotComponentChannel->lockYAxis(!b); });
 
 	m_yaxisMenu->contentLayout()->addWidget(m_yCtrl);
 
@@ -171,7 +171,7 @@ QWidget *GRFFTChannelComponent::createCurveMenu(QWidget *parent)
 	section->contentLayout()->addWidget(m_curvemenu);
 
 	auto *controller = m_fftPlotComponentChannel->minMaxHoldController();
-	connect(controller, &MinMaxHoldController::enabledChanged, this, [=](bool enabled) {
+	connect(controller, &MinMaxHoldController::enabledChanged, this, [this, controller](bool enabled) {
 		if(enabled) {
 			if(controller->minChannel()) {
 				m_curvemenu->addChannels(controller->minChannel());
@@ -260,7 +260,7 @@ QWidget *GRFFTChannelComponent::createAveragingMenu(QWidget *parent)
 	m_avgSection = c.section;
 	m_avgSpin = c.sizeSpin;
 
-	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [this, c](bool b) {
 		auto ch = dynamic_cast<FFTChannel *>(m_grtch);
 		if(ch) {
 			int size = b ? c.sizeSpin->value() : 1;
@@ -268,7 +268,7 @@ QWidget *GRFFTChannelComponent::createAveragingMenu(QWidget *parent)
 		}
 	});
 
-	connect(c.sizeSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, [=](int value) {
+	connect(c.sizeSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, [this, c](int value) {
 		auto ch = dynamic_cast<FFTChannel *>(m_grtch);
 		if(ch) {
 			ch->setAveragingSize(value);
@@ -305,42 +305,46 @@ QWidget *GRFFTChannelComponent::createMarkerMenu(QWidget *parent)
 
 	MenuOnOffSwitch *fixedMarkerEditBtn = c.fixedEditSwitch;
 	connect(fixedMarkerEditBtn->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(b); });
+		[this](bool b) { m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(b); });
 
-	connect(c.countSpin, &MenuSpinbox::valueChanged, this, [=](double cnt) {
+	connect(c.countSpin, &MenuSpinbox::valueChanged, this, [this](double cnt) {
 		m_fftPlotComponentChannel->markerController()->setNrOfMarkers(cnt);
 		m_fftPlotComponentChannel->markerController()->computeMarkers();
 	});
 
-	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
-		if(b) {
+	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this,
+		[this, c, fixedMarkerEditBtn](bool b) {
+			if(b) {
+				auto markerType = static_cast<PlotMarkerController::MarkerTypes>(
+					c.typeCombo->combo()->currentData().toInt());
+				m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(
+					markerType == PlotMarkerController::MC_FIXED &&
+					fixedMarkerEditBtn->onOffswitch()->isChecked());
+				m_fftPlotComponentChannel->markerController()->setMarkerType(markerType);
+			} else {
+				m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(false);
+				m_fftPlotComponentChannel->markerController()->setMarkerType(
+					PlotMarkerController::MC_NONE);
+			}
+		});
+
+	connect(c.typeCombo->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this,
+		[this, c, fixedMarkerEditBtn](int idx) {
 			auto markerType = static_cast<PlotMarkerController::MarkerTypes>(
 				c.typeCombo->combo()->currentData().toInt());
+			if(markerType == PlotMarkerController::MC_SINGLETONE) {
+				c.countSpin->setMinValue(2);
+				if(c.countSpin->value() < 2)
+					c.countSpin->setValue(2);
+			} else {
+				c.countSpin->setMinValue(0);
+			}
 			m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(
 				markerType == PlotMarkerController::MC_FIXED &&
 				fixedMarkerEditBtn->onOffswitch()->isChecked());
 			m_fftPlotComponentChannel->markerController()->setMarkerType(markerType);
-		} else {
-			m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(false);
-			m_fftPlotComponentChannel->markerController()->setMarkerType(PlotMarkerController::MC_NONE);
-		}
-	});
-
-	connect(c.typeCombo->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
-		auto markerType =
-			static_cast<PlotMarkerController::MarkerTypes>(c.typeCombo->combo()->currentData().toInt());
-		if(markerType == PlotMarkerController::MC_SINGLETONE) {
-			c.countSpin->setMinValue(2);
-			if(c.countSpin->value() < 2)
-				c.countSpin->setValue(2);
-		} else {
-			c.countSpin->setMinValue(0);
-		}
-		m_fftPlotComponentChannel->markerController()->setFixedHandleVisible(
-			markerType == PlotMarkerController::MC_FIXED && fixedMarkerEditBtn->onOffswitch()->isChecked());
-		m_fftPlotComponentChannel->markerController()->setMarkerType(markerType);
-		fixedMarkerEditBtn->setVisible(markerType == PlotMarkerController::MC_FIXED);
-	});
+			fixedMarkerEditBtn->setVisible(markerType == PlotMarkerController::MC_FIXED);
+		});
 
 	return c.section;
 }

--- a/packages/generic-plugins/plugins/adc/src/freq/grfftdevicecomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/freq/grfftdevicecomponent.cpp
@@ -79,21 +79,21 @@ QWidget *GRFFTDeviceComponent::createMarkerMenu(QWidget *parent)
 	c.fixedEditSwitch->hide();
 	attachOverrideWarning(c.section);
 
-	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyMarkerEnabled(b); });
+	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [this, c](bool b) {
+		forEachChannel<GRFFTChannelComponent>([b](GRFFTChannelComponent *ch) { ch->applyMarkerEnabled(b); });
 		if(b) {
 			int t = c.typeCombo->combo()->currentData().toInt();
 			forEachChannel<GRFFTChannelComponent>(
-				[=](GRFFTChannelComponent *ch) { ch->applyMarkerType(t); });
+				[t](GRFFTChannelComponent *ch) { ch->applyMarkerType(t); });
 		}
 	});
-	connect(c.typeCombo->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int) {
+	connect(c.typeCombo->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [this, c](int) {
 		int t = c.typeCombo->combo()->currentData().toInt();
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyMarkerType(t); });
+		forEachChannel<GRFFTChannelComponent>([t](GRFFTChannelComponent *ch) { ch->applyMarkerType(t); });
 	});
-	connect(c.countSpin, &MenuSpinbox::valueChanged, this, [=](double cnt) {
+	connect(c.countSpin, &MenuSpinbox::valueChanged, this, [this](double cnt) {
 		int n = static_cast<int>(cnt);
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyMarkerCount(n); });
+		forEachChannel<GRFFTChannelComponent>([n](GRFFTChannelComponent *ch) { ch->applyMarkerCount(n); });
 	});
 
 	return c.section;
@@ -104,17 +104,17 @@ QWidget *GRFFTDeviceComponent::createAveragingMenu(QWidget *parent)
 	AveragingMenuControls c = buildAveragingMenu(parent);
 	attachOverrideWarning(c.section);
 
-	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyAveragingEnabled(b); });
+	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [this, c](bool b) {
+		forEachChannel<GRFFTChannelComponent>([b](GRFFTChannelComponent *ch) { ch->applyAveragingEnabled(b); });
 		if(b) {
 			int sz = c.sizeSpin->value();
 			forEachChannel<GRFFTChannelComponent>(
-				[=](GRFFTChannelComponent *ch) { ch->applyAveragingSize(sz); });
+				[sz](GRFFTChannelComponent *ch) { ch->applyAveragingSize(sz); });
 		}
 	});
-	connect(c.sizeSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, [=](int value) {
+	connect(c.sizeSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
 		forEachChannel<GRFFTChannelComponent>(
-			[=](GRFFTChannelComponent *ch) { ch->applyAveragingSize(value); });
+			[value](GRFFTChannelComponent *ch) { ch->applyAveragingSize(value); });
 	});
 
 	return c.section;
@@ -125,21 +125,21 @@ QWidget *GRFFTDeviceComponent::createMinMaxHoldMenu(QWidget *parent)
 	MinMaxHoldMenuControls c = buildMinMaxHoldMenu(parent);
 	attachOverrideWarning(c.section);
 
-	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(c.section->collapseSection()->header(), &QAbstractButton::toggled, this, [this](bool b) {
 		forEachChannel<GRFFTChannelComponent>(
-			[=](GRFFTChannelComponent *ch) { ch->applyMinMaxHoldEnabled(b); });
+			[b](GRFFTChannelComponent *ch) { ch->applyMinMaxHoldEnabled(b); });
 	});
-	connect(c.minSwitch, &QCheckBox::toggled, this, [=](bool b) {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyMinHoldEnabled(b); });
+	connect(c.minSwitch, &QCheckBox::toggled, this, [this](bool b) {
+		forEachChannel<GRFFTChannelComponent>([b](GRFFTChannelComponent *ch) { ch->applyMinHoldEnabled(b); });
 	});
-	connect(c.maxSwitch, &QCheckBox::toggled, this, [=](bool b) {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->applyMaxHoldEnabled(b); });
+	connect(c.maxSwitch, &QCheckBox::toggled, this, [this](bool b) {
+		forEachChannel<GRFFTChannelComponent>([b](GRFFTChannelComponent *ch) { ch->applyMaxHoldEnabled(b); });
 	});
-	connect(c.minReset, &QPushButton::clicked, this, [=]() {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->resetMinHold(); });
+	connect(c.minReset, &QPushButton::clicked, this, [this]() {
+		forEachChannel<GRFFTChannelComponent>([](GRFFTChannelComponent *ch) { ch->resetMinHold(); });
 	});
-	connect(c.maxReset, &QPushButton::clicked, this, [=]() {
-		forEachChannel<GRFFTChannelComponent>([=](GRFFTChannelComponent *ch) { ch->resetMaxHold(); });
+	connect(c.maxReset, &QPushButton::clicked, this, [this]() {
+		forEachChannel<GRFFTChannelComponent>([](GRFFTChannelComponent *ch) { ch->resetMaxHold(); });
 	});
 
 	return c.section;

--- a/packages/generic-plugins/plugins/adc/src/genalyzersettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/genalyzersettings.cpp
@@ -157,7 +157,7 @@ void GenalyzerSettings::setupUI()
 	mainLayout->addWidget(section);
 
 	// Connect mode change to show/hide appropriate controls
-	connect(m_modeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int index) {
+	connect(m_modeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
 		bool isFixedTone = (m_modeCombo->currentData().toInt() == static_cast<int>(GenalyzerMode::FIXED_TONE));
 		m_fixedToneContainer->setVisible(isFixedTone);
 		m_autoModeContainer->setVisible(!isFixedTone);

--- a/packages/generic-plugins/plugins/adc/src/grdevicecomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/grdevicecomponent.cpp
@@ -203,7 +203,7 @@ void GRDeviceComponent::createMenuControlButton(QWidget *parent)
 void GRDeviceComponent::setupDeviceOnOffSwitch()
 {
 	m_ctrl->enableOnOffSwitch(true);
-	connect(m_ctrl->onOffSwitch(), &SmallOnOffSwitch::toggled, this, [=](bool en) {
+	connect(m_ctrl->onOffSwitch(), &SmallOnOffSwitch::toggled, this, [this](bool en) {
 		for(auto ch : m_channels) {
 			ch->ctrl()->checkBox()->setChecked(en);
 		}

--- a/packages/generic-plugins/plugins/adc/src/importchannelcomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/importchannelcomponent.cpp
@@ -69,7 +69,7 @@ QWidget *ImportChannelComponent::createMenu(QWidget *parent)
 	QWidget *curvemenu = createCurveMenu(m_menu);
 	// QWidget *measuremenu = m_measureMgr->createMeasurementMenu(w);
 	m_menu->header()->title()->setEnabled(true);
-	connect(m_menu->header()->title(), &QLineEdit::textChanged, this, [=](QString s) { m_ctrl->setName(s); });
+	connect(m_menu->header()->title(), &QLineEdit::textChanged, this, [this](QString s) { m_ctrl->setName(s); });
 
 	QPushButton *m_forget = new QPushButton("Remove reference channel");
 	StyleHelper::BasicButton(m_forget);
@@ -96,11 +96,11 @@ QWidget *ImportChannelComponent::createYAxisMenu(QWidget *parent)
 	connect(m_autoscaler, &PlotAutoscaler::newMin, m_yCtrl, &MenuPlotAxisRangeControl::setMin);
 	connect(m_autoscaler, &PlotAutoscaler::newMax, m_yCtrl, &MenuPlotAxisRangeControl::setMax);
 
-	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [=](double min, double max) {
+	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [this](double min, double max) {
 		m_timePlotChannelComponent->m_xyPlotYAxis->setInterval(m_yCtrl->min(), m_yCtrl->max());
 	});
 
-	connect(section->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(section->collapseSection()->header(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_yLock = b;
 		m_timePlotChannelComponent->lockYAxis(!b);
 	});

--- a/packages/generic-plugins/plugins/adc/src/measurementcontroller.cpp
+++ b/packages/generic-plugins/plugins/adc/src/measurementcontroller.cpp
@@ -43,7 +43,7 @@ MeasurementController::MeasurementController(QPen pen, MeasureModel *msr, QObjec
 	, m_measure(msr)
 	, m_pen(pen)
 {
-	connect(m_measure, &MeasureModel::newMeasurementsAvailable, this, [=]() {
+	connect(m_measure, &MeasureModel::newMeasurementsAvailable, this, [this]() {
 		for(auto lbl : std::as_const(m_measureLabels)) {
 			lbl->setValue(m_measure->measurement(lbl->name())->value());
 		}
@@ -281,7 +281,7 @@ QWidget *TimeMeasureManager::createMeasurementMenuSection(QString category, QWid
 		if(meas.type.toUpper() == category.toUpper()) {
 			measureSelector->addMeasurement(meas.name, meas.icon);
 			connect(measureSelector->measurement(meas.name)->measureCheckbox(), &QCheckBox::toggled,
-				[=](bool b) {
+				[m_measureController, meas](bool b) {
 					if(b)
 						m_measureController->enableMeasurement(meas.name);
 					else
@@ -289,7 +289,7 @@ QWidget *TimeMeasureManager::createMeasurementMenuSection(QString category, QWid
 				});
 
 			connect(measureSelector->measurement(meas.name)->statsCheckbox(), &QCheckBox::toggled,
-				[=](bool b) {
+				[m_measureController, meas](bool b) {
 					if(b)
 						m_measureController->enableStats(meas.name);
 					else

--- a/packages/generic-plugins/plugins/adc/src/time/grtimechannelcomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/grtimechannelcomponent.cpp
@@ -123,16 +123,16 @@ QWidget *GRTimeChannelComponent::createYAxisMenu(QWidget *parent)
 	connect(m_autoscaler, &PlotAutoscaler::newMin, m_yCtrl, &MenuPlotAxisRangeControl::setMin);
 	connect(m_autoscaler, &PlotAutoscaler::newMax, m_yCtrl, &MenuPlotAxisRangeControl::setMax);
 
-	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [=](double min, double max) {
+	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [this](double min, double max) {
 		m_timePlotComponentChannel->m_xyPlotYAxis->setInterval(m_yCtrl->min(), m_yCtrl->max());
 	});
 
-	connect(m_yaxisMenu->collapseSection()->header(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_yaxisMenu->collapseSection()->header(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_yLock = b;
 		m_timePlotComponentChannel->lockYAxis(!b);
 	});
 
-	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_yCtrl->setEnabled(!b);
 		m_autoscaleEnabled = b;
 		toggleAutoScale();
@@ -146,14 +146,14 @@ QWidget *GRTimeChannelComponent::createYAxisMenu(QWidget *parent)
 		m_yaxisMenu->contentLayout()->addWidget(m_scaleWidget);
 
 	connect(m_scaleSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
-		[=](double value) { setYModeHelper(YMODE_SCALE_OVERRIDE); });
+		[this](double value) { setYModeHelper(YMODE_SCALE_OVERRIDE); });
 
-	connect(cb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(cb, qOverload<int>(&QComboBox::currentIndexChanged), this, [this, cb](int idx) {
 		auto mode = cb->itemData(idx).toInt();
 		setYMode(static_cast<YMode>(mode));
 	});
 
-	connect(this, &GRTimeChannelComponent::yModeChanged, this, [=]() {
+	connect(this, &GRTimeChannelComponent::yModeChanged, this, [this, cb]() {
 		int idx = cb->currentIndex();
 		int itemcount = cb->count();
 		for(int i = 0; i < itemcount; i++) {
@@ -184,7 +184,7 @@ QPushButton *GRTimeChannelComponent::createSnapshotButton(QWidget *parent)
 	QPushButton *snapBtn = new QPushButton("Snapshot", parent);
 	StyleHelper::BasicButton(snapBtn);
 
-	connect(snapBtn, &QPushButton::clicked, this, [=]() {
+	connect(snapBtn, &QPushButton::clicked, this, [this]() {
 		std::vector<float> x, y;
 		auto data = m_timePlotComponentChannel->m_timePlotCh->curve()->data();
 		for(int i = 0; i < data->size(); i++) {

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotcomponent.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotcomponent.cpp
@@ -99,7 +99,8 @@ TimePlotComponent::TimePlotComponent(QString name, uint32_t uuid, QWidget *paren
 	m_plotMenu = new TimePlotComponentSettings(this, parent);
 	addComponent(m_plotMenu);
 
-	connect(m_plotMenu, &TimePlotComponentSettings::requestDeletePlot, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_plotMenu, &TimePlotComponentSettings::requestDeletePlot, this,
+		[this]() { Q_EMIT requestDeletePlot(); });
 	m_cursor = new CursorController(m_timePlot, this);
 	int xCursorPos = Preferences::get("adc_plot_xcursor_position").toInt();
 	int yCursorPos = Preferences::get("adc_plot_ycursor_position").toInt();
@@ -146,16 +147,18 @@ void TimePlotComponent::setXYXChannel(ChannelComponent *c)
 		onXyXNewData(c->chData()->xData(), c->chData()->yData(), c->chData()->size(), true);
 		xyDataConn = connect(c->chData(), &ChannelData::newData, this, &TimePlotComponent::onXyXNewData);
 		cPlotChCmpt->m_xyPlotCh->setEnabled(m_showXSourceOnXy);
-		xyAxisMinConn = connect(cPlotChCmpt->m_timePlotYAxis, &PlotAxis::minChanged, this, [=](double val) {
-			if(!cPlotChCmpt->m_singleYMode) {
-				m_xyPlot->xAxis()->setMin(val);
-			}
-		});
-		xyAxisMaxConn = connect(cPlotChCmpt->m_timePlotYAxis, &PlotAxis::maxChanged, this, [=](double val) {
-			if(!cPlotChCmpt->m_singleYMode) {
-				m_xyPlot->xAxis()->setMax(val);
-			}
-		});
+		xyAxisMinConn = connect(cPlotChCmpt->m_timePlotYAxis, &PlotAxis::minChanged, this,
+					[this, cPlotChCmpt](double val) {
+						if(!cPlotChCmpt->m_singleYMode) {
+							m_xyPlot->xAxis()->setMin(val);
+						}
+					});
+		xyAxisMaxConn = connect(cPlotChCmpt->m_timePlotYAxis, &PlotAxis::maxChanged, this,
+					[this, cPlotChCmpt](double val) {
+						if(!cPlotChCmpt->m_singleYMode) {
+							m_xyPlot->xAxis()->setMax(val);
+						}
+					});
 	}
 }
 

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentchannel.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentchannel.cpp
@@ -87,7 +87,7 @@ void adc::TimePlotComponentChannel ::initPlotComponent(PlotComponent *pc)
 	m_timePlotAxisHandle->handle()->setBarVisibility(BarVisibility::ON_HOVER);
 	m_timePlotAxisHandle->handle()->setColor(m_ch->pen().color());
 
-	connect(m_timePlotAxisHandle, &PlotAxisHandle::scalePosChanged, this, [=](double pos) {
+	connect(m_timePlotAxisHandle, &PlotAxisHandle::scalePosChanged, this, [this](double pos) {
 		double min = m_timePlotYAxis->min() - pos;
 		double max = m_timePlotYAxis->max() - pos;
 		m_timePlotYAxis->setInterval(min, max);
@@ -106,9 +106,9 @@ void adc::TimePlotComponentChannel ::initPlotComponent(PlotComponent *pc)
 
 	// Sync curve style from time plot channel to XY plot channel
 	connect(m_timePlotCh, &PlotChannel::thicknessChanged, this,
-		[=]() { m_xyPlotCh->setThickness(m_timePlotCh->thickness()); });
-	connect(m_timePlotCh, &PlotChannel::styleChanged, this, [=]() { m_xyPlotCh->setStyle(m_timePlotCh->style()); });
-	connect(m_timePlotCh, &PlotChannel::penChanged, this, [=]() {
+		[this]() { m_xyPlotCh->setThickness(m_timePlotCh->thickness()); });
+	connect(m_timePlotCh, &PlotChannel::styleChanged, this, [this]() { m_xyPlotCh->setStyle(m_timePlotCh->style()); });
+	connect(m_timePlotCh, &PlotChannel::penChanged, this, [this]() {
 		QColor color = m_timePlotCh->pen().color();
 		m_xyPlotCh->setColor(color);
 		m_timePlotAxisHandle->handle()->setColor(color);
@@ -116,7 +116,7 @@ void adc::TimePlotComponentChannel ::initPlotComponent(PlotComponent *pc)
 	});
 
 	// Sync name changes from ChannelComponent to PlotChannels
-	connect(m_ch, &ChannelComponent::nameChanged, this, [=](const QString &name) {
+	connect(m_ch, &ChannelComponent::nameChanged, this, [this](const QString &name) {
 		m_timePlotCh->setName(name);
 		m_xyPlotCh->setName(name);
 		m_ch->ctrl()->setName(name);

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentchannel.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentchannel.cpp
@@ -107,7 +107,8 @@ void adc::TimePlotComponentChannel ::initPlotComponent(PlotComponent *pc)
 	// Sync curve style from time plot channel to XY plot channel
 	connect(m_timePlotCh, &PlotChannel::thicknessChanged, this,
 		[this]() { m_xyPlotCh->setThickness(m_timePlotCh->thickness()); });
-	connect(m_timePlotCh, &PlotChannel::styleChanged, this, [this]() { m_xyPlotCh->setStyle(m_timePlotCh->style()); });
+	connect(m_timePlotCh, &PlotChannel::styleChanged, this,
+		[this]() { m_xyPlotCh->setStyle(m_timePlotCh->style()); });
 	connect(m_timePlotCh, &PlotChannel::penChanged, this, [this]() {
 		QColor color = m_timePlotCh->pen().color();
 		m_xyPlotCh->setColor(color);

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentsettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotcomponentsettings.cpp
@@ -56,7 +56,7 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 
 	QLineEdit *plotTitle = new QLineEdit(m_plotComponent->name());
 	Style::setStyle(plotTitle, style::properties::lineedit::menuLineEdit);
-	connect(plotTitle, &QLineEdit::textChanged, this, [=](QString s) {
+	connect(plotTitle, &QLineEdit::textChanged, this, [this](QString s) {
 		m_plotComponent->setName(s);
 		//	plotMenu->setTitle("PLOT - " + s);
 	});
@@ -77,7 +77,7 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 	connect(m_autoscaler, &PlotAutoscaler::newMin, m_yCtrl, &MenuPlotAxisRangeControl::setMin);
 	connect(m_autoscaler, &PlotAutoscaler::newMax, m_yCtrl, &MenuPlotAxisRangeControl::setMax);
 
-	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [=](double min, double max) {
+	connect(m_yCtrl, &MenuPlotAxisRangeControl::intervalChanged, this, [this](double min, double max) {
 		bool singleYMode = false;
 		if(m_plotComponent->XYXChannel()) {
 			singleYMode = dynamic_cast<TimePlotComponentChannel *>(
@@ -91,7 +91,7 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 		m_plotComponent->xyPlot()->yAxis()->setInterval(m_yCtrl->min(), m_yCtrl->max());
 	});
 
-	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_autoscaleBtn->onOffswitch(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_yCtrl->setEnabled(!b);
 		m_autoscaleEnabled = b;
 		toggleAutoScale();
@@ -107,7 +107,7 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 	m_xAxisSrc = new MenuCombo("XY - X Axis source");
 	InfoIconWidget::addHoveringInfoToWidget(
 		m_xAxisSrc->label(), "Selects which channel provides the X-axis values for the XY plot", m_xAxisSrc);
-	connect(m_xAxisSrc->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(m_xAxisSrc->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
 		QComboBox *cb = m_xAxisSrc->combo();
 		ChannelComponent *c = static_cast<ChannelComponent *>(cb->itemData(idx).value<void *>());
 		m_plotComponent->setXYXChannel(c);
@@ -116,14 +116,14 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 	m_xAxisShow = new MenuOnOffSwitch("XY - Plot X source", plotMenu, false);
 	InfoIconWidget::addHoveringInfoToWidget(
 		m_xAxisShow->label(), "Plots selected channel by itself over the current XY plot", m_xAxisShow);
-	connect(xySwitch, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(xySwitch, &QAbstractButton::toggled, this, [this](bool b) {
 		m_plotComponent->xyDockWidget()->setActivated(b);
 		m_xAxisSrc->setVisible(b);
 		m_xAxisShow->setVisible(b);
 	});
 
 	connect(m_xAxisShow->onOffswitch(), &QAbstractButton::toggled, this,
-		[=](bool b) { m_plotComponent->showXSourceOnXy(b); });
+		[this](bool b) { m_plotComponent->showXSourceOnXy(b); });
 
 	m_yModeCb = new MenuCombo("YMODE", plotMenu);
 	InfoIconWidget::addHoveringInfoToWidget(m_yModeCb->label(),
@@ -132,7 +132,7 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 	ycb->addItem("ADC Counts", YMODE_COUNT);
 	ycb->addItem("% Full Scale", YMODE_FS);
 
-	connect(ycb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(ycb, qOverload<int>(&QComboBox::currentIndexChanged), this, [this, ycb](int idx) {
 		m_ymode = static_cast<YMode>(ycb->itemData(idx).toInt());
 		for(auto c : std::as_const(m_scaleProviders)) {
 			c->setYMode(m_ymode);
@@ -142,11 +142,11 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 
 	m_deletePlot = new QPushButton("Delete Plot");
 	StyleHelper::BasicButton(m_deletePlot);
-	connect(m_deletePlot, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_deletePlot, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestDeletePlot(); });
 
 	QPushButton *exportBtn = new QPushButton("Export plot to CSV");
 	StyleHelper::BasicButton(exportBtn);
-	connect(exportBtn, &QPushButton::clicked, this, [=]() {
+	connect(exportBtn, &QPushButton::clicked, this, [this]() {
 		QString csvData = m_plotComponent->timePlot()->generateCsvData();
 		FileManagerHelper::saveDataToFile(this, csvData, tr("Export Plot Data"));
 	});
@@ -188,14 +188,14 @@ TimePlotComponentSettings::TimePlotComponentSettings(TimePlotComponent *plt, QWi
 	m_deletePlotHover->setMaximumSize(16, 16);
 	m_deletePlotHover->setIcon(QIcon(":/gui/icons/orange_close.svg"));
 
-	connect(m_deletePlotHover, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestDeletePlot(); });
+	connect(m_deletePlotHover, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestDeletePlot(); });
 
 	m_settingsPlotHover = new QPushButton("", nullptr);
 	m_settingsPlotHover->setMaximumSize(16, 16);
 	m_settingsPlotHover->setIcon(
 		QIcon(":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) + "/icons/preferences.svg"));
 
-	connect(m_settingsPlotHover, &QAbstractButton::clicked, this, [=]() { Q_EMIT requestSettings(); });
+	connect(m_settingsPlotHover, &QAbstractButton::clicked, this, [this]() { Q_EMIT requestSettings(); });
 
 	m_plotComponent->timePlot()->plotButtonManager()->add(m_deletePlotHover);
 	m_plotComponent->timePlot()->plotButtonManager()->add(m_settingsPlotHover);

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotmanager.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotmanager.cpp
@@ -59,7 +59,7 @@ uint32_t TimePlotManager::addPlot(QString name)
 
 	plt->setXInterval(m_xInterval);
 
-	connect(plt, &TimePlotComponent::requestDeletePlot, this, [=]() {
+	connect(plt, &TimePlotComponent::requestDeletePlot, this, [this, plt]() {
 		Q_EMIT plotRemoved(plt->uuid());
 		removePlot(plt->uuid());
 

--- a/packages/generic-plugins/plugins/adc/src/time/timeplotmanagersettings.cpp
+++ b/packages/generic-plugins/plugins/adc/src/time/timeplotmanagersettings.cpp
@@ -58,18 +58,18 @@ QWidget *TimePlotManagerSettings::createMenu(QWidget *parent)
 	m_addPlotBtn = new QPushButton("Add Plot", this);
 	StyleHelper::BasicButton(m_addPlotBtn, "AddPlotButton");
 
-	connect(m_addPlotBtn, &QPushButton::clicked, this, [=]() {
+	connect(m_addPlotBtn, &QPushButton::clicked, this, [this]() {
 		uint32_t idx = m_plotManager->addPlot("Time Plot " + QString::number(m_plotManager->plots().count()));
 		TimePlotComponent *plt = m_plotManager->plot(idx);
 		addPlot(plt);
 	});
 
-	connect(m_plotManager, &PlotManager::plotRemoved, this, [=](uint32_t uuid) {
+	connect(m_plotManager, &PlotManager::plotRemoved, this, [this](uint32_t uuid) {
 		TimePlotComponent *plt = m_plotManager->plot(uuid);
 		removePlot(plt);
 	});
 
-	connect(this, &TimePlotManagerSettings::samplingInfoChanged, this, [=](SamplingInfo s) {
+	connect(this, &TimePlotManagerSettings::samplingInfoChanged, this, [this](SamplingInfo s) {
 		for(auto p : m_plotManager->plots()) {
 			auto tpc = dynamic_cast<TimePlotComponent *>(p);
 			if(tpc) {
@@ -92,7 +92,7 @@ QWidget *TimePlotManagerSettings::createMenu(QWidget *parent)
 	m_menu->add(m_plotStack);
 
 	connect(m_plotCb->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { m_plotStack->show(QString::number(m_plotCb->combo()->currentData().toInt())); });
+		[this](int idx) { m_plotStack->show(QString::number(m_plotCb->combo()->currentData().toInt())); });
 
 	m_menu->add(m_addPlotBtn, "add", gui::MenuWidget::MA_BOTTOMLAST);
 
@@ -113,7 +113,7 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	m_bufferSizeSpin = new MenuSpinbox("Buffer Size", 16, "samples", 16, 4000000, true, false, bufferPlotSize);
 	m_bufferSizeSpin->setScaleRange(1, 1);
 
-	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) {
+	connect(m_bufferSizeSpin, &MenuSpinbox::valueChanged, this, [this](double val) {
 		if(m_plotSizeSpin->value() < val) {
 			m_plotSizeSpin->setValue(val);
 		}
@@ -126,13 +126,13 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	m_plotSizeSpin = new MenuSpinbox("Plot Size", 16, "samples", 0, 4000000, true, false, bufferPlotSize);
 	m_plotSizeSpin->setScaleRange(0, 1);
 
-	connect(m_plotSizeSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setPlotSize((uint32_t)val); });
+	connect(m_plotSizeSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setPlotSize((uint32_t)val); });
 
 	bufferPlotSizeLayout->addWidget(m_bufferSizeSpin);
 	bufferPlotSizeLayout->addWidget(m_plotSizeSpin);
 
 	m_syncBufferPlot = new MenuOnOffSwitch(tr("SYNC BUFFER-PLOT SIZES"), section, false);
-	connect(m_syncBufferPlot->onOffswitch(), &QAbstractButton::toggled, this, [=](bool b) {
+	connect(m_syncBufferPlot->onOffswitch(), &QAbstractButton::toggled, this, [this](bool b) {
 		m_plotSizeSpin->setEnabled(!b);
 		m_rollingModeSw->setEnabled(!b);
 		if(b) {
@@ -166,9 +166,9 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	m_xmax->setIncrementMode(gui::MenuSpinbox::IS_FIXED);
 
 	connect(m_xmin, &MenuSpinbox::valueChanged, this,
-		[=](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
+		[this](double min) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
 	connect(m_xmax, &MenuSpinbox::valueChanged, this,
-		[=](double max) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
+		[this](double max) { m_plotManager->setXInterval(m_xmin->value(), m_xmax->value()); });
 
 	xMinMaxLayout->addWidget(m_xmin);
 	xMinMaxLayout->addWidget(m_xmax);
@@ -181,7 +181,7 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 	xcb->addItem("Samples", XMODE_SAMPLES);
 	xcb->addItem("Time - override samplerate", XMODE_OVERRIDE);
 
-	connect(xcb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
+	connect(xcb, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
 		for(PlotComponent *plt : m_plotManager->plots()) {
 			auto p = dynamic_cast<TimePlotComponent *>(plt);
 			updateXMode(idx, p->timePlot()->xAxis());
@@ -197,7 +197,7 @@ QWidget *TimePlotManagerSettings::createXAxisMenu(QWidget *parent)
 
 	m_sampleRateSpin->setValue(10);
 	m_sampleRateSpin->setEnabled(false);
-	connect(m_sampleRateSpin, &MenuSpinbox::valueChanged, this, [=](double val) { setSampleRate(val); });
+	connect(m_sampleRateSpin, &MenuSpinbox::valueChanged, this, [this](double val) { setSampleRate(val); });
 
 	connect(this, &TimePlotManagerSettings::sampleRateChanged, m_sampleRateSpin, &MenuSpinbox::setValue);
 
@@ -386,7 +386,7 @@ void TimePlotManagerSettings::addPlot(TimePlotComponent *p)
 {
 	QWidget *plotMenu = p->plotMenu();
 
-	connect(p, &TimePlotComponent::nameChanged, this, [=](QString newName) {
+	connect(p, &TimePlotComponent::nameChanged, this, [this, p](QString newName) {
 		int idx = m_plotCb->combo()->findData(p->uuid());
 		m_plotCb->combo()->setItemText(idx, newName);
 	});
@@ -394,7 +394,7 @@ void TimePlotManagerSettings::addPlot(TimePlotComponent *p)
 	m_plotStack->add(QString::number(p->uuid()), plotMenu);
 	// m_menu->add(plotMenu, p->name() + QString::number(p->uuid()), gui::MenuWidget::MA_TOPLAST);
 	setPlotComboVisible();
-	connect(p->plotMenu(), &TimePlotComponentSettings::requestSettings, this, [=]() {
+	connect(p->plotMenu(), &TimePlotComponentSettings::requestSettings, this, [this, p]() {
 		int idx = m_plotCb->combo()->findData(p->uuid());
 		m_plotCb->combo()->setCurrentIndex(idx);
 		m_menu->scrollTo(m_plotCb);

--- a/packages/generic-plugins/plugins/adc/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/adc/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/generic-plugins/plugins/dac/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/dac/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE dac)
 

--- a/packages/generic-plugins/plugins/dac/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/dac/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/generic-plugins/plugins/datalogger/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/datalogger/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE datalogger)
 

--- a/packages/generic-plugins/plugins/datalogger/src/datamonitortool.cpp
+++ b/packages/generic-plugins/plugins/datalogger/src/datamonitortool.cpp
@@ -77,7 +77,7 @@ DatamonitorTool::DatamonitorTool(DataAcquisitionManager *dataAcquisitionManager,
 		infoBtn->generateInfoPopup(this);
 
 		connect(infoBtn->getTutorialButton(), &QPushButton::clicked, this, &DatamonitorTool::startTutorial);
-		connect(infoBtn->getDocumentationButton(), &QPushButton::clicked, this, [=]() {
+		connect(infoBtn->getDocumentationButton(), &QPushButton::clicked, this, []() {
 			QDesktopServices::openUrl(
 				QUrl("https://analogdevicesinc.github.io/scopy/plugins/datalogger/datalogger.html"));
 		});

--- a/packages/generic-plugins/plugins/datalogger/src/menus/channelattributesmenu.cpp
+++ b/packages/generic-plugins/plugins/datalogger/src/menus/channelattributesmenu.cpp
@@ -42,7 +42,7 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	MenuHeaderWidget *header = new MenuHeaderWidget(model->getDisplayName(), model->getColor(), this);
 	header->title()->setEnabled(true);
 	connect(header->title(), &QLineEdit::textChanged, model, &DataMonitorModel::setDisplayName);
-	connect(model, &DataMonitorModel::displayNameChanged, header, [=](QString name) {
+	connect(model, &DataMonitorModel::displayNameChanged, header, [header](QString name) {
 		header->blockSignals(true);
 		header->title()->setText(name);
 		header->blockSignals(false);
@@ -115,32 +115,33 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	scaleOverride->setVisible(false);
 	scaleOverride->setScalingEnabled(false);
 
-	connect(scaleCb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
-		if(scaleCb->itemData(idx) == SCALE_RAW) {
+	connect(scaleCb, qOverload<int>(&QComboBox::currentIndexChanged), this,
+		[scaleCb, scaleOverride, model](int idx) {
+			if(scaleCb->itemData(idx) == SCALE_RAW) {
 
-			scaleOverride->setVisible(false);
-			// non scaled value is 1
-			model->setScale(1);
+				scaleOverride->setVisible(false);
+				// non scaled value is 1
+				model->setScale(1);
 
-		} else if(scaleCb->itemData(idx) == SCALE_SCALED) {
+			} else if(scaleCb->itemData(idx) == SCALE_SCALED) {
 
-			scaleOverride->setVisible(true);
-			scaleOverride->setEnabled(false);
-			model->setScale(model->defaultScale());
-			scaleOverride->blockSignals(true);
-			scaleOverride->setValue(model->defaultScale());
-			scaleOverride->blockSignals(false);
+				scaleOverride->setVisible(true);
+				scaleOverride->setEnabled(false);
+				model->setScale(model->defaultScale());
+				scaleOverride->blockSignals(true);
+				scaleOverride->setValue(model->defaultScale());
+				scaleOverride->blockSignals(false);
 
-		} else if(scaleCb->itemData(idx) == SCALE_OVERRIDE) {
+			} else if(scaleCb->itemData(idx) == SCALE_OVERRIDE) {
 
-			scaleOverride->setVisible(true);
-			scaleOverride->setEnabled(true);
-			model->setScale(model->defaultScale());
-			scaleOverride->blockSignals(true);
-			scaleOverride->setValue(model->defaultScale());
-			scaleOverride->blockSignals(false);
-		}
-	});
+				scaleOverride->setVisible(true);
+				scaleOverride->setEnabled(true);
+				model->setScale(model->defaultScale());
+				scaleOverride->blockSignals(true);
+				scaleOverride->setValue(model->defaultScale());
+				scaleOverride->blockSignals(false);
+			}
+		});
 
 	if(model->hasScale()) {
 		scaleCb->setCurrentIndex(1);
@@ -149,7 +150,7 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	scalingLayout->addWidget(scaleModeCBb);
 	scalingLayout->addWidget(scaleOverride);
 
-	connect(scaleOverride, &MenuSpinbox::valueChanged, this, [=](double value) {
+	connect(scaleOverride, &MenuSpinbox::valueChanged, this, [model](double value) {
 		if(qobject_cast<DmmDataMonitorModel *>(model)) {
 			DmmDataMonitorModel *dmmModel = dynamic_cast<DmmDataMonitorModel *>(model);
 			if(dmmModel) {
@@ -178,32 +179,33 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	offsetOverride->setVisible(false);
 	offsetOverride->setScalingEnabled(false);
 
-	connect(offsetCb, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int idx) {
-		if(offsetCb->itemData(idx) == OFFSET_RAW) {
+	connect(offsetCb, qOverload<int>(&QComboBox::currentIndexChanged), this,
+		[offsetCb, offsetOverride, model](int idx) {
+			if(offsetCb->itemData(idx) == OFFSET_RAW) {
 
-			offsetOverride->setVisible(false);
-			// non offset value is 0
-			model->setOffset(0);
+				offsetOverride->setVisible(false);
+				// non offset value is 0
+				model->setOffset(0);
 
-		} else if(offsetCb->itemData(idx) == OFFSET_OFFSETED) {
+			} else if(offsetCb->itemData(idx) == OFFSET_OFFSETED) {
 
-			offsetOverride->setVisible(true);
-			offsetOverride->setEnabled(false);
-			model->setOffset(model->defaultOffset());
-			offsetOverride->blockSignals(true);
-			offsetOverride->setValue(model->defaultOffset());
-			offsetOverride->blockSignals(false);
+				offsetOverride->setVisible(true);
+				offsetOverride->setEnabled(false);
+				model->setOffset(model->defaultOffset());
+				offsetOverride->blockSignals(true);
+				offsetOverride->setValue(model->defaultOffset());
+				offsetOverride->blockSignals(false);
 
-		} else if(offsetCb->itemData(idx) == OFFSET_OVERRIDE) {
+			} else if(offsetCb->itemData(idx) == OFFSET_OVERRIDE) {
 
-			offsetOverride->setVisible(true);
-			offsetOverride->setEnabled(true);
-			model->setOffset(model->defaultOffset());
-			offsetOverride->blockSignals(true);
-			offsetOverride->setValue(model->defaultOffset());
-			offsetOverride->blockSignals(false);
-		}
-	});
+				offsetOverride->setVisible(true);
+				offsetOverride->setEnabled(true);
+				model->setOffset(model->defaultOffset());
+				offsetOverride->blockSignals(true);
+				offsetOverride->setValue(model->defaultOffset());
+				offsetOverride->blockSignals(false);
+			}
+		});
 
 	if(model->hasOffset()) {
 		offsetCb->setCurrentIndex(1);
@@ -212,7 +214,7 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	scalingLayout->addWidget(offsetModeCBb);
 	scalingLayout->addWidget(offsetOverride);
 
-	connect(offsetOverride, &MenuSpinbox::valueChanged, this, [=](double value) {
+	connect(offsetOverride, &MenuSpinbox::valueChanged, this, [model](double value) {
 		if(qobject_cast<DmmDataMonitorModel *>(model)) {
 			DmmDataMonitorModel *dmmModel = dynamic_cast<DmmDataMonitorModel *>(model);
 			if(dmmModel) {
@@ -268,16 +270,17 @@ ChannelAttributesMenu::ChannelAttributesMenu(DataMonitorModel *model, MonitorPlo
 	QLineEdit *umSymbol = new QLineEdit(model->getUnitOfMeasure()->getSymbol(), um);
 	umSymbol->setPlaceholderText("Symbol");
 
-	connect(umName, &QLineEdit::textChanged, this, [=](QString text) { model->getUnitOfMeasure()->setName(text); });
-	connect(model->getUnitOfMeasure(), &UnitOfMeasurement::unitChanged, this, [=]() {
+	connect(umName, &QLineEdit::textChanged, this,
+		[model](QString text) { model->getUnitOfMeasure()->setName(text); });
+	connect(model->getUnitOfMeasure(), &UnitOfMeasurement::unitChanged, this, [umName, model]() {
 		umName->blockSignals(true);
 		umName->setText(model->getUnitOfMeasure()->getName());
 		umName->blockSignals(false);
 	});
 
 	connect(umSymbol, &QLineEdit::textChanged, this,
-		[=](QString text) { model->getUnitOfMeasure()->setSymbol(text); });
-	connect(model->getUnitOfMeasure(), &UnitOfMeasurement::unitChanged, this, [=]() {
+		[model](QString text) { model->getUnitOfMeasure()->setSymbol(text); });
+	connect(model->getUnitOfMeasure(), &UnitOfMeasurement::unitChanged, this, [umSymbol, model]() {
 		umSymbol->blockSignals(true);
 		umSymbol->setText(model->getUnitOfMeasure()->getSymbol());
 		umSymbol->blockSignals(false);

--- a/packages/generic-plugins/plugins/datalogger/src/menus/datamonitorsettings.cpp
+++ b/packages/generic-plugins/plugins/datalogger/src/menus/datamonitorsettings.cpp
@@ -141,7 +141,7 @@ void DataMonitorSettings::init(QString title, QColor color)
 		monitorPlotsSettings->setCurrentIndex(0);
 
 	connect(plotSelectorCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { monitorPlotsSettings->setCurrentIndex(idx); });
+		[monitorPlotsSettings](int idx) { monitorPlotsSettings->setCurrentIndex(idx); });
 
 	// Helper to connect controller signals to a plot
 	auto connectXAxisController = [this](MonitorPlot *plt) {
@@ -194,19 +194,21 @@ void DataMonitorSettings::init(QString title, QColor color)
 	});
 
 	// Remove menu when a plot is removed
-	connect(m_plotManager, &MonitorPlotManager::plotRemoved, this, [=](uint32_t uuid) {
-		for(int i = 0; i < plotSelectorCombo->count(); ++i) {
-			if(plotSelectorCombo->itemData(i).toUInt() == uuid) {
-				plotSelectorCombo->removeItem(i);
-				QWidget *w = monitorPlotsSettings->widget(i);
-				monitorPlotsSettings->removeWidget(w);
-				w->deleteLater();
-				break;
+	connect(m_plotManager, &MonitorPlotManager::plotRemoved, this,
+		[plotSelectorCombo, monitorPlotsSettings](uint32_t uuid) {
+			for(int i = 0; i < plotSelectorCombo->count(); ++i) {
+				if(plotSelectorCombo->itemData(i).toUInt() == uuid) {
+					plotSelectorCombo->removeItem(i);
+					QWidget *w = monitorPlotsSettings->widget(i);
+					monitorPlotsSettings->removeWidget(w);
+					w->deleteLater();
+					break;
+				}
 			}
-		}
-		if(plotSelectorCombo->count() > 0 && plotSelectorCombo->currentIndex() >= plotSelectorCombo->count())
-			plotSelectorCombo->setCurrentIndex(0);
-	});
+			if(plotSelectorCombo->count() > 0 &&
+			   plotSelectorCombo->currentIndex() >= plotSelectorCombo->count())
+				plotSelectorCombo->setCurrentIndex(0);
+		});
 
 	// Keep plotSelectorCombo text in sync with plot name changes
 	for(const auto &pair : plotList) {

--- a/packages/generic-plugins/plugins/datalogger/src/menus/monitorselectionmenu.cpp
+++ b/packages/generic-plugins/plugins/datalogger/src/menus/monitorselectionmenu.cpp
@@ -138,7 +138,7 @@ void MonitorSelectionMenu::addMonitor(DataMonitorModel *monitor)
 	m_monitorsGroup->addButton(monitorChannel);
 
 	connect(deviceMap.value(monitor->getDeviceName())->onOffSwitch(), &SmallOnOffSwitch::toggled, this,
-		[=](bool en) { monitorChannel->checkBox()->setChecked(en); });
+		[monitorChannel](bool en) { monitorChannel->checkBox()->setChecked(en); });
 
 	connect(monitorChannel, &MenuControlButton::clicked, this, [=, this](bool toggled) {
 		if(!monitorChannel->checkBox()->isChecked()) {

--- a/packages/generic-plugins/plugins/datalogger/src/monitorplotmanager.cpp
+++ b/packages/generic-plugins/plugins/datalogger/src/monitorplotmanager.cpp
@@ -196,7 +196,7 @@ QComboBox *MonitorPlotManager::createPlotAssignmentComboBox(DataMonitorModel *mo
 		if(plt)
 			combo->addItem(plt->name(), QVariant::fromValue(uuid));
 	});
-	QObject::connect(this, &MonitorPlotManager::plotRemoved, combo, [=](uint32_t uuid) {
+	QObject::connect(this, &MonitorPlotManager::plotRemoved, combo, [combo](uint32_t uuid) {
 		for(int i = 0; i < combo->count(); ++i) {
 			if(combo->itemData(i).toUInt() == uuid) {
 				combo->removeItem(i);

--- a/packages/generic-plugins/plugins/datalogger/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/datalogger/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/generic-plugins/plugins/debugger/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/debugger/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE debugger)
 
@@ -31,7 +31,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/generic-plugins/plugins/debugger/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/debugger/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/generic-plugins/plugins/jesdstatus/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/jesdstatus/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE jesdstatus)
 

--- a/packages/generic-plugins/plugins/jesdstatus/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/jesdstatus/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/generic-plugins/plugins/regmap/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/regmap/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE regmap)
 
@@ -31,7 +31,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/generic-plugins/plugins/regmap/src/deviceregistermap.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/deviceregistermap.cpp
@@ -92,7 +92,7 @@ DeviceRegisterMap::DeviceRegisterMap(RegisterMapTemplate *registerMapTemplate, R
 	if(registerMapTemplate) {
 		registerController->setHasMap(true);
 		QObject::connect(registerController, &RegisterController::toggleDetailedMenu, this,
-				 [=](bool toggled) { tool->openBottomContainerHelper(toggled); });
+				 [this](bool toggled) { tool->openBottomContainerHelper(toggled); });
 
 		QWidget *registerMapTable = new QWidget();
 		QVBoxLayout *registerMapTableLayout = new QVBoxLayout(registerMapTable);
@@ -144,7 +144,7 @@ DeviceRegisterMap::DeviceRegisterMap(RegisterMapTemplate *registerMapTemplate, R
 		}
 
 		QObject::connect(registerMapTableWidget, &RegisterMapTable::registerSelected, this,
-				 [=](uint32_t address) {
+				 [this, registerMapTemplate, registerMapValues](uint32_t address) {
 					 registerController->blockSignals(true);
 					 registerMapTableWidget->setRegisterSelected(address);
 					 registerChanged(registerMapTemplate->getRegisterTemplate(address));
@@ -155,7 +155,7 @@ DeviceRegisterMap::DeviceRegisterMap(RegisterMapTemplate *registerMapTemplate, R
 				 });
 
 		QObject::connect(registerController, &RegisterController::registerAddressChanged, this,
-				 [=](uint32_t address) {
+				 [this, registerMapTemplate, registerMapValues](uint32_t address) {
 					 registerChanged(registerMapTemplate->getRegisterTemplate(address));
 					 registerMapTableWidget->scrollTo(address);
 					 if(autoread) {
@@ -165,12 +165,13 @@ DeviceRegisterMap::DeviceRegisterMap(RegisterMapTemplate *registerMapTemplate, R
 	}
 
 	QObject::connect(registerController, &RegisterController::requestRead, registerMapValues,
-			 [=](uint32_t address) { Q_EMIT registerMapValues->requestRead(address); });
-	QObject::connect(
-		registerController, &RegisterController::requestWrite, registerMapValues,
-		[=](uint32_t address, uint32_t value) { Q_EMIT registerMapValues->requestWrite(address, value); });
+			 [registerMapValues](uint32_t address) { Q_EMIT registerMapValues->requestRead(address); });
+	QObject::connect(registerController, &RegisterController::requestWrite, registerMapValues,
+			 [registerMapValues](uint32_t address, uint32_t value) {
+				 Q_EMIT registerMapValues->requestWrite(address, value);
+			 });
 	QObject::connect(registerMapValues, &RegisterMapValues::registerValueChanged, this,
-			 [=](uint32_t address, uint32_t value) {
+			 [this, registerMapTemplate](uint32_t address, uint32_t value) {
 				 int regSize = 8;
 				 if(registerMapTemplate) {
 					 regSize = registerMapTemplate->getRegisterTemplate(0)->getWidth();
@@ -228,7 +229,7 @@ void DeviceRegisterMap::registerChanged(RegisterModel *regModel)
 
 	QObject::connect(registerDetailedWidget, &RegisterDetailedWidget::bitFieldValueChanged, registerController,
 			 &RegisterController::registerValueChanged);
-	QObject::connect(registerController, &RegisterController::valueChanged, this, [=](QString val) {
+	QObject::connect(registerController, &RegisterController::valueChanged, this, [this](QString val) {
 		registerDetailedWidget->updateBitFieldsValue(Utils::convertQStringToUint32(val));
 	});
 
@@ -276,12 +277,12 @@ void DeviceRegisterMap::initSettings()
 void DeviceRegisterMap::initTutorial()
 {
 
-	controllerTutorialFinish = connect(registerController, &RegisterController::tutorialFinished, this, [=]() {
+	controllerTutorialFinish = connect(registerController, &RegisterController::tutorialFinished, this, [this]() {
 		QWidget *parent = Util::findContainingWindow(this);
 		tutorial = new gui::TutorialBuilder(this, ":/registermap/tutorial_chapters.json", "device_register_map",
 						    parent);
 
-		connect(tutorial, &gui::TutorialBuilder::finished, this, [=]() { Q_EMIT tutorialFinished(); });
+		connect(tutorial, &gui::TutorialBuilder::finished, this, [this]() { Q_EMIT tutorialFinished(); });
 		connect(tutorial, &gui::TutorialBuilder::aborted, this, &DeviceRegisterMap::tutorialAborted);
 		tutorial->setTitle("Tutorial");
 		tutorial->start();

--- a/packages/generic-plugins/plugins/regmap/src/recyclerview/recyclerview.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/recyclerview/recyclerview.cpp
@@ -65,7 +65,7 @@ RecyclerView::RecyclerView(QList<int> *widgets, QWidget *parent)
 	slider->setFixedWidth(8);
 	Style::setStyle(slider, style::properties::regmap::regmapSlider);
 
-	QObject::connect(m_scrollArea->verticalScrollBar(), &QAbstractSlider::valueChanged, this, [=](int value) {
+	QObject::connect(m_scrollArea->verticalScrollBar(), &QAbstractSlider::valueChanged, this, [this](int value) {
 		if(value == m_scrollArea->verticalScrollBar()->minimum()) {
 			slider->setValue(m_scrollBarCurrentValue - 1);
 			m_scrollArea->verticalScrollBar()->setValue(value + 1);
@@ -96,7 +96,7 @@ void RecyclerView::init()
 
 	m_scrollBarCurrentValue = slider->value();
 
-	QObject::connect(slider, &QAbstractSlider::valueChanged, this, [=](int value) {
+	QObject::connect(slider, &QAbstractSlider::valueChanged, this, [this](int value) {
 		if(m_scrollBarCurrentValue < value) {
 			int diff = value - (activeWidgetTop - widgets->begin());
 

--- a/packages/generic-plugins/plugins/regmap/src/recyclerview/registermaptable.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/recyclerview/registermaptable.cpp
@@ -48,7 +48,7 @@ RegisterMapTable::RegisterMapTable(QMap<uint32_t, RegisterModel *> *registerMode
 	QObject::connect(this, &RegisterMapTable::widgetGenerated, recyclerView, &RecyclerView::addWidget);
 	QObject::connect(
 		recyclerView, &RecyclerView::initDone, this,
-		[=]() {
+		[this]() {
 			RegisterSimpleWidget *registerWidget = registersMap->value(registersMap->firstKey());
 			RegisterModel *registerModel = registerWidget->getRegisterModel();
 			selectedAddress = registerModel->getAddress();

--- a/packages/generic-plugins/plugins/regmap/src/register/bitfield/bitfielddetailedwidget.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/register/bitfield/bitfielddetailedwidget.cpp
@@ -143,7 +143,7 @@ void BitFieldDetailedWidget::firstRead()
 			valueComboBox->insertItem(i, options->at(i)->getDescription());
 		}
 
-		QObject::connect(valueComboBox, &QComboBox::currentTextChanged, this, [=](QString val) {
+		QObject::connect(valueComboBox, &QComboBox::currentTextChanged, this, [this](QString val) {
 			for(int i = 0; i < options->length(); i++) {
 				if(options->at(i)->getDescription() == val) {
 					Q_EMIT valueUpdated(options->at(i)->getValue());
@@ -159,7 +159,7 @@ void BitFieldDetailedWidget::firstRead()
 		layout->addWidget(valueSwitch);
 		layout->setAlignment(valueSwitch, Qt::AlignRight);
 
-		QObject::connect(valueSwitch, &SmallOnOffSwitch::toggled, this, [=](bool toggled) {
+		QObject::connect(valueSwitch, &SmallOnOffSwitch::toggled, this, [this](bool toggled) {
 			if(toggled) {
 				Q_EMIT valueUpdated("0");
 			} else {
@@ -171,7 +171,7 @@ void BitFieldDetailedWidget::firstRead()
 		valueLineEdit = new QLineEdit(this);
 		layout->addWidget(valueLineEdit);
 		QObject::connect(valueLineEdit, &QLineEdit::textChanged, this,
-				 [=](QString val) { Q_EMIT valueUpdated(val); });
+				 [this](QString val) { Q_EMIT valueUpdated(val); });
 	}
 }
 

--- a/packages/generic-plugins/plugins/regmap/src/register/bitfield/bitfieldsimplewidget.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/register/bitfield/bitfieldsimplewidget.cpp
@@ -86,7 +86,7 @@ BitFieldSimpleWidget::BitFieldSimpleWidget(QString name, int defaultValue, QStri
 	setLayout(mainFrameLayout);
 
 	Preferences *p = Preferences::GetInstance();
-	QObject::connect(p, &Preferences::preferenceChanged, this, [=](QString id, QVariant var) {
+	QObject::connect(p, &Preferences::preferenceChanged, this, [this](QString id, QVariant var) {
 		if(id.contains("regmap")) {
 			applyStyle();
 		}

--- a/packages/generic-plugins/plugins/regmap/src/register/registerdetailedwidget.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/register/registerdetailedwidget.cpp
@@ -99,7 +99,7 @@ RegisterDetailedWidget::RegisterDetailedWidget(RegisterModel *regModel, QWidget 
 			col = 0;
 		}
 		QObject::connect(bitFieldDetailedWidget, &BitFieldDetailedWidget::valueUpdated, this,
-				 [=]() { Q_EMIT bitFieldValueChanged(getBitFieldsValue()); });
+				 [this]() { Q_EMIT bitFieldValueChanged(getBitFieldsValue()); });
 	}
 	// add spacers to keep the shape of the detailed bitfileds when the number of bitfields didn't fill a row
 	if(row == 1) {

--- a/packages/generic-plugins/plugins/regmap/src/register/registersimplewidget.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/register/registersimplewidget.cpp
@@ -121,7 +121,7 @@ RegisterSimpleWidget::RegisterSimpleWidget(RegisterModel *registerModel, QVector
 	setToolTip(toolTip);
 
 	Preferences *p = Preferences::GetInstance();
-	QObject::connect(p, &Preferences::preferenceChanged, this, [=](QString id, QVariant var) {
+	QObject::connect(p, &Preferences::preferenceChanged, this, [this](QString id, QVariant var) {
 		if(id.contains("regmap")) {
 			applyStyle();
 		}

--- a/packages/generic-plugins/plugins/regmap/src/registercontroller.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/registercontroller.cpp
@@ -71,7 +71,7 @@ RegisterController::RegisterController(QWidget *parent)
 	addressPicker->setMaximum(INT_MAX);
 	addressPicker->setPrefix("0x");
 	addressPicker->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-	QObject::connect(addressPicker, &QSpinBox::textChanged, this, [=](QString address) {
+	QObject::connect(addressPicker, &QSpinBox::textChanged, this, [this](QString address) {
 		Q_EMIT registerAddressChanged(Utils::convertQStringToUint32(address));
 	});
 	readWidgetLayout->addLayout(readWidgetLeftLayout, 3);
@@ -79,7 +79,7 @@ RegisterController::RegisterController(QWidget *parent)
 	readButton = new QPushButton("Read", readWidget);
 	// request read
 	QObject::connect(readButton, &QPushButton::clicked, this,
-			 [=]() { Q_EMIT requestRead(Utils::convertQStringToUint32(addressPicker->text())); });
+			 [this]() { Q_EMIT requestRead(Utils::convertQStringToUint32(addressPicker->text())); });
 
 	readWidgetLayout->addWidget(readButton, 1, Qt::AlignRight);
 
@@ -110,7 +110,7 @@ RegisterController::RegisterController(QWidget *parent)
 	Style::setStyle(writeWidget, style::properties::regmap::registercontroller);
 	writeButton = new QPushButton("Write", writeWidget);
 	// request write on register
-	QObject::connect(writeButton, &QPushButton::clicked, this, [=]() {
+	QObject::connect(writeButton, &QPushButton::clicked, this, [this]() {
 		uint32_t address = addressPicker->value();
 		uint32_t value = Utils::convertQStringToUint32(regValue->text());
 		Q_EMIT requestWrite(address, value);
@@ -189,7 +189,7 @@ void RegisterController::startTutorial()
 	registerMapTutorial =
 		new gui::TutorialBuilder(this, ":/registermap/tutorial_chapters.json", "register_controller", parent);
 
-	connect(registerMapTutorial, &gui::TutorialBuilder::finished, this, [=]() { Q_EMIT tutorialFinished(); });
+	connect(registerMapTutorial, &gui::TutorialBuilder::finished, this, [this]() { Q_EMIT tutorialFinished(); });
 	connect(registerMapTutorial, &gui::TutorialBuilder::aborted, this, &RegisterController::tutorialAborted);
 
 	registerMapTutorial->setTitle("Tutorial");
@@ -203,7 +203,7 @@ void RegisterController::startSimpleTutorial()
 							     "simple_register_controller", parent);
 
 	connect(registerMapSimpleTutorial, &gui::TutorialBuilder::finished, this,
-		[=]() { Q_EMIT simpleTutorialFinished(); });
+		[this]() { Q_EMIT simpleTutorialFinished(); });
 
 	connect(registerMapSimpleTutorial, &gui::TutorialBuilder::aborted, this, &RegisterController::tutorialAborted);
 

--- a/packages/generic-plugins/plugins/regmap/src/registermapsettingsmenu.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/registermapsettingsmenu.cpp
@@ -90,7 +90,7 @@ RegisterMapSettingsMenu::RegisterMapSettingsMenu(QWidget *parent)
 
 	readInterval->setEnabled(false);
 
-	QObject::connect(readInterval, &QPushButton::clicked, this, [=]() {
+	QObject::connect(readInterval, &QPushButton::clicked, this, [this]() {
 		int startInterval = Utils::convertQStringToUint32(startReadInterval->text());
 		int endInterval = Utils::convertQStringToUint32(endReadInterval->text());
 		for(int i = startInterval; i <= endInterval; i++) {
@@ -98,7 +98,7 @@ RegisterMapSettingsMenu::RegisterMapSettingsMenu(QWidget *parent)
 		}
 	});
 
-	QObject::connect(startReadInterval, &QLineEdit::textChanged, this, [=]() {
+	QObject::connect(startReadInterval, &QLineEdit::textChanged, this, [this]() {
 		if(!startReadInterval->text().isEmpty() && !endReadInterval->text().isEmpty()) {
 			readInterval->setEnabled(true);
 		} else {
@@ -106,7 +106,7 @@ RegisterMapSettingsMenu::RegisterMapSettingsMenu(QWidget *parent)
 		}
 	});
 
-	QObject::connect(endReadInterval, &QLineEdit::textChanged, this, [=]() {
+	QObject::connect(endReadInterval, &QLineEdit::textChanged, this, [this]() {
 		if(!startReadInterval->text().isEmpty() && !endReadInterval->text().isEmpty()) {
 			readInterval->setEnabled(true);
 		} else {

--- a/packages/generic-plugins/plugins/regmap/src/registermaptool.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/registermaptool.cpp
@@ -71,9 +71,9 @@ RegisterMapTool::RegisterMapTool(QWidget *parent)
 	InfoBtn *infoBtn = new InfoBtn(this, true);
 	tool->addWidgetToTopContainerHelper(infoBtn, TTA_LEFT);
 
-	connect(infoBtn, &InfoBtn::clicked, this, [=]() {
+	connect(infoBtn, &InfoBtn::clicked, this, [this, infoBtn]() {
 		infoBtn->generateInfoPopup(this);
-		connect(infoBtn->getTutorialButton(), &QPushButton::clicked, this, [=]() {
+		connect(infoBtn->getTutorialButton(), &QPushButton::clicked, this, [this]() {
 			if(searchBarWidget->isVisible()) {
 				startTutorial();
 			} else {
@@ -81,7 +81,7 @@ RegisterMapTool::RegisterMapTool(QWidget *parent)
 			}
 		});
 
-		connect(infoBtn->getDocumentationButton(), &QAbstractButton::clicked, this, [=]() {
+		connect(infoBtn->getDocumentationButton(), &QAbstractButton::clicked, this, []() {
 			QDesktopServices::openUrl(
 				QUrl("https://analogdevicesinc.github.io/scopy/plugins/registermap/registermap.html"));
 		});
@@ -99,7 +99,7 @@ RegisterMapTool::RegisterMapTool(QWidget *parent)
 	settingsMenu = new GearBtn(this);
 	Style::setStyle(settingsMenu, style::properties::button::squareIconButton, true, true);
 
-	connect(settingsMenu, &QAbstractButton::toggled, this, [=](bool toggled) {
+	connect(settingsMenu, &QAbstractButton::toggled, this, [this](bool toggled) {
 		tool->openRightContainerHelper(toggled);
 		tool->requestMenu("settings");
 	});
@@ -120,7 +120,7 @@ RegisterMapTool::RegisterMapTool(QWidget *parent)
 	tool->getContainerSpacer(tool->topContainerMenuControl())
 		->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-	QObject::connect(searchBarWidget, &SearchBarWidget::requestSearch, this, [=](QString searchParam) {
+	QObject::connect(searchBarWidget, &SearchBarWidget::requestSearch, this, [this](QString searchParam) {
 		deviceList->value(registerDeviceList->currentText())->applyFilters(searchParam);
 	});
 

--- a/packages/generic-plugins/plugins/regmap/src/searchbarwidget.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/searchbarwidget.cpp
@@ -51,7 +51,7 @@ SearchBarWidget::SearchBarWidget(QWidget *parent)
 	QString iconPath = ":/gui/icons/" + Style::getAttribute(json::theme::icon_theme_folder) + "/icons/search.svg";
 	searchButton->setIcon(Style::getPixmap(iconPath, Style::getColor(json::theme::content_default)));
 
-	connect(searchButton, &QPushButton::toggled, this, [=](bool toggle) {
+	connect(searchButton, &QPushButton::toggled, this, [this, iconPath](bool toggle) {
 		const char *color = toggle ? json::theme::content_inverse : json::theme::content_default;
 		searchButton->setIcon(Style::getPixmap(iconPath, Style::getColor(color)));
 	});
@@ -61,7 +61,7 @@ SearchBarWidget::SearchBarWidget(QWidget *parent)
 	QObject::connect(searchBar, &QLineEdit::returnPressed, searchButton, &QPushButton::pressed);
 
 	QObject::connect(searchButton, &QPushButton::pressed, this,
-			 [=]() { Q_EMIT requestSearch(searchBar->text().toLower()); });
+			 [this]() { Q_EMIT requestSearch(searchBar->text().toLower()); });
 	layout->addWidget(searchBar);
 	layout->addWidget(searchButton);
 

--- a/packages/generic-plugins/plugins/regmap/src/titlespinbox.cpp
+++ b/packages/generic-plugins/plugins/regmap/src/titlespinbox.cpp
@@ -71,8 +71,9 @@ TitleSpinBox::TitleSpinBox(QString title, QWidget *parent)
 
 	spinBox = new QSpinBox(spinboxWidget);
 	spinBox->setButtonSymbols(spinBox->ButtonSymbols::NoButtons);
-	connect(spinBoxUpButton, &QPushButton::clicked, spinBox, [=]() { spinBox->setValue(spinBox->value() + 1); });
-	connect(spinBoxDownButton, &QPushButton::clicked, spinBox, [=]() { spinBox->setValue(spinBox->value() - 1); });
+	connect(spinBoxUpButton, &QPushButton::clicked, spinBox, [this]() { spinBox->setValue(spinBox->value() + 1); });
+	connect(spinBoxDownButton, &QPushButton::clicked, spinBox,
+		[this]() { spinBox->setValue(spinBox->value() - 1); });
 
 	spinboxWidgetLayout->addWidget(titleLabel);
 	spinboxWidgetLayout->addWidget(spinBox);

--- a/packages/generic-plugins/plugins/regmap/test/CMakeLists.txt
+++ b/packages/generic-plugins/plugins/regmap/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 # set(CMAKE_FIND_DEBUG_MODE ON)
 include(ScopyTest)

--- a/packages/imu/CMakeLists.txt
+++ b/packages/imu/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE imu)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/imu/plugins/imuanalyzer/CMakeLists.txt
+++ b/packages/imu/plugins/imuanalyzer/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE imuanalyzer)
 
@@ -30,7 +30,7 @@ include(GenerateExportHeader)
 
 # TODO : split stylesheet / resources and add here TODO : export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/imu/plugins/imuanalyzer/src/imuanalyzersettings.cpp
+++ b/packages/imu/plugins/imuanalyzer/src/imuanalyzersettings.cpp
@@ -56,7 +56,7 @@ ImuAnalyzerSettings::ImuAnalyzerSettings(SceneRenderer *scRend, BubbleLevelRende
 
 	connect(this, &ImuAnalyzerSettings::updateDisplayPoints, blRend, &BubbleLevelRenderer::setDisplayPoints);
 	connect(displayPoints->combo(), qOverload<int>(&QComboBox::currentIndexChanged), this,
-		[=](int idx) { emit updateDisplayPoints(displayPoints->combo()->itemText(idx)); });
+		[this, displayPoints](int idx) { emit updateDisplayPoints(displayPoints->combo()->itemText(idx)); });
 
 	bubbleLevelSettingsWidget->contentLayout()->addWidget(displayPoints);
 

--- a/packages/imu/plugins/imuanalyzer/test/CMakeLists.txt
+++ b/packages/imu/plugins/imuanalyzer/test/CMakeLists.txt
@@ -18,6 +18,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)

--- a/packages/m2k/CMakeLists.txt
+++ b/packages/m2k/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE m2k)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/m2k/plugins/m2k/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE m2k)
 
@@ -29,7 +29,7 @@ set(PLUGIN_DESCRIPTION "Plugin for ADALM2000 (M2K)")
 
 include(GenerateExportHeader)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui ${CMAKE_CURRENT_SOURCE_DIR}/ui/patterns)

--- a/packages/m2k/plugins/m2k/m2k-gui/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 set(SCOPY_MODULE m2k-gui)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
 
@@ -26,7 +26,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/m2k/plugins/m2k/m2k-gui/gr-gui/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/gr-gui/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 set(SCOPY_MODULE gr-gui)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
 
@@ -26,7 +26,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/m2k/plugins/m2k/m2k-gui/gr-gui/test/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/gr-gui/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 function(SETUP_TESTS)
 	foreach(_testname ${ARGS})

--- a/packages/m2k/plugins/m2k/m2k-gui/sigrok-gui/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/sigrok-gui/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 set(SCOPY_MODULE sigrok-gui)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
 
@@ -26,7 +26,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/m2k/plugins/m2k/m2k-gui/sigrok-gui/test/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/sigrok-gui/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 function(SETUP_TESTS)
 	foreach(_testname ${ARGS})

--- a/packages/m2k/plugins/m2k/m2k-gui/test/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 function(SETUP_TESTS)
 	foreach(_testname ${ARGS})

--- a/packages/m2k/plugins/m2k/test/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/pqmon/CMakeLists.txt
+++ b/packages/pqmon/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE pqmon)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/pqmon/plugins/pqm/CMakeLists.txt
+++ b/packages/pqmon/plugins/pqm/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE pqm)
 

--- a/packages/pqmon/plugins/pqm/src/settingsinstrument.cpp
+++ b/packages/pqmon/plugins/pqm/src/settingsinstrument.cpp
@@ -287,11 +287,12 @@ void SettingsInstrument::initTimestampSection(QWidget *parent)
 
 	qInfo() << "Date time: " << timestampEdit2->dateTime().toString("yyyyMMddhhmmsszzz");
 
-	connect(timestampEdit1, &QDateTimeEdit::dateTimeChanged, this, [=](QDateTime dateTime) {
-		if(dateTime > timestampEdit2->dateTime()) {
-			timestampEdit1->setDateTime(timestampEdit2->dateTime());
-		}
-	});
+	connect(timestampEdit1, &QDateTimeEdit::dateTimeChanged, this,
+		[timestampEdit1, timestampEdit2](QDateTime dateTime) {
+			if(dateTime > timestampEdit2->dateTime()) {
+				timestampEdit1->setDateTime(timestampEdit2->dateTime());
+			}
+		});
 
 	QPushButton *timestampBtn = new QPushButton("Set", timestampSection);
 	timestampBtn->setFixedWidth(88);

--- a/packages/pqmon/plugins/pqm/test/CMakeLists.txt
+++ b/packages/pqmon/plugins/pqm/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 # set(CMAKE_FIND_DEBUG_MODE ON)
 include(ScopyTest)

--- a/packages/rfpowermeter/CMakeLists.txt
+++ b/packages/rfpowermeter/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE rfpowermeter)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/rfpowermeter/plugins/rfpowermeter/CMakeLists.txt
+++ b/packages/rfpowermeter/plugins/rfpowermeter/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE rfpowermeter)
 

--- a/packages/rfpowermeter/plugins/rfpowermeter/test/CMakeLists.txt
+++ b/packages/rfpowermeter/plugins/rfpowermeter/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/packages/swiot/CMakeLists.txt
+++ b/packages/swiot/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE swiot)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/swiot/plugins/swiot/CMakeLists.txt
+++ b/packages/swiot/plugins/swiot/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE swiot)
 

--- a/packages/swiot/plugins/swiot/src/ad74413r/buffermenuview.cpp
+++ b/packages/swiot/plugins/swiot/src/ad74413r/buffermenuview.cpp
@@ -155,13 +155,13 @@ QWidget *BufferMenuView::createVerticalSettingsMenu(QString unit, double yMin, d
 
 	// Connects
 	connect(m_yMin, &MenuSpinbox::valueChanged, this, &BufferMenuView::setYMin);
-	connect(this, &BufferMenuView::minChanged, this, [=](double min) {
+	connect(this, &BufferMenuView::minChanged, this, [m_yMin](double min) {
 		QSignalBlocker b(m_yMin);
 		m_yMin->setValue(min);
 	});
 
 	connect(m_yMax, &MenuSpinbox::valueChanged, this, &BufferMenuView::setYMax);
-	connect(this, &BufferMenuView::maxChanged, this, [=](double max) {
+	connect(this, &BufferMenuView::maxChanged, this, [m_yMax](double max) {
 		QSignalBlocker b(m_yMax);
 		m_yMax->setValue(max);
 	});

--- a/packages/swiot/plugins/swiot/test/CMakeLists.txt
+++ b/packages/swiot/plugins/swiot/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/test-plugins/CMakeLists.txt
+++ b/packages/test-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE test-plugins)
 set(CURRENT_PKG_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/packages/test-plugins/plugins/bareminimum/CMakeLists.txt
+++ b/packages/test-plugins/plugins/bareminimum/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE bareminimum)
 
@@ -28,7 +28,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/test-plugins/plugins/bareminimum/test/CMakeLists.txt
+++ b/packages/test-plugins/plugins/bareminimum/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/test-plugins/plugins/guitest/CMakeLists.txt
+++ b/packages/test-plugins/plugins/guitest/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE guitest)
 
@@ -28,7 +28,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/test-plugins/plugins/guitest/test/CMakeLists.txt
+++ b/packages/test-plugins/plugins/guitest/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/test-plugins/plugins/test/CMakeLists.txt
+++ b/packages/test-plugins/plugins/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE test)
 
@@ -28,7 +28,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/test-plugins/plugins/test/src/testplugin.cpp
+++ b/packages/test-plugins/plugins/test/src/testplugin.cpp
@@ -132,8 +132,8 @@ bool TestPlugin::loadExtraButtons()
 	Style::setStyle(btnRegister, style::properties::button::grayButton);
 	m_extraButtons.append(btnRegister);
 
-	connect(m_extraButtons[0], &QAbstractButton::clicked, this, [=]() { edit->setText("Calibrating"); });
-	connect(m_extraButtons[1], &QAbstractButton::clicked, this, [=]() { edit->setText("Registering"); });
+	connect(m_extraButtons[0], &QAbstractButton::clicked, this, [this]() { edit->setText("Calibrating"); });
+	connect(m_extraButtons[1], &QAbstractButton::clicked, this, [this]() { edit->setText("Registering"); });
 	return true;
 }
 
@@ -213,10 +213,10 @@ bool TestPlugin::onConnect()
 	gui::MenuSpinbox *m_spin = new gui::MenuSpinbox("Frequency", 1e6, "Hz", 400000, 6000000000, tool);
 	;
 
-	connect(btn, &QPushButton::clicked, this, [=]() { m_toolList[0]->setAttached(!m_toolList[0]->attached()); });
+	connect(btn, &QPushButton::clicked, this, [this]() { m_toolList[0]->setAttached(!m_toolList[0]->attached()); });
 	connect(btn2, &QPushButton::clicked, this,
-		[=]() { m_toolList[0]->setName("TestPlugin" + QString::number(renameCnt++)); });
-	connect(btn3, &QPushButton::clicked, this, [=]() { startTutorial(); });
+		[this]() { m_toolList[0]->setName("TestPlugin" + QString::number(renameCnt++)); });
+	connect(btn3, &QPushButton::clicked, this, [this]() { startTutorial(); });
 	edit = new QLineEdit(tool);
 	pic->setStyleSheet("border-image: url(\":/testplugin/testImage.png\") ");
 
@@ -256,7 +256,7 @@ void TestPlugin::initHoverWidgetTests()
 	HoverWidget *hover = new HoverWidget(cursorMenu, btn4, tool);
 	hover->setAnchorPos(HoverPosition::HP_TOPLEFT);
 	hover->setContentPos(HoverPosition::HP_TOPRIGHT);
-	connect(btn4, &QPushButton::toggled, this, [=](bool b) {
+	connect(btn4, &QPushButton::toggled, this, [hover](bool b) {
 		hover->setVisible(b);
 		hover->raise();
 	});
@@ -269,37 +269,37 @@ void TestPlugin::initHoverWidgetTests()
 	hoverTestLayout->addWidget(testBtn);
 	QLabel *testLabel = new QLabel("--HOVER TEST--");
 	testLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setContent(testLabel); });
+	connect(testBtn, &QPushButton::clicked, this, [hover, testLabel]() { hover->setContent(testLabel); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("reset content");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setContent(cursorMenu); });
+	connect(testBtn, &QPushButton::clicked, this, [hover, cursorMenu]() { hover->setContent(cursorMenu); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("change anchor");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setAnchor(edit); });
+	connect(testBtn, &QPushButton::clicked, this, [this, hover]() { hover->setAnchor(edit); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("reset anchor");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setAnchor(btn4); });
+	connect(testBtn, &QPushButton::clicked, this, [this, hover]() { hover->setAnchor(btn4); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("change parent");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setParent(lbl2); });
+	connect(testBtn, &QPushButton::clicked, this, [this, hover]() { hover->setParent(lbl2); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("reset parent");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() { hover->setParent(tool); });
+	connect(testBtn, &QPushButton::clicked, this, [this, hover]() { hover->setParent(tool); });
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("change position");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() {
+	connect(testBtn, &QPushButton::clicked, this, [hover]() {
 		hover->setAnchorPos(HoverPosition::HP_TOPRIGHT);
 		hover->setContentPos(HoverPosition::HP_TOPLEFT);
 	});
@@ -307,7 +307,7 @@ void TestPlugin::initHoverWidgetTests()
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("reset position");
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::clicked, this, [=]() {
+	connect(testBtn, &QPushButton::clicked, this, [hover]() {
 		hover->setAnchorPos(HoverPosition::HP_TOPLEFT);
 		hover->setContentPos(HoverPosition::HP_TOPRIGHT);
 	});
@@ -316,14 +316,14 @@ void TestPlugin::initHoverWidgetTests()
 	testBtn->setText("set draggable");
 	testBtn->setCheckable(true);
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::toggled, this, [=](bool toggled) { hover->setDraggable(toggled); });
+	connect(testBtn, &QPushButton::toggled, this, [hover](bool toggled) { hover->setDraggable(toggled); });
 	testBtn->setStyleSheet("QPushButton::checked{background-color: grey;}");
 
 	testBtn = new QPushButton(hoverTest);
 	testBtn->setText("set relative");
 	testBtn->setCheckable(true);
 	hoverTestLayout->addWidget(testBtn);
-	connect(testBtn, &QPushButton::toggled, this, [=](bool toggled) { hover->setRelative(toggled); });
+	connect(testBtn, &QPushButton::toggled, this, [hover](bool toggled) { hover->setRelative(toggled); });
 	testBtn->setStyleSheet("QPushButton::checked{background-color: grey;}");
 
 	tool->layout()->addWidget(hoverTest);

--- a/packages/test-plugins/plugins/test/src/testtool.cpp
+++ b/packages/test-plugins/plugins/test/src/testtool.cpp
@@ -92,7 +92,7 @@ TestTool::TestTool(QWidget *parent)
 
 	QTimer *dataRefreshTimer = new QTimer(this);
 	dataRefreshTimer->setInterval(10);
-	connect(runBtn, &QPushButton::toggled, this, [=](bool b) {
+	connect(runBtn, &QPushButton::toggled, this, [dataRefreshTimer](bool b) {
 		if(b) {
 			dataRefreshTimer->start();
 		} else {
@@ -130,8 +130,8 @@ TestTool::TestTool(QWidget *parent)
 	plot->addPlotAxisHandle(ch1_plotch->handle());
 
 	connect(ch1->checkBox(), &QCheckBox::toggled, ch1_plotch, &PlotChannel::setEnabled);
-	connect(ch1->checkBox(), &QCheckBox::toggled, this, [=]() { plot->replot(); });
-	connect(ch1, &QAbstractButton::toggled, this, [=]() { plot->selectChannel(ch1_plotch); });
+	connect(ch1->checkBox(), &QCheckBox::toggled, this, [plot]() { plot->replot(); });
+	connect(ch1, &QAbstractButton::toggled, this, [plot, ch1_plotch]() { plot->selectChannel(ch1_plotch); });
 	ch1_plotch->curve()->setRawSamples(xTime.data(), y1Volt.data(), xTime.size());
 
 	MenuControlButton *ch2 = new MenuControlButton(this);
@@ -149,8 +149,8 @@ TestTool::TestTool(QWidget *parent)
 	ch2_plotch->setHandle(handle2);
 	plot->addPlotAxisHandle(ch2_plotch->handle());
 	connect(ch2->checkBox(), &QCheckBox::toggled, ch2_plotch, &PlotChannel::setEnabled);
-	connect(ch2->checkBox(), &QCheckBox::toggled, this, [=]() { plot->replot(); });
-	connect(ch2, &QAbstractButton::toggled, this, [=]() { plot->selectChannel(ch2_plotch); });
+	connect(ch2->checkBox(), &QCheckBox::toggled, this, [plot]() { plot->replot(); });
+	connect(ch2, &QAbstractButton::toggled, this, [plot, ch2_plotch]() { plot->selectChannel(ch2_plotch); });
 	ch2_plotch->curve()->setRawSamples(xTime.data(), y2Volt.data(), xTime.size());
 
 	MenuControlButton *cursor = new MenuControlButton(this);
@@ -206,9 +206,9 @@ TestTool::TestTool(QWidget *parent)
 	tool->rightStack()->add("ch1", wch1);
 	tool->rightStack()->add("ch2", wch2);
 
-	connect(channels->button(), &QAbstractButton::pressed, this, [=]() { tool->requestMenu("ch0"); });
-	connect(ch1->button(), &QAbstractButton::pressed, this, [=]() { tool->requestMenu("ch1"); });
-	connect(ch2->button(), &QAbstractButton::pressed, this, [=]() { tool->requestMenu("ch2"); });
+	connect(channels->button(), &QAbstractButton::pressed, this, [this]() { tool->requestMenu("ch0"); });
+	connect(ch1->button(), &QAbstractButton::pressed, this, [this]() { tool->requestMenu("ch1"); });
+	connect(ch2->button(), &QAbstractButton::pressed, this, [this]() { tool->requestMenu("ch2"); });
 
 	auto grp = static_cast<OpenLastMenuBtn *>(btn3)->getButtonGroup();
 	grp->addButton(channels->button());
@@ -248,7 +248,7 @@ TestTool::TestTool(QWidget *parent)
 	hv->setAnchorPos(HoverPosition::HP_TOPLEFT);
 	hv->setContentPos(HoverPosition::HP_TOPRIGHT);
 
-	connect(channels, &QAbstractButton::toggled, this, [=](bool b) {
+	connect(channels, &QAbstractButton::toggled, this, [hv](bool b) {
 		qInfo() << "setVisible: " << b;
 		hv->setVisible(b);
 		hv->raise();

--- a/packages/test-plugins/plugins/test/test/CMakeLists.txt
+++ b/packages/test-plugins/plugins/test/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/packages/test-plugins/plugins/test2/CMakeLists.txt
+++ b/packages/test-plugins/plugins/test2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE test2)
 
@@ -28,7 +28,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/packages/test-plugins/plugins/test2/src/testpluginip.cpp
+++ b/packages/test-plugins/plugins/test2/src/testpluginip.cpp
@@ -66,13 +66,13 @@ bool TestPluginIp::onConnect()
 	QPushButton *sendMessage = new QPushButton("SendMessage");
 	lay->addWidget(sendMessage);
 
-	connect(btn, &QPushButton::clicked, this, [=]() { requestTool(m_toolList[0]->id()); });
-	connect(sendMessage, &QPushButton::clicked, this, [=]() {
+	connect(btn, &QPushButton::clicked, this, [this]() { requestTool(m_toolList[0]->id()); });
+	connect(sendMessage, &QPushButton::clicked, this, []() {
 		MessageBroker::GetInstance()->publish("TestPlugin", "testMessage");
 		MessageBroker::GetInstance()->publish("broadcast", "testMessage");
 		MessageBroker::GetInstance()->publish("TestPlugin2", "testMessage");
 	});
-	connect(disc, &QPushButton::clicked, this, [=]() { Q_EMIT disconnectDevice(); });
+	connect(disc, &QPushButton::clicked, this, [this]() { Q_EMIT disconnectDevice(); });
 
 	Q_EMIT toolListChanged();
 	m_toolList[1]->setTool(m_tool);

--- a/packages/test-plugins/plugins/test2/test/CMakeLists.txt
+++ b/packages/test-plugins/plugins/test2/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 include(ScopyTest)
 
 setup_scopy_tests(pluginloader)

--- a/pkg-manager/CMakeLists.txt
+++ b/pkg-manager/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE pkg-manager)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/pluginbase/CMakeLists.txt
+++ b/pluginbase/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE pluginbase)
 project(scopy-${SCOPY_MODULE} VERSION 0.1 LANGUAGES CXX)
@@ -27,7 +27,7 @@ include(GenerateExportHeader)
 
 # TODO: split stylesheet/resources and add here TODO: export header files correctly
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)

--- a/pluginbase/test/CMakeLists.txt
+++ b/pluginbase/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 include(ScopyTest)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 # JS AUTOMATED TESTS
 option(ENABLE_AUTOMATED_TESTS "Enable JS Automated Tests" OFF)

--- a/tools/packagegenerator/plugin.json
+++ b/tools/packagegenerator/plugin.json
@@ -23,7 +23,7 @@
         }
     ],
     "cmakelists": {
-        "cmake_min_required": 3.9,
+        "cmake_min_required": 3.16,
         "cxx_standard": 20,
         "enable_testing": "ON"
     },
@@ -33,7 +33,7 @@
     },
     "test": {
         "cmakelists": true,
-        "cmake_min_required": 3.5,
+        "cmake_min_required": 3.16,
         "tst_pluginloader": true
     },
     "resources": {

--- a/tools/packagegenerator/templates/package/pkg_cmakelists.mako
+++ b/tools/packagegenerator/templates/package/pkg_cmakelists.mako
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 set(SCOPY_MODULE ${id})
 set(CURRENT_PKG_PATH ${"${CMAKE_CURRENT_SOURCE_DIR}"})

--- a/tools/packagegenerator/templates/pdk/pdk_cmakelists.mako
+++ b/tools/packagegenerator/templates/pdk/pdk_cmakelists.mako
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 # Project name
 set(TARGET_NAME "ScopyPluginRunner")
@@ -8,7 +8,7 @@ project(${"${TARGET_NAME}"} VERSION 0.0.1 DESCRIPTION "Project Description")
 # Make sure CMake will take care of moc for us
 set(CMAKE_AUTOMOC ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(INSERT CMAKE_MODULE_PATH 0 ${"${PROJECT_SOURCE_DIR}"}/cmake/Modules)
 

--- a/tools/packagegenerator/templates/plugin/cmakelists.mako
+++ b/tools/packagegenerator/templates/plugin/cmakelists.mako
@@ -1,7 +1,7 @@
 % if "cmake_min_required" in config:
 cmake_minimum_required(VERSION ${config['cmake_min_required']})
 % else:
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 %endif
 
 set(SCOPY_MODULE ${scopy_module})
@@ -18,7 +18,7 @@ include(GenerateExportHeader)
 % if "cxx_standard" in config:
 set(CMAKE_CXX_STANDARD ${config['cxx_standard']})
 % else:
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 % endif
 set(CMAKE_CXX_STANDARD_REQUIRED ON) 
 


### PR DESCRIPTION
The CMAKE_CXX_STANDARD 20 requires CMake >= 3.12
CMake 3.16 has a better compatibility with Qt6
The current CI use CMake 3.29
This change also fixed the warnings related to "=" being deprecated in CXX 20 standard 