### PR TITLE
ci: Fix find_package(Boost) for Ubuntu 26.04

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -111,7 +111,9 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets Xml Svg REQUIRED)
 find_package(KDDockWidgets QUIET)
 
 add_definitions(-DBOOST_ALL_DYN_LINK)
-find_package(Boost COMPONENTS system filesystem thread chrono REQUIRED)
+# Boost.System is header-only since Boost 1.69 and its compiled library was removed in Boost 1.89, so it must not be
+# requested as a component.
+find_package(Boost 1.69 COMPONENTS filesystem thread chrono REQUIRED)
 
 message(STATUS "Building: " ${PROJECT_NAME})
 add_library(${PROJECT_NAME} SHARED ${PROJECT_SOURCES} ${PROJECT_RESOURCES})

--- a/packages/m2k/plugins/m2k/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/CMakeLists.txt
@@ -78,8 +78,9 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};/usr/local/lib/cmake)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS ${SCOPY_QT_COMPONENTS} REQUIRED)
 find_package(libm2k REQUIRED)
 
-find_package(Boost COMPONENTS system filesystem thread chrono REQUIRED) # workaround for Gnuradio not finding
-# Boost::chrono
+# Boost.System is header-only since Boost 1.69 and its compiled library was removed in Boost 1.89, so it must not be
+# requested as a component.
+find_package(Boost 1.69 COMPONENTS filesystem thread chrono REQUIRED)
 find_package(
 	Gnuradio "3.10" REQUIRED
 	COMPONENTS runtime

--- a/packages/m2k/plugins/m2k/m2k-gui/CMakeLists.txt
+++ b/packages/m2k/plugins/m2k/m2k-gui/CMakeLists.txt
@@ -106,7 +106,9 @@ if(SCOPY_ENABLE_SIGROK_GUI)
 endif()
 
 add_definitions(-DBOOST_ALL_DYN_LINK)
-find_package(Boost COMPONENTS system filesystem thread chrono REQUIRED)
+# Boost.System is header-only since Boost 1.69 and its compiled library was removed in Boost 1.89, so it must not be
+# requested as a component.
+find_package(Boost 1.69 COMPONENTS filesystem thread chrono REQUIRED)
 
 message(STATUS "Building " ${PROJECT_NAME})
 add_library(${PROJECT_NAME} SHARED ${PROJECT_SOURCES})


### PR DESCRIPTION
Boost.System is header-only since Boost 1.19 and its compiled library was removed in Boost 1.89, so it must not be requested as a component. This is especially visible in Ubuntu 26.04 since it is the latest apt version.

Using this fix, I managed to build Scopy (Qt5, tag: v2.2.1) on Ubuntu 26.04.